### PR TITLE
Fix: Federated Authority -> filter call + increase members size + fix weights

### DIFF
--- a/pallets/federated-authority/README.md
+++ b/pallets/federated-authority/README.md
@@ -1,3 +1,40 @@
 # Federated Authority Pallet
 
-`pallet-federated-authority` enables Collectives (pallet-collective) to make Root-origin calls.
+The `federated_authority` pallet implements a cross-collective governance mechanism. Its purpose is to enable a federation of distinct on-chain authority bodies to collectively approve a motion. Each participating body must first approve the motion individually, and only once all required approvals are collected will the motion be dispatched with elevated `Root` privileges. This creates a final checkpoint that requires consensus from multiple governance groups before any critical action can be executed.
+
+The pallet is designed to be configurable so that a runtime can define:
+
+- How many authority bodies participate in the federation.  
+- Which specific collectives or governance groups those bodies represent.  
+- The approval thresholds and voting mechanisms for each body.  
+- The number of approvals required to dispatch a motion.  
+- The lifetime of a motion before it expires.  
+
+## The Motion Lifecycle
+
+The lifecycle of a motion, from proposal to execution, is structured to ensure that every configured authority body independently agrees on a course of action.
+
+### 1. Initiating a Motion
+A motion is not created directly. Instead, one of the authority bodies signals its approval of a particular call.  
+
+- The body conducts its own internal decision-making process (e.g., through a collective vote).  
+- If its rules are satisfied, it dispatches a call to `federated_authority::motion_approve`, passing along the target call to be executed.  
+- On the first approval of a new call, the pallet creates a motion entry in storage. That entry records which body approved it and sets an expiration period.  
+
+### 2. Gathering Approvals
+Once a motion is recorded, it is pending further approvals from the remaining authority bodies.  
+
+- Each other body must go through its own internal process to approve the exact same call.  
+- If they approve, they also dispatch `federated_authority::motion_approve`, which adds their approval to the motion.  
+
+### 3. Executing or Closing a Motion
+The `motion_close` extrinsic can be called by anyone to finalize a motion. A motion can only be closed if it has either been approved or has expired.
+
+### 4. Revoking an Approval
+The `motion_revoke` extrinsic allows an authority body to withdraw its approval before execution. If all approvals are revoked, the motion is immediately removed from storage.  
+
+## Summary
+
+In essence, the `federated_authority` pallet provides a **federated governance layer**, requiring independent approval from multiple on-chain bodies before a critical call can be executed with elevated privileges.  
+
+The number of bodies, their internal voting rules, required approval proportions, and motion duration are all configurable by the runtime, making the pallet flexible enough to support various governance designs.

--- a/pallets/federated-authority/src/lib.rs
+++ b/pallets/federated-authority/src/lib.rs
@@ -30,7 +30,7 @@ use frame_support::{
 	dispatch::{Pays, PostDispatchInfo},
 };
 use sp_runtime::{
-	DispatchErrorWithPostInfo, Saturating,
+	DispatchError, DispatchErrorWithPostInfo, Saturating,
 	traits::{Dispatchable, Hash},
 };
 use sp_std::prelude::*;
@@ -125,7 +125,10 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::motion_approve(T::MaxAuthorityBodies::get()))]
+		#[pallet::weight((
+            T::WeightInfo::motion_approve(T::MaxAuthorityBodies::get()),
+            DispatchClass::Operational
+        ))]
 		#[allow(clippy::useless_conversion)]
 		pub fn motion_approve(
 			origin: OriginFor<T>,
@@ -194,7 +197,10 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(1)]
-		#[pallet::weight(T::WeightInfo::motion_revoke(T::MaxAuthorityBodies::get()).max(T::WeightInfo::motion_revoke_remove()))]
+		#[pallet::weight((
+            T::WeightInfo::motion_revoke(T::MaxAuthorityBodies::get()).max(T::WeightInfo::motion_revoke_remove()),
+            DispatchClass::Operational
+        ))]
 		#[allow(clippy::useless_conversion)]
 		pub fn motion_revoke(
 			origin: OriginFor<T>,
@@ -273,12 +279,16 @@ pub mod pallet {
 			if Self::is_motion_approved(total_approvals) {
 				// Dispatch motion
 				Self::motion_dispatch(motion_hash)?;
+				// Get dispatch weight
+				let dispatch_weight = Self::get_dispatch_weight(motion_hash)?;
 				// Remove after dispatch
 				Self::motion_remove(motion_hash);
 
 				// Return actual weight for approved motion
 				Ok(PostDispatchInfo {
-					actual_weight: Some(T::WeightInfo::motion_close_approved()),
+					actual_weight: Some(
+						T::WeightInfo::motion_close_approved().saturating_add(dispatch_weight),
+					),
 					pays_fee: Pays::No,
 				})
 			} else {
@@ -336,6 +346,11 @@ pub mod pallet {
 		/// Returns `true` if the motion has finished (expired).
 		fn has_ended(motion: &MotionInfo<T>) -> bool {
 			Self::block_number() >= motion.ends_block
+		}
+
+		fn get_dispatch_weight(motion_hash: T::Hash) -> Result<Weight, DispatchError> {
+			let motion = Motions::<T>::get(motion_hash).ok_or(Error::<T>::MotionNotFound)?;
+			Ok(motion.call.get_dispatch_info().call_weight)
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]

--- a/res/devnet/federated-authority-config.json
+++ b/res/devnet/federated-authority-config.json
@@ -2,13 +2,15 @@
     "council": {
         "members": [
             "0xc28906486ffd3ab7e46df7f5d707a63aa8355711a8a1b1e124816a0d15d3d037",
-            "0x04e997e9f76db18fb567feed993f562b66a8af6d423cd588f8a13a7853301224"
+            "0x04e997e9f76db18fb567feed993f562b66a8af6d423cd588f8a13a7853301224",
+            "0xcec5940b3194105778751a73501621b8ad366aa85d988e9e015d47151a012f42"
         ]  
     },
     "technical_committee": {
         "members": [
             "0x5ec6e58917dd04bb852da1de48616c55a13b631cea71832a8467aea75184376d",
-            "0x185364a4f0cab392ca81d8e28776dea556f7cf741e204bc55ba4a1ad10a64d03"
+            "0x185364a4f0cab392ca81d8e28776dea556f7cf741e204bc55ba4a1ad10a64d03",
+            "0x241fef1d1907fcf8c54399707c719bf3b5ef5936e56da9c85a1736b481e41943"
         ]
     }
 }

--- a/res/node-dev-01/federated-authority-config.json
+++ b/res/node-dev-01/federated-authority-config.json
@@ -2,13 +2,15 @@
     "council": {
         "members": [
             "0xc28906486ffd3ab7e46df7f5d707a63aa8355711a8a1b1e124816a0d15d3d037",
-            "0x04e997e9f76db18fb567feed993f562b66a8af6d423cd588f8a13a7853301224"
+            "0x04e997e9f76db18fb567feed993f562b66a8af6d423cd588f8a13a7853301224",
+            "0xcec5940b3194105778751a73501621b8ad366aa85d988e9e015d47151a012f42"
         ]  
     },
     "technical_committee": {
         "members": [
             "0x5ec6e58917dd04bb852da1de48616c55a13b631cea71832a8467aea75184376d",
-            "0x185364a4f0cab392ca81d8e28776dea556f7cf741e204bc55ba4a1ad10a64d03"
+            "0x185364a4f0cab392ca81d8e28776dea556f7cf741e204bc55ba4a1ad10a64d03",
+            "0x241fef1d1907fcf8c54399707c719bf3b5ef5936e56da9c85a1736b481e41943"
         ]
     }
 }

--- a/res/qanet/federated-authority-config.json
+++ b/res/qanet/federated-authority-config.json
@@ -2,13 +2,15 @@
     "council": {
         "members": [
             "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
-            "0x7c24a8cb088769cb57462594c0012a335f6b938454b5853aee48b139ae4fac0a"
+            "0x7c24a8cb088769cb57462594c0012a335f6b938454b5853aee48b139ae4fac0a",
+            "0xfea7b7383a91972818f4a507071b58e299518a6041d703dcdfaa3b44f50e7a5d"
         ]  
     },
     "technical_committee": {
         "members": [
             "0x7c45fee2baacf39999113ef0d9cb35144f17dae6a51ab0e8211853162d3d6840",
-            "0x52f3c5ec2fe34821a0c1d38ab8750f6644a8f23fdf2b1c3688a12a695f7de158"
+            "0x52f3c5ec2fe34821a0c1d38ab8750f6644a8f23fdf2b1c3688a12a695f7de158",
+            "0xce7b43e2c20c0800553d7829eaebe948cd8900e6e6ed92b610f169c1f135fa28"
         ]
     }
 }

--- a/res/src/networks/definitions.rs
+++ b/res/src/networks/definitions.rs
@@ -51,11 +51,11 @@ impl MidnightNetwork for UndeployedNetwork {
 	}
 
 	fn council(&self) -> InitialFederedatedAuthority {
-		InitialFederedatedAuthority::new_from_uris(vec!["//Alice", "//Bob"])
+		InitialFederedatedAuthority::new_from_uris(vec!["//Alice", "//Bob", "//Charlie"])
 	}
 
 	fn technical_committee(&self) -> InitialFederedatedAuthority {
-		InitialFederedatedAuthority::new_from_uris(vec!["//Charlie", "//Dave"])
+		InitialFederedatedAuthority::new_from_uris(vec!["//Dave", "//Eve", "//Ferdie"])
 	}
 
 	fn genesis_utxo(&self) -> &str {

--- a/runtime/src/check_call_filter.rs
+++ b/runtime/src/check_call_filter.rs
@@ -19,7 +19,7 @@ impl Contains<RuntimeCall> for GovernanceAuthorityCallFilter {
 				| RuntimeCall::Sudo(_)
 				| RuntimeCall::FederatedAuthority(
 					pallet_federated_authority::Call::motion_close { .. }
-				)
+				) | RuntimeCall::System(frame_system::Call::apply_authorized_upgrade { .. })
 		)
 	}
 }


### PR DESCRIPTION
## 📝 Description
Improves: https://github.com/midnightntwrk/midnight-node/pull/42

This PR fixes the following:
- Increase the number of default collective's members to 3 to better show the need of 2/3 while demoing/manual testing
- Fixed weight for `motion_close` call. Now it takes into consideration the `Weight` of the dispatched call.
- Make all pallet's calls `Operational`

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Checklist

- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] I have performed a self-review of my code
- [ ] I have updated doc strings and comments where necessary

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->
- [ ] Manual testing (describe scenarios)
- [ ] Unit tests added
- [ ] Integration tests added
- [ ] Other (please specify):
