### PR TITLE
test: bump whisky to 1.0.16 and fix address derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2208,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cquisitor-lib"
+version = "0.1.0-beta.25"
+source = "git+https://github.com/rsporny/cquisitor-lib?branch=wasm-bindgen-update#7720b6f3440701bcda62475962b7cbefb9228f67"
+dependencies = [
+ "anyhow",
+ "bech32 0.11.0",
+ "blst",
+ "bs58",
+ "cardano-serialization-lib 15.0.1",
+ "console_error_panic_hook",
+ "cquisitor-minicbor",
+ "cryptoxide",
+ "hex",
+ "itertools 0.14.0",
+ "js-sys",
+ "noop_proc_macro",
+ "pallas-codec 0.31.0",
+ "pallas-crypto 0.31.0",
+ "pallas-primitives 0.31.0",
+ "pallas-traverse 0.31.0",
+ "schemars 0.9.0",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "uplc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "cquisitor-minicbor"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110df8c2a45011b2d8a33fc76483a6f5c3274bcc382ec4de2da804c5a872c8a9"
+dependencies = [
+ "half 1.8.3",
+ "minicbor-derive 0.13.0",
 ]
 
 [[package]]
@@ -7257,6 +7307,7 @@ version = "0.1.0"
 dependencies = [
  "blake2 0.10.6",
  "hex",
+ "midnight-node-ledger-helpers",
  "midnight-node-metadata",
  "ogmios-client",
  "rand 0.9.2",
@@ -13706,7 +13757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
 ]
@@ -13719,6 +13770,7 @@ checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 0.9.0",
  "serde",
  "serde_json",
 ]
@@ -13740,6 +13792,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "serde_derive_internals",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -18672,8 +18736,8 @@ dependencies = [
 
 [[package]]
 name = "whisky"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "async-trait",
  "cryptoxide",
@@ -18702,8 +18766,8 @@ dependencies = [
 
 [[package]]
 name = "whisky-common"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "async-trait",
  "hex",
@@ -18716,10 +18780,11 @@ dependencies = [
 
 [[package]]
 name = "whisky-csl"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "cardano-serialization-lib 15.0.1",
+ "cquisitor-lib",
  "cryptoxide",
  "getrandom 0.2.16",
  "hex",
@@ -18742,8 +18807,8 @@ dependencies = [
 
 [[package]]
 name = "whisky-macros"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -18752,8 +18817,8 @@ dependencies = [
 
 [[package]]
 name = "whisky-provider"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "async-trait",
  "futures",
@@ -18769,8 +18834,8 @@ dependencies = [
 
 [[package]]
 name = "whisky-wallet"
-version = "1.0.10"
-source = "git+https://github.com/ozgb/whisky?rev=9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a#9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a"
+version = "1.0.16"
+source = "git+https://github.com/rsporny/whisky?branch=wasm-bindgen-update#c7b138a6dd1bf176f4a2d95b78d264d74a6d73e2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/scripts/cnight-generates-dust/mkWallets.sh
+++ b/scripts/cnight-generates-dust/mkWallets.sh
@@ -23,9 +23,9 @@ if [[ !(-f payment-alice.vkey || -f payment-alice.skey) ]]; then
     --verification-key-file payment-alice.vkey \
     --signing-key-file payment-alice.skey
 
-  cardano-cli conway address key-gen \
-    --verification-key-file payment-alice.vkey \
-    --signing-key-file payment-alice.skey
+  cardano-cli conway stake-address key-gen \
+    --verification-key-file stake-alice.vkey \
+    --signing-key-file stake-alice.skey
   echo "Created wallet for Alice"
 fi
 
@@ -36,29 +36,39 @@ if [[ !(-f payment-bob.vkey || -f payment-bob.skey) ]]; then
     --verification-key-file payment-bob.vkey \
     --signing-key-file payment-bob.skey
 
-  cardano-cli conway address key-gen \
-    --verification-key-file payment-bob.vkey \
-    --signing-key-file payment-bob.skey
+  cardano-cli conway stake-address key-gen \
+    --verification-key-file stake-bob.vkey \
+    --signing-key-file stake-bob.skey
   echo "Created wallet for Bob"
 fi
 
 # Create address files
 cardano-cli conway address build \
   --payment-verification-key-file payment-alice.vkey \
-  --out-file payment-alice.addr \
+  --stake-verification-key-file stake-alice.vkey \
+  --out-file payment-alice.addr
+
+cardano-cli conway stake-address build \
+    --stake-verification-key-file stake-alice.vkey \
+    --out-file stake-alice.addr
 
 cardano-cli conway address build \
   --payment-verification-key-file payment-bob.vkey \
-  --out-file payment-bob.addr \
+  --stake-verification-key-file stake-bob.vkey \
+  --out-file payment-bob.addr
+
+cardano-cli conway stake-address build \
+    --stake-verification-key-file stake-bob.vkey \
+    --out-file stake-bob.addr
 
 echo "Wallet address for Alice: `cat payment-alice.addr`"
 echo "Wallet address for Bob  : `cat payment-bob.addr`"
 
-cardano-cli address key-hash --payment-verification-key-file payment-alice.vkey
-echo "Wallet PKH for Alice   : `cardano-cli address key-hash --payment-verification-key-file payment-alice.vkey`"
+echo "Stake address for Alice  : `cat stake-alice.addr`"
+echo "Stake address for Bob    : `cat stake-bob.addr`"
 
-cardano-cli address key-hash --payment-verification-key-file payment-bob.vkey
-echo "Wallet PKH for Bob     : `cardano-cli address key-hash --payment-verification-key-file payment-bob.vkey`"
+echo "Stake PKH for Alice   : `cardano-cli address key-hash --payment-verification-key-file stake-alice.vkey`"
+echo "Stake PKH for Bob     : `cardano-cli address key-hash --payment-verification-key-file stake-bob.vkey`"
 
 echo "Update datum-*.json files with the above PKHs before proceeding."
 echo "Done."

--- a/scripts/cnight-generates-dust/register.sh
+++ b/scripts/cnight-generates-dust/register.sh
@@ -24,7 +24,7 @@ COLLATERAL=ea22bb7b5f8787dc31985fd86d3d209459018180486074165e29401705de8795#0
 # Pick the first UTxO on the wallet that is not a collateral. This should be entered manually
 UTXO=87fb4d421a2e19babe592047e37e41b219e60dcbff49227f0ba3cf3f610298a3#0
 
-USER_PKH=$(cardano-cli address key-hash --payment-verification-key-file payment-$1.vkey)
+USER_PKH=$(cardano-cli address key-hash --payment-verification-key-file stake-$1.vkey)
 
 rm register-$1.tx 2>/dev/null
 rm register-$1-signed.tx 2>/dev/null
@@ -46,6 +46,7 @@ cardano-cli conway transaction build \
 cardano-cli conway transaction sign \
   --tx-file register-$1.tx \
   --signing-key-file payment-$1.skey \
+  --signing-key-file stake-$1.skey \
   --out-file register-$1-signed.tx || exit
 
 cardano-cli conway transaction submit \

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -8,18 +8,20 @@ autotests = false
 [features]
 local = []
 local-ci = []
+qanet = []
 default = ["local-ci"]
 
 [dependencies]
 hex.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-whisky = { git = "https://github.com/ozgb/whisky", rev = "9cd916b8eb2cbb17ec6561c69ed285dcd3ad446a" }
+whisky = { git = "https://github.com/rsporny/whisky", branch = "wasm-bindgen-update" }
 tiny-bip39 = "2.0.0"
 ogmios-client = { git = "https://github.com/input-output-hk/partner-chains", tag = "v1.8.1" }
 serde_json.workspace = true
 rand = "0.9.2"
 subxt.workspace = true
 midnight-node-metadata.workspace = true
+midnight-node-ledger-helpers = { workspace = true, features = ["can-panic"] }
 blake2 = "0.10.6"
 
 [[test]]

--- a/tests/e2e/src/api/cardano.rs
+++ b/tests/e2e/src/api/cardano.rs
@@ -10,11 +10,13 @@ use std::path::{Path, PathBuf};
 use std::slice::from_ref;
 use std::time::Duration;
 use tokio::time::sleep;
-use whisky::csl::{Address, BaseAddress, Credential, NetworkInfo, RewardAddress};
+use whisky::csl::{
+    Address, Bip32PrivateKey, Credential, EnterpriseAddress, NetworkInfo, PrivateKey, RewardAddress,
+};
 use whisky::data::{constr0, constr1};
 use whisky::{
-    Asset, Budget, LanguageVersion, Network, OfflineTxEvaluator, TxBuilder, WData, WRedeemer,
-    Wallet,
+    Asset, Budget, LanguageVersion, Network, OfflineTxEvaluator, TxBuilder, WData, WError,
+    WRedeemer, Wallet, WalletType,
 };
 
 #[derive(Debug)]
@@ -35,7 +37,6 @@ pub struct CardanoClient {
     pub ogmios_clients: OgmiosClients,
     pub constants: Constants,
     pub wallet: Wallet,
-    pub address: Address,
     pub network: Network,
     pub network_info: NetworkInfo,
 }
@@ -50,6 +51,7 @@ impl CardanoClient {
         .expect("Failed to initialize client");
 
         let wallet = Self::create_wallet();
+        Self::print_addresses(&wallet, &Self::network_info(&ogmios_settings.network));
         Self::from_wallet(ogmios_settings, constants, wallet, ogmios_clients)
     }
 
@@ -75,13 +77,11 @@ impl CardanoClient {
         ogmios_clients: OgmiosClients,
     ) -> Self {
         let network_info = Self::network_info(&ogmios_settings.network);
-        let address = Self::address(&wallet, network_info.network_id());
 
         Self {
             ogmios_clients,
             constants,
             wallet,
-            address,
             network: ogmios_settings.network,
             network_info,
         }
@@ -99,7 +99,31 @@ impl CardanoClient {
     fn create_wallet() -> Wallet {
         let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
         let phrase = mnemonic.phrase().to_string();
+        println!("Generated mnemonic phrase: {}", phrase);
         Wallet::new_mnemonic(&phrase).expect("Failed to create a wallet")
+    }
+
+    fn print_addresses(wallet: &Wallet, network_info: &NetworkInfo) {
+        let delegated_payment_address = wallet
+            .get_change_address(whisky::AddressType::Payment)
+            .expect("Failed to get change address");
+        println!("Payment address: {}", delegated_payment_address);
+
+        let payment_public_key_hash = wallet.account.as_ref().unwrap().public_key.hash().to_hex();
+        println!("Payment public key hash: {}", payment_public_key_hash);
+
+        let stake_cred = wallet.addresses.base_address.as_ref().unwrap().stake_cred();
+
+        let reward_address = RewardAddress::new(network_info.network_id(), &stake_cred)
+            .to_address()
+            .to_bech32(None)
+            .unwrap();
+
+        println!("Reward (stake) address: {}", reward_address);
+        println!(
+            "Stake public key hash: {}",
+            stake_cred.to_keyhash().unwrap().to_hex()
+        );
     }
 
     fn wallet_for_funded(cli_skey: &str) -> Wallet {
@@ -110,12 +134,31 @@ impl CardanoClient {
         Wallet::new_cli(cli_hex.as_str()).expect("Failed to create a funded wallet")
     }
 
-    fn address(wallet: &Wallet, network_id: u8) -> Address {
-        let pub_key_hash = wallet.account.public_key.hash();
-        let cred = Credential::from_keyhash(&pub_key_hash);
-        let private_key_hash = wallet.account.private_key.to_hex();
-        println!("Private key hash: {}", private_key_hash);
-        BaseAddress::new(network_id, &cred, &cred).to_address()
+    fn derive_stake_signing_key_from_mnemonic(wallet: &Wallet) -> Result<PrivateKey, WError> {
+        let phrase = match &wallet.wallet_type {
+            WalletType::MnemonicWallet(mw) => &mw.mnemonic_phrase,
+            _ => {
+                return Err(WError::new(
+                    "derive_stake_signing_key_from_mnemonic",
+                    "wallet does not contain mnemonic",
+                ));
+            }
+        };
+        let mnemonic = Mnemonic::from_phrase(phrase, Language::English).unwrap();
+        let entropy = mnemonic.entropy();
+
+        let mut root = Bip32PrivateKey::from_bip39_entropy(entropy, &[]);
+
+        // m / 1852' / 1815' / 0'
+        root = root
+            .derive(1852 | 0x8000_0000)
+            .derive(1815 | 0x8000_0000)
+            .derive(0x8000_0000);
+
+        // stake: /2/0
+        let stake_xprv = root.derive(2).derive(0);
+
+        Ok(PrivateKey::from_extended_bytes(&stake_xprv.to_raw_key().as_bytes()).unwrap())
     }
 
     pub async fn make_collateral(&self) -> Option<OgmiosUtxo> {
@@ -134,7 +177,19 @@ impl CardanoClient {
     }
 
     pub fn address_as_bech32(&self) -> String {
-        self.address.to_bech32(None).unwrap()
+        match self.wallet.get_change_address(whisky::AddressType::Payment) {
+            Ok(addr) => addr,
+            Err(_) => {
+                let pub_key_hash = self.wallet.account.as_ref().unwrap().public_key.hash();
+                let cred = Credential::from_keyhash(&pub_key_hash);
+                let address_bech32 = EnterpriseAddress::new(self.network_info.network_id(), &cred)
+                    .to_address()
+                    .to_bech32(None)
+                    .unwrap();
+                println!("Derived enterprise address: {}", address_bech32);
+                address_bech32
+            }
+        }
     }
 
     pub async fn register(
@@ -153,7 +208,7 @@ impl CardanoClient {
                         "constructor": 0,
                         "fields": [
                             {
-                                "bytes": &self.wallet.account.public_key.hash().to_hex()
+                                "bytes": &self.wallet.addresses.base_address.as_ref().unwrap().stake_cred().to_keyhash().unwrap().to_hex()
                             }
                         ]
                     },
@@ -202,12 +257,30 @@ impl CardanoClient {
                 },
             })
             .change_address(&payment_addr)
-            .required_signer_hash(&self.wallet.account.public_key.hash().to_hex())
+            .required_signer_hash(
+                &self
+                    .wallet
+                    .addresses
+                    .base_address
+                    .as_ref()
+                    .unwrap()
+                    .stake_cred()
+                    .to_keyhash()
+                    .unwrap()
+                    .to_hex(),
+            )
             .complete_sync(None)
             .unwrap();
 
         let signed_tx = self.wallet.sign_tx(&tx_builder.tx_hex());
-        let tx_bytes = hex::decode(signed_tx.unwrap()).expect("Failed to decode hex string");
+
+        // sign with stake key
+        let stake_signing_key = Self::derive_stake_signing_key_from_mnemonic(&self.wallet).unwrap();
+        let stake_wallet = Wallet::new_cli(&stake_signing_key.to_hex()).unwrap();
+        let signed_by_stake_tx = stake_wallet.sign_tx(&signed_tx.unwrap());
+
+        let tx_bytes =
+            hex::decode(signed_by_stake_tx.unwrap()).expect("Failed to decode hex string");
         self.ogmios_clients.submit_transaction(&tx_bytes).await
     }
 
@@ -276,7 +349,18 @@ impl CardanoClient {
                 },
             })
             .change_address(&payment_addr)
-            .required_signer_hash(&self.wallet.account.public_key.hash().to_hex())
+            .required_signer_hash(
+                &self
+                    .wallet
+                    .addresses
+                    .base_address
+                    .as_ref()
+                    .unwrap()
+                    .stake_cred()
+                    .to_keyhash()
+                    .unwrap()
+                    .to_hex(),
+            )
             .complete_sync(None)
             .unwrap();
 
@@ -284,7 +368,14 @@ impl CardanoClient {
             .wallet
             .sign_tx(&tx_builder.tx_hex())
             .expect("Failed to sign tx");
-        let tx_bytes = hex::decode(signed_tx).expect("Failed to decode hex string");
+
+        // sign with stake key
+        let stake_signing_key = Self::derive_stake_signing_key_from_mnemonic(&self.wallet).unwrap();
+        let stake_wallet = Wallet::new_cli(&stake_signing_key.to_hex()).unwrap();
+        let signed_by_stake_tx = stake_wallet.sign_tx(&signed_tx);
+
+        let tx_bytes =
+            hex::decode(signed_by_stake_tx.unwrap()).expect("Failed to decode hex string");
         self.ogmios_clients.submit_transaction(&tx_bytes).await
     }
 
@@ -699,8 +790,13 @@ impl CardanoClient {
     }
 
     pub fn reward_address_bytes(&self) -> [u8; 29] {
-        let pub_key_hash = self.wallet.account.public_key.hash();
-        let cred = Credential::from_keyhash(&pub_key_hash);
+        let cred = self
+            .wallet
+            .addresses
+            .base_address
+            .as_ref()
+            .unwrap()
+            .stake_cred();
         RewardAddress::new(self.network_info.network_id(), &cred)
             .to_address()
             .to_bytes()

--- a/tests/e2e/src/api/midnight.rs
+++ b/tests/e2e/src/api/midnight.rs
@@ -1,6 +1,8 @@
 use crate::config::NodeClientSettings;
 use blake2::digest::{Update, VariableOutput};
 use blake2::Blake2bVar;
+use hex::ToHex;
+use midnight_node_ledger_helpers::{DefaultDB, DustWallet, WalletSeed, serialize_untagged};
 use midnight_node_metadata::midnight_metadata_latest::c_night_observation::storage::types::utxo_owners::UtxoOwners;
 use midnight_node_metadata::midnight_metadata_latest::federated_authority_observation::events::{CouncilMembersReset, TechnicalCommitteeMembersReset};
 use midnight_node_metadata::midnight_metadata_latest::runtime_types::midnight_primitives_cnight_observation::ObservedUtxo;
@@ -29,8 +31,14 @@ impl MidnightClient {
     }
 
     pub fn new_dust_hex() -> String {
-        let bytes: [u8; 33] = rand::random();
-        hex::encode(bytes)
+        let seed_bytes: [u8; 32] = rand::random();
+        println!("Midnight seed: {}", hex::encode(seed_bytes));
+        let wallet_seed = WalletSeed::from(seed_bytes);
+        let dust_wallet = DustWallet::<DefaultDB>::default(wallet_seed, None);
+        let dust_public = dust_wallet.public_key;
+        let dust_public_hex = serialize_untagged(&dust_public).unwrap().encode_hex();
+        println!("Dust public key hex: {}", dust_public_hex);
+        dust_public_hex
     }
 
     pub async fn subscribe_to_cnight_observation_events(

--- a/tests/e2e/src/config.rs
+++ b/tests/e2e/src/config.rs
@@ -19,12 +19,17 @@ impl Settings {
 
                     #[cfg(feature="local-ci")]
                     base_url: "ws://172.17.0.1:9933".into(),
+
+                    #[cfg(feature="qanet")]
+                    base_url: "wss://rpc.qanet.dev.midnight.network".into(),
                 },
                 ogmios_client: OgmiosClientSettings {
                     #[cfg(feature="local")]
                     base_url: "ws://127.0.0.1:1337".into(),
                     #[cfg(feature="local-ci")]
                     base_url: "ws://172.17.0.1:1337".into(),
+                    #[cfg(feature="qanet")]
+                    base_url: "wss://ogmios.qanet.dev.midnight.network".into(),
                     timeout_seconds: 5,
                     network: CardanoNetwork::Preview,
                     network_info: network_info.clone(),

--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -53,8 +53,8 @@ async fn register_for_dust_production() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Registration transaction submitted with hash: {}",
+        hex::encode(register_tx_id)
     );
 
     let reward_address = cardano_client.reward_address_bytes();
@@ -346,8 +346,8 @@ async fn register_2_cardano_same_dust_address_production() {
         .transaction
         .id;
     println!(
-        "Registration transaction for the first cardano submitted with hash: {:?}",
-        register_tx_id_1
+        "Registration transaction for the first cardano submitted with hash: {}",
+        hex::encode(register_tx_id_1)
     );
 
     let register_tx_id_2 = cardano_client_2
@@ -357,8 +357,8 @@ async fn register_2_cardano_same_dust_address_production() {
         .transaction
         .id;
     println!(
-        "Registration transaction for second cardano submitted with hash: {:?}",
-        register_tx_id_1
+        "Registration transaction for second cardano submitted with hash: {}",
+        hex::encode(register_tx_id_2)
     );
 
     let reward_address_1 = cardano_client_1.reward_address_bytes();
@@ -487,8 +487,8 @@ async fn cnight_produces_dust() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Registration transaction submitted with hash: {}",
+        hex::encode(register_tx_id)
     );
 
     let amount = 100;
@@ -498,7 +498,7 @@ async fn cnight_produces_dust() {
         .expect("Failed to mint tokens")
         .transaction
         .id;
-    println!("Minted {} cNIGHT. Tx: {:?}", amount, tx_id);
+    println!("Minted {} cNIGHT. Tx: {}", amount, hex::encode(tx_id));
 
     // FIXME: it returns first utxo, find by native token or return all utxos
     let cnight_utxo = match cardano_client
@@ -561,8 +561,8 @@ async fn deregister_from_dust_production() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Registration transaction submitted with hash: {}",
+        hex::encode(register_tx_id)
     );
 
     let validator_address = cardano_client.constants.policies.auth_token_address();
@@ -590,8 +590,8 @@ async fn deregister_from_dust_production() {
         .transaction
         .id;
     println!(
-        "Deregistration transaction submitted with hash: {:?}",
-        deregister_tx
+        "Deregistration transaction submitted with hash: {}",
+        hex::encode(deregister_tx)
     );
 
     let reward_address = cardano_client.reward_address_bytes();
@@ -687,8 +687,8 @@ async fn alice_cannot_deregister_bob() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Registration transaction submitted with hash: {}",
+        hex::encode(register_tx_id)
     );
 
     // Find Bob's registration UTXO
@@ -771,8 +771,8 @@ async fn removing_excessive_registrations() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Registration transaction submitted with hash: {}",
+        hex::encode(register_tx_id)
     );
 
     let reward_address = cardano_client.reward_address_bytes();
@@ -831,8 +831,8 @@ async fn removing_excessive_registrations() {
         .transaction
         .id;
     println!(
-        "Registration transaction submitted with hash: {:?}",
-        register_tx_id
+        "Second registration transaction submitted with hash: {}",
+        hex::encode(second_register_tx_id)
     );
 
     let second_registration_events = midnight_client
@@ -896,8 +896,8 @@ async fn removing_excessive_registrations() {
         .transaction
         .id;
     println!(
-        "Deregistration transaction submitted with hash: {:?}",
-        deregister_tx
+        "Deregistration transaction submitted with hash: {}",
+        hex::encode(deregister_tx)
     );
 
     let deregister_events = midnight_client
@@ -951,7 +951,7 @@ async fn removing_excessive_registrations() {
         .expect("Failed to mint tokens")
         .transaction
         .id;
-    println!("Minted {} cNIGHT. Tx: {:?}", amount, tx_id);
+    println!("Minted {} cNIGHT. Tx: {}", amount, hex::encode(tx_id));
 
     // FIXME: it returns first utxo, find by native token or return all utxos
     let cnight_utxo = match cardano_client


### PR DESCRIPTION
# Overview

fixed:
- e2e tests stake address part derivation
- scripts/cnight-generates-dust

added:
- QANet config for e2e tests

changed:
- whisky crate bumped to 1.0.16
- e2e cNgD tests are registering with stake public key hash in datum
- print transactions hex encoded instead of bytes array
- Midnight Dust hex is derived from seed instead of random bytes

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
