### PR TITLE
fix(ci): use default branch for signing script checkout in release wo…

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Checkout node repository (for signing script)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
-          ref: ${{ inputs.ref }}
           path: ./.tmp-node-scripts
           sparse-checkout: .github/scripts
 


### PR DESCRIPTION
…rkflow

# Overview

Fix release workflow failing with "No such file or directory" when trying to source the signing script. The checkout step was using `${{ inputs.ref }}` (the release ref) to get the signing script, but older refs predate the script's addition in d33b11f. Changed to use the default branch (main) which always has the script.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- Re-run the failed release workflow after merging

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

- Failed run: https://github.com/midnightntwrk/midnight-node/actions/runs/21512582004/job/61983010989

https://shielded.atlassian.net/browse/SRE-1773?atlOrigin=eyJpIjoiYzBiY2IzMmJmYWZiNDA5OTgyMjBmNmViN2NhMTJjN2QiLCJwIjoiaiJ9