### PR TITLE
fix: correct MIDNIGHT_STATE_KEY hash to use twox_128("StateKey")

### DIFF
--- a/primitives/midnight/src/lib.rs
+++ b/primitives/midnight/src/lib.rs
@@ -59,9 +59,13 @@ pub enum TransactionTypeV2 {
 pub mod well_known_keys {
 	use super::hex;
 
+	/// Storage key for the Midnight pallet's StateKey storage item.
+	/// Computed as: twox_128("Midnight") ++ twox_128("StateKey")
 	pub const MIDNIGHT_STATE_KEY: &[u8] =
-		&hex!["2a760f9a173a6df5cd4373ff49fa999bf39a107f2d8d3854c9aba9b021f43d9c"];
+		&hex!["2a760f9a173a6df5cd4373ff49fa999bd3b3812d84b965be98ec477e3575379b"];
 
+	/// Storage key for the Midnight pallet's NetworkId storage item.
+	/// Computed as: twox_128("Midnight") ++ twox_128("NetworkId")
 	pub const MIDNIGHT_NETWORK_ID_KEY: &[u8] =
 		&hex!["2a760f9a173a6df5cd4373ff49fa999b47872dec514b30607df0c271efce9fc4"];
 }


### PR DESCRIPTION
### Summary
Fixes the `MIDNIGHT_STATE_KEY` well-known constant which was incorrectly computed, causing the `midnight_dustRootHistory` RPC (PR #342) to fail with "Unable to get dust root history".

### Root Cause
The `MIDNIGHT_STATE_KEY` constant was computed using `twox_128("State")` instead of `twox_128("StateKey")`:

| Component | Wrong (current) | Correct (this PR) |
|-----------|-----------------|-------------------|
| Prefix | `2a760f9a173a6df5cd4373ff49fa999b` | `2a760f9a173a6df5cd4373ff49fa999b` |
| Suffix | `f39a107f2d8d3854c9aba9b021f43d9c` | `d3b3812d84b965be98ec477e3575379b` |
| Suffix is | `twox_128("State")` | `twox_128("StateKey")` |

This bug existed since the initial codebase but was never discovered because `MIDNIGHT_STATE_KEY` was never used until PR #342.

### Verification

Tested on preview network (node 0.18.0-rc.9):

```bash
# Wrong key returns null
curl -s -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"state_getStorage","params":["0x2a760f9a173a6df5cd4373ff49fa999bf39a107f2d8d3854c9aba9b021f43d9c"]}' \
  https://rpc.preview.midnight.network
# Result: {"jsonrpc":"2.0","id":1,"result":null}

# Correct key returns ledger state
curl -s -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"state_getStorage","params":["0x2a760f9a173a6df5cd4373ff49fa999bd3b3812d84b965be98ec477e3575379b"]}' \
  https://rpc.preview.midnight.network
# Result: {"jsonrpc":"2.0","id":1,"result":"0x1d016d69646e696768743a73746f726167652d6b6579..."}
```

### Changes
- `primitives/midnight/src/lib.rs`: Fixed `MIDNIGHT_STATE_KEY` hash and added documentation comments explaining key computation

### Testing
Local test `CFG_PRESET=dev cargo run --bin midnight-node --release`:
```
curl -s -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"midnight_dustRootHistory","params":[0]}' \
  http://localhost:9944/
```
- Result: {"jsonrpc":"2.0","id":1,"result":["00","00"]}
- Previously: {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Unable to get dust root history"}}

After deployment, verify `midnight_dustRootHistory` RPC works:
```bash
curl -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"midnight_dustRootHistory","params":[1733745600]}' \
  https://rpc.preview.midnight.network
```

### Related
- PR #342: Added `midnight_dustRootHistory` RPC (uses `MIDNIGHT_STATE_KEY`)
- Indexer investigation: Block 8226 dust proof failure analysis