### PR TITLE
ci: don't rebuild everything if a change file changes.

### DIFF
--- a/.github/workflows/continuous-integration-checks.yml
+++ b/.github/workflows/continuous-integration-checks.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "changes/**"
   push:
     branches: ["main"]
 concurrency:

--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "changes/**"
   push:
     branches: ["main"]
 concurrency:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,8 @@ on:
   merge_group:
   pull_request:
     branches: [ "**" ]
+    paths-ignore:
+      - "changes/**"
   workflow_dispatch:
 permissions:
   id-token: write

--- a/.github/workflows/rebuild-chainspec-bot.yml
+++ b/.github/workflows/rebuild-chainspec-bot.yml
@@ -12,6 +12,8 @@ on:
         description: 'Space-separated network names (e.g., "qanet preview")'
         required: true
   push:
+    paths-ignore:
+      - "changes/**"
 
 jobs:
   rebuild-chainspec:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -4,6 +4,8 @@ permissions: {}
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "changes/**"
   pull_request:
     branches: [main]
   workflow_dispatch: {}   # so you can still run it manually

--- a/.github/workflows/security-audit-scan.yml
+++ b/.github/workflows/security-audit-scan.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "changes/**"
   push:
     branches: ["main"]
 concurrency:


### PR DESCRIPTION
When you make a PR you need a change file with a PR reference in it.
When you stick the PR in the change file, we don't want to restart the majority of the CI checks as they're unaffected.

https://github.com/midnightntwrk/midnight-node/pull/453