### PR TITLE
test: added command to send shielded tokens with toolkit

### DIFF
--- a/scripts/tests/toolkit-e2e.sh
+++ b/scripts/tests/toolkit-e2e.sh
@@ -84,11 +84,18 @@ docker run --rm -e RESTORE_OWNER="$(id -u):$(id -g)" -e RUST_BACKTRACE=1 -v $tem
     --rng-seed "$RNG_SEED" \
     --contract-address "$contract_address"
 
-# Send just unshielded
+echo "Sending just unshielded tokens..."
 docker run --rm -e RUST_BACKTRACE=1 --network container:midnight-node-tx "$TOOLKIT_IMAGE" \
     generate-txs single-tx \
     --source-seed "0000000000000000000000000000000000000000000000000000000000000001" \
     --unshielded-amount 10 \
-    --destination-address mn_addr_dev1m008urkd83umdn3j2nznwyrp34ug5negs2tawcgvcxnmchx7v60qr7c804
+    --destination-address mn_addr_undeployed1na9c5lvmj6rvwkwkuq7vsqvyjcx74tg0th0vevrcluatxq02h9gsjtnn9j
+
+echo "Sending just shielded tokens..."
+docker run --rm -e RUST_BACKTRACE=1 --network container:midnight-node-tx "$TOOLKIT_IMAGE" \
+    generate-txs single-tx \
+    --source-seed "0000000000000000000000000000000000000000000000000000000000000001" \
+    --shielded-amount 10 \
+    --destination-address mn_shield-addr_undeployed12ch04fxzmmcfsy7nvy2894pfsm7smxrvzdkmc0scw6vshjrw5pkqxqyxd4ythchgl47ma2qp04703dpkwzkxtkxea7053xsyyunuvlxzp5fn43u5
 
 echo "✅ Toolkit E2E"


### PR DESCRIPTION
# Overview

Updated toolkit-e2e.sh test script with the following: 
- appends a command to generate a single tx sending shileded tokens
- fixes incorrect address in command to generate single UNshielded tx

This is to add a smoke test for the shielded part of submitting transactions to node via the toolkit

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
