### PR TITLE
ci: raise audit severity threshold to high/critical only

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -904,7 +904,7 @@ audit-npm:
     COPY ${DIRECTORY} ${DIRECTORY}
     WORKDIR ${DIRECTORY}
     RUN corepack enable
-    RUN --no-cache npm audit
+    RUN --no-cache npm audit --audit-level=high
 
 audit-yarn:
     ARG DIRECTORY
@@ -914,7 +914,7 @@ audit-yarn:
     WORKDIR ${DIRECTORY}
     RUN corepack enable
     RUN yarn install --immutable
-    RUN --no-cache yarn npm audit
+    RUN --no-cache yarn npm audit --severity high
 
 audit-local-environment:
     BUILD +audit-npm --DIRECTORY=local-environment/


### PR DESCRIPTION
Implements team decision to only fail builds on high and critical severity vulnerabilities, filtering out moderate and low severity issues including deprecation warnings.

- npm audit: added --audit-level=high flag
- yarn npm audit: added --severity high flag
- cargo-deny: no changes needed (configured via deny.toml)

PR : https://github.com/midnightntwrk/midnight-node/pull/132