### PR TITLE
ci: notify indexer repo on release publication

### DIFF
--- a/.github/workflows/notify-indexer-on-release.yml
+++ b/.github/workflows/notify-indexer-on-release.yml
@@ -1,0 +1,69 @@
+name: Notify Indexer on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-indexer:
+    name: Notify indexer of new release
+    runs-on: ubuntu-latest
+    # Only notify for non-draft releases
+    if: "!github.event.release.prerelease && !github.event.release.draft"
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Release tag: $TAG"
+
+      - name: Check if metadata.scale exists in release assets
+        id: check_metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # List release assets
+          echo "Checking for metadata.scale in release $TAG..."
+          gh release view "$TAG" --repo midnightntwrk/midnight-node --json assets -q '.assets[].name' > /tmp/assets.txt
+
+          if grep -q "metadata.scale" /tmp/assets.txt; then
+            echo "metadata_exists=true" >> "$GITHUB_OUTPUT"
+            # Get the download URL
+            METADATA_URL=$(gh release view "$TAG" --repo midnightntwrk/midnight-node --json assets -q '.assets[] | select(.name == "metadata.scale") | .url')
+            echo "metadata_url=$METADATA_URL" >> "$GITHUB_OUTPUT"
+            echo "metadata.scale found in release assets"
+          else
+            echo "metadata_exists=false" >> "$GITHUB_OUTPUT"
+            echo "metadata_url=" >> "$GITHUB_OUTPUT"
+            echo "::warning::metadata.scale not found in release assets - indexer integration may need manual metadata download"
+          fi
+
+      - name: Dispatch to midnight-indexer
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.INDEXER_DISPATCH_TOKEN }}
+          repository: midnightntwrk/midnight-indexer
+          event-type: node-release-published
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.tag }}",
+              "metadata_url": "${{ steps.check_metadata.outputs.metadata_url }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "release_name": "${{ github.event.release.name }}",
+              "release_body": ${{ toJSON(github.event.release.body) }}
+            }
+
+      - name: Summary
+        run: |
+          echo "### Release Notification Sent" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Release**: ${{ steps.version.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Release URL**: ${{ github.event.release.html_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Metadata**: ${{ steps.check_metadata.outputs.metadata_exists == 'true' && 'Available' || 'Not in release assets' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Indexer Notification**: Dispatched to midnight-indexer repo" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The midnight-indexer repository will automatically create an integration PR." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/automation/indexer-notification.md
+++ b/docs/automation/indexer-notification.md
@@ -1,0 +1,31 @@
+# Indexer Notification on Release
+
+**Jira**: [TPM-774](https://shielded.atlassian.net/browse/TPM-774)
+
+## Overview
+
+Automatically notifies midnight-indexer when node release published (non-draft, non-prerelease). Sends `repository_dispatch` to indexer repo → creates integration PR.
+
+**Workflow**: [`.github/workflows/notify-indexer-on-release.yml`](../../.github/workflows/notify-indexer-on-release.yml)
+
+## Usage
+
+Include `metadata.scale` in release:
+
+```bash
+# Create release with metadata
+gh release create v0.19.0 metadata.scale \
+  --repo midnightntwrk/midnight-node \
+  --title "Midnight Node 0.19.0"
+
+# Or add to existing release
+gh release upload v0.19.0 metadata.scale
+```
+
+Check result: https://github.com/midnightntwrk/midnight-indexer/pulls
+
+## Troubleshooting
+
+**No indexer PR?** Check [workflow runs](https://github.com/midnightntwrk/midnight-node/actions/workflows/notify-indexer-on-release.yml), verify `INDEXER_DISPATCH_TOKEN` secret configured.
+
+Contact: @cosmir17, Giles, Oscar


### PR DESCRIPTION
Closes : [TPM-774](https://shielded.atlassian.net/browse/TPM-774)

## Summary
Automatically notifies midnight-indexer when node releases are published, triggering automated integration PR creation.

## Changes

**Workflow** (`.github/workflows/notify-indexer-on-release.yml`):
- Triggers on release publication (non-draft, non-prerelease)
- Checks for metadata.scale in release assets
- Sends `repository_dispatch` event to midnight-indexer repo with:
  - Node version
  - Metadata URL (if available)
  - Release URL and metadata
- Provides workflow summary with dispatch status

**Documentation** (`docs/automation/indexer-notification.md`):
- Usage guide for release managers
- Instructions for publishing releases with metadata
- Troubleshooting information

## Testing

- Validated with actionlint (0 errors)
- Formatted with prettier
- Ready for testing with next node release

## Configuration

Requires `INDEXER_DISPATCH_TOKEN` secret (GitHub PAT with repo scope). Contact SRE/platform team if not configured.

## Related
- Indexer PR: https://github.com/midnightntwrk/midnight-indexer/pull/509

PR : https://github.com/midnightntwrk/midnight-node/pull/243

[TPM-774]: https://shielded.atlassian.net/browse/TPM-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ