### PR TITLE
Fix: Make sure `reset_members` inherent is not called if empty membership sets

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,8 +125,7 @@ use constants::time_units::DAYS;
 use pallet_federated_authority::{
 	AuthorityBody, FederatedAuthorityEnsureProportionAtLeast, FederatedAuthorityOriginManager,
 };
-use runtime_common::governance::MembershipObservationHandler;
-use runtime_common::governance::{AlwaysNo, MembershipHandler};
+use runtime_common::governance::{AlwaysNo, MembershipHandler, MembershipObservationHandler};
 
 /// An index to a block.
 pub type BlockNumber = u32;


### PR DESCRIPTION
# Overview
Previous approach https://github.com/midnightntwrk/midnight-node/pull/143 didn't work as the Inherent tx will fail if the membership sets are empty, halting block production.

In this PR we make sure the inherent is never called unless both Council and Technical Committee membership sets are not empty.

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

Manual

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links
