### PR TITLE
ci: remove lychee link checker from changes check workflow

### DIFF
--- a/.github/workflows/changes_check.yml
+++ b/.github/workflows/changes_check.yml
@@ -69,25 +69,3 @@ jobs:
           FILENAME=$(grep -R 'changes' -e "pull/$PR_NUMBER" | head -1 | cut -d':' -f1)
           echo "Checking if $FILENAME contains a link to a JIRA ticket - fail if it does not"
           if [ ! -z "$FILENAME" ]; then grep -q "atlassian\.net" "$FILENAME"; fi
-
-      - name: Restore lychee cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  #v4.3.0
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
-      - name: Run lychee
-        uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 #v2.6.1
-        with:
-          args: >
-            --base .
-            --cache
-            --max-cache-age 1d
-            --exclude-path ./ui/index.html
-            --exclude-path ./changes/index.md
-            --exclude '^https://github\.com/midnightntwrk/midnight-node/actions/workflows/nightly-build-check'
-            --exclude '^https://x\.com/MidnightNtwrk'
-            .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHP_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the lychee link checker from the Changes Check workflow.

---

### Changes

- Removed 'Restore lychee cache' step
- Removed 'Run lychee' step

---

### Rationale

The lychee link checker was causing intermittent CI failures due to external link availability issues. It may be useful to occasionally manually run a link checker but every PR or even nightly is too frequent given the false positives.

---

### Files Changed

```
1 file changed, 22 deletions(-)
.github/workflows/changes_check.yml
```

https://github.com/midnightntwrk/midnight-node/pull/366