### PR TITLE
fix: Update CI workflow for merge queue compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,7 +381,7 @@ jobs:
           ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
   build-indexer-images:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == false) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest-16-core-x64
     permissions:
       pull-requests: write
@@ -497,7 +497,7 @@ jobs:
 
   local-environment-tests:
     name: Local Environment Tests
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == false) || github.event_name == 'merge_group'
     needs: [run, build-indexer-images]
     runs-on: ubuntu-latest-16-core-x64
     permissions:
@@ -548,7 +548,7 @@ jobs:
           ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
   ephemeral-environment-tests:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == false) || github.event_name == 'merge_group'
     # needs:
     #   - hardfork-e2e
     #   - ledger-rollback-e2e


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

Updated 'if' conditions in continuous-integration.yml to ensure jobs
run correctly when triggered by 'merge_group' events. Previously,
jobs were skipped due to conditions checking only for 'pull_request'
event names.

Follow-up to https://github.com/midnightntwrk/midnight-node/pull/250

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
