### PR TITLE
fix: node-toolkit missing cache file on host (linux)

### DIFF
--- a/util/toolkit/bin/entrypoint.sh
+++ b/util/toolkit/bin/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 MOUNTED_DIRS=(/tmp /mnt/output /out)
+# Add cache directory from environment variable, default to /.cache/sync
+CACHE_DIR="${MN_SYNC_CACHE:-/.cache/sync}"
+MOUNTED_DIRS+=("$CACHE_DIR")
+
 mkdir -p ${MOUNTED_DIRS[@]}
 chown -R appuser:appuser ${MOUNTED_DIRS[@]}
 


### PR DESCRIPTION
# Overview

this addresses the problem by mounting cache dir together with the others, taking into account that the cache dir can be set from outside with -e MN_SYNC_CACHE

## 🗹 TODO before merging

- [ ] Ready
- [x] Tested it locally

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

I have redirected the docker run entry point command to the updated entrypoint.sh script and verified that the cache file was generated as hoped

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

Closes https://shielded.atlassian.net/browse/PM-20389

