### PR TITLE
chore: set minimum npm audit severity to high

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -904,7 +904,7 @@ audit-npm:
     COPY ${DIRECTORY} ${DIRECTORY}
     WORKDIR ${DIRECTORY}
     RUN corepack enable
-    RUN --no-cache npm audit
+    RUN --no-cache npm audit --severity high
 
 audit-yarn:
     ARG DIRECTORY
@@ -914,7 +914,7 @@ audit-yarn:
     WORKDIR ${DIRECTORY}
     RUN corepack enable
     RUN yarn install --immutable
-    RUN --no-cache yarn npm audit
+    RUN --no-cache yarn npm audit --severity high
 
 audit-local-environment:
     BUILD +audit-npm --DIRECTORY=local-environment/


### PR DESCRIPTION
Keeps less important issues like deprecations from blocking builds.

discussed in https://sundae-labs.slack.com/archives/C080BQ1KA0L/p1760629487257659