### PR TITLE
E2e cnight nightly run

### DIFF
--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   rust_e2e:
-    runs-on: ubuntu-latest-8-core-x64
-    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
 
     steps:
       - name: Resolve runtime settings


### PR DESCRIPTION
Now e2e of cNgD runs every night at 00:00 and result will be sent to https://shielded.slack.com/archives/C0A9SSV62N6

https://shielded.atlassian.net/browse/PM-21671