### PR TITLE
fix: add retry loop for metadata check CI failures

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -129,8 +129,20 @@ get-metadata:
     FROM +subxt
     WITH DOCKER --load localhost/node:latest=+node-image
       RUN docker run --env CFG_PRESET=dev -p 9944:9944 localhost/node:latest & \
-          sleep 5 && \
-          subxt metadata -f bytes > /metadata.scale && \
+          echo "Waiting for node to be ready..." && \
+          for i in $(seq 1 30); do \
+            if subxt metadata -f bytes > /metadata.scale 2>/dev/null; then \
+              echo "Node ready after ${i} attempts"; \
+              break; \
+            fi; \
+            if [ $i -eq 30 ]; then \
+              echo "ERROR: Node failed to start within 30 seconds"; \
+              docker logs $(docker ps -q --filter ancestor=localhost/node:latest) || true; \
+              exit 1; \
+            fi; \
+            echo "Attempt $i/30: Node not ready, waiting 1 second..."; \
+            sleep 1; \
+          done && \
           docker kill $(docker ps -q --filter ancestor=localhost/node:latest)
     END
     SAVE ARTIFACT /metadata.scale
@@ -624,8 +636,20 @@ check-metadata:
 
     WITH DOCKER --pull $NODE_IMAGE
       RUN docker run --env CFG_PRESET=dev -p 9944:9944 ${NODE_IMAGE} & \
-          sleep 5 && \
-          subxt metadata -f bytes > /image_metadata.scale && \
+          echo "Waiting for node to be ready..." && \
+          for i in $(seq 1 30); do \
+            if subxt metadata -f bytes > /image_metadata.scale 2>/dev/null; then \
+              echo "Node ready after ${i} attempts"; \
+              break; \
+            fi; \
+            if [ $i -eq 30 ]; then \
+              echo "ERROR: Node failed to start within 30 seconds"; \
+              docker logs $(docker ps -q --filter ancestor=${NODE_IMAGE}) || true; \
+              exit 1; \
+            fi; \
+            echo "Attempt $i/30: Node not ready, waiting 1 second..."; \
+            sleep 1; \
+          done && \
           docker kill $(docker ps -q --filter ancestor=${NODE_IMAGE})
     END
     COPY metadata/static/midnight_metadata.scale repo_metadata.scale


### PR DESCRIPTION
 ## Problem
The `check-metadata` CI job on main branch is failing with "Connection reset by peer" errors when attempting to fetch metadata from the node.

From the CI logs:
Error:
0: Request error: i/o error: Connection reset by peer (os error 104)

  ## Root Cause

The `check-metadata` and `get-metadata` Earthfile targets use a fixed 5-second sleep before attempting to fetch metadata via `subxt metadata`. However, the node takes 8-10 seconds to fully initialise and be ready for RPC connections, causing the metadata fetch to fail.

## Solution
Replace the fixed `sleep 5` with a retry loop that:
  - Attempts to fetch metadata up to 30 times (1-second intervals, 30 seconds max timeout)
  - Provides clear progress logging for each retry attempt
  - Displays docker logs if the node fails to start within 30 seconds
  - Exits immediately once metadata is successfully fetched

## Changes
  - `Earthfile` lines 131-146: Updated `get-metadata` target
  - `Earthfile` lines 626-641: Updated `check-metadata` target
  
 PR : https://github.com/midnightntwrk/midnight-node/pull/244