### PR TITLE
Adding Coveralls to Github CI

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -51,3 +51,10 @@ jobs:
         with:
           name: Lcov Coverage Report
           path: test-artifacts/tests.lcov
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ github.token }}
+          file: test-artifacts/tests.lcov
+          format: lcov         


### PR DESCRIPTION
# Overview

For https://shielded.atlassian.net/browse/PM-14598

## 🗹 TODO before merging

- [ ] Invite [@Coveralls](https://github.com/coveralls) to the repository
   
<img width="888" height="404" alt="Screenshot 2025-11-22 at 2 21 37 AM" src="https://github.com/user-attachments/assets/dcf3ff2b-4ea8-4868-be12-44dfb97e64f1" />

- [ ] Create `midnightntwrk` account in Coveralls website
   <img width="689" height="386" alt="Screenshot 2025-11-21 at 8 30 58 PM" src="https://github.com/user-attachments/assets/19150837-90ac-45f2-92d7-9509a391df41" />

   - [ ] Add `midnight-node` repo. Example:
           <img width="548" height="173" alt="Screenshot 2025-11-21 at 8 29 09 PM" src="https://github.com/user-attachments/assets/e5a724b8-dd42-41ff-907a-0fc8a2882aa6" />
 
## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
