### PR TITLE
fix(toolkit): update vite to fix security vulnerability

### DIFF
--- a/util/toolkit-js/package-lock.json
+++ b/util/toolkit-js/package-lock.json
@@ -3010,9 +3010,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.10.tgz",
-      "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updates vite from 7.1.0-7.1.10 to 7.1.11 to fix [GHSA-93m4-6634-74q7](https://github.com/advisories/GHSA-93m4-6634-74q7) (server.fs.deny bypass via backslash on Windows).

The vulnerability was causing CI build failures in the audit-npm step. Running npm audit fix resolved the moderate severity issue.

- Updated vite: 7.1.0-7.1.10 → 7.1.11 (via vitest dependency)
- Verified npm audit --severity high now passes
- Tested build locally with Node 22.19.0
