### PR TITLE
ci: fix the artifacts amd64 missing - add steps to publish arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,12 @@ jobs:
           name: midnight-node-amd64
           path: artifacts-amd64/
 
+      - name: Archive artifacts
+        run: |
+          tar -czf artifacts-amd64.tar.gz -C artifacts-amd64 .
+          echo "Created artifacts-amd64.tar.gz"
+          ls -lh artifacts-amd64.tar.gz
+
       - name: Create or Update Draft Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,7 +143,7 @@ jobs:
             --draft \
             --notes-file RELEASE_NOTES.md
 
-          gh release upload "$RELEASE_TITLE" artifacts-amd64/* --clobber
+          gh release upload "$RELEASE_TITLE" artifacts-amd64.tar.gz --clobber
 
       - name: Archive release notes
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -195,6 +201,44 @@ jobs:
         with:
           name: midnight-node-arm64
           path: artifacts-arm64/
+
+      - name: Archive ARM artifacts
+        run: |
+          tar -czf artifacts-arm64.tar.gz -C artifacts-arm64 .
+          echo "Created artifacts-arm64.tar.gz"
+          ls -lh artifacts-arm64.tar.gz
+
+      - name: Create or Update Draft Release (ARM64)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ "$BRANCH" != "main" ]; then
+            echo "Branch \"$BRANCH\" is not \"main\", skipping draft release creation for ARM64..."
+            exit 0
+          fi
+
+          VERSION=$(cat node/Cargo.toml | grep "version =" | head -1 | awk '{print $3}' | tr -d '"')
+          RELEASE_TITLE="[Unreleased]"
+
+          if gh release view "$RELEASE_TITLE"; then
+            echo "Release already exists, modifying..."
+            EDIT_OR_CREATE="edit"
+          else
+            echo "Creating release..."
+            EDIT_OR_CREATE="create"
+          fi
+
+          # We are modifying an existing draft created by AMD, or creating a new one if it's the first.
+          # If the AMD job already created the release, this step will simply modify it and add the ARM64 asset.
+          gh release $EDIT_OR_CREATE "$RELEASE_TITLE" \
+            --title "$RELEASE_TITLE" \
+            --draft \
+            --notes-file RELEASE_NOTES.md
+
+          echo "Uploading ARM64 artifacts..."
+          gh release upload "$RELEASE_TITLE" artifacts-arm64.tar.gz --clobber
+          echo "ARM64 artifacts uploaded successfully."
 
   build-indexer-images:
     name: Build Indexer Images


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

This PR fixes the issue that we're facing here: https://github.com/midnightntwrk/midnight-node/actions/runs/20304344904/job/58317611981

```
Release already exists, modifying...
https://github.com/***/midnight-node/releases/tag/untagged-eb786cc10ddb0594553d
Post "https://uploads.github.com/repos/***/midnight-node/releases/268852069/assets?label=&name=midnight-node-runtime": read artifacts-amd64/midnight-node-runtime: is a directory
Error: Process completed with exit code 1.
```

also adds the steps to publish the arm64, they were missing

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
