### PR TITLE
fix: remove deprecated expect-playwright dependency

### DIFF
--- a/ui/tests/package.json
+++ b/ui/tests/package.json
@@ -21,7 +21,6 @@
     "@types/node": "^22.13.14",
     "allure-playwright": "^3.0.8",
     "cross-env": "^7.0.3",
-    "expect-playwright": "^0.8.0",
     "testcontainers": "^11.7.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",

--- a/ui/tests/tsconfig.json
+++ b/ui/tests/tsconfig.json
@@ -22,9 +22,6 @@
     "noEmit": false,
     "noFallthroughCasesInSwitch": true,
     "strictPropertyInitialization": false,
-    "types": [
-      "expect-playwright"
-    ],
     "baseUrl": ".",
     "rootDirs": [
       "./utils",

--- a/ui/tests/yarn.lock
+++ b/ui/tests/yarn.lock
@@ -1718,13 +1718,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-playwright@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "expect-playwright@npm:0.8.0"
-  checksum: 10/cf8f7f1db819debfb1457b2e56509f838ac4e29c832790f665cf8db7baf21af8271e0ca97849b3998040780c6848533be2afcd262c75edf1ca98805bc2b51b35
-  languageName: node
-  linkType: hard
-
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.2
   resolution: "exponential-backoff@npm:3.1.2"
@@ -2301,7 +2294,6 @@ __metadata:
     "@types/node": "npm:^22.13.14"
     allure-playwright: "npm:^3.0.8"
     cross-env: "npm:^7.0.3"
-    expect-playwright: "npm:^0.8.0"
     testcontainers: "npm:^11.7.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.2.2"


### PR DESCRIPTION
expect-playwright is deprecated as Playwright now has built-in assertions. The package was listed as a dependency but not actually used in any test files.

Removed from:
- ui/tests/package.json devDependencies
- ui/tests/tsconfig.json types array

Note: yarn.lock will be automatically updated when yarn install runs next (CI or local with GITHUB_TOKEN).

PR : https://github.com/midnightntwrk/midnight-node/pull/129