### PR TITLE
fix: allow branches that start with release/*

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,8 +116,8 @@ jobs:
           export SEASON_VAR_RELEASE_TAG="$SEASON_GIT_TAG"
           season-build-release-notes
 
-          if [ "$BRANCH" != "main" ]; then
-            echo "Branch \"$BRANCH\" is not \"main\", skipping draft release creation..."
+          if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release/.* ]]; then
+            echo "Branch \"$BRANCH\" is not \"main\" and does not start with \"release/\", skipping draft release creation for AMD64..."
             exit 0
           fi
 
@@ -214,8 +214,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [ "$BRANCH" != "main" ]; then
-            echo "Branch \"$BRANCH\" is not \"main\", skipping draft release creation for ARM64..."
+          if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release/.* ]]; then
+            echo "Branch \"$BRANCH\" is not \"main\" and does not start with \"release/\", skipping draft release creation for ARM64..."
             exit 0
           fi
 


### PR DESCRIPTION
# Overview

This fix will solved the issue that we saw here: https://github.com/midnightntwrk/midnight-node/actions/runs/20346398978/job/58459695246

```
Branch "release/node-0.18.0" is not "main", skipping draft release creation...
```

allowing the branches that starts with `release/*`

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
