### PR TITLE
ci: fix signing non-existant arch-specific release tags

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -37,6 +37,9 @@ jobs:
   run:
     name: Release image
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.export-tags.outputs.release_tag }}
+      image_tag: ${{ steps.export-tags.outputs.image_tag }}
     env:
       FORCE_COLOR: 1
     steps:
@@ -191,6 +194,12 @@ jobs:
         run: |
           season-create-release
 
+      - name: Export tags for downstream jobs
+        id: export-tags
+        run: |
+          echo "release_tag=$SEASON_GIT_TAG" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$SEASON_IMAGE_TAG_RELEASE" >> "$GITHUB_OUTPUT"
+
       - name: Make PR against main
         working-directory: ./.tmp-package
         shell: bash
@@ -201,6 +210,7 @@ jobs:
   create-release-assets:
     runs-on: ubuntu-latest
     needs: run
+    if: github.event.inputs.release-type != 'Don''t create a release.'
     strategy:
       matrix:
         platform: [amd64, arm64]
@@ -215,9 +225,8 @@ jobs:
 
       - name: Extract files from Docker image
         run: |
-          RELEASE_TAG="${{ github.event.inputs.releaseTag || github.event.release.tagName }}"
-          # Strip "node-" prefix to get image tag
-          IMAGE_TAG="${RELEASE_TAG#node-}"
+          RELEASE_TAG="${{ needs.run.outputs.release_tag }}"
+          IMAGE_TAG="${{ needs.run.outputs.image_tag }}"
           IMAGE_NAME="ghcr.io/midnight-ntwrk/midnight-node:${IMAGE_TAG}"
           RELEASE_NAME="${RELEASE_TAG}-linux-${{ matrix.platform }}.tar.gz"
 
@@ -243,5 +252,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_TAG="${{ github.event.inputs.releaseTag || github.event.release.tagName }}"
-          gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" ${{ env.RELEASE_FILE }}
+          gh release upload --repo "$GITHUB_REPOSITORY" "${{ needs.run.outputs.release_tag }}" "${{ env.RELEASE_FILE }}"


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

We were attempting to sign images that don't exist (we only publish multi-arch images for release tags)

Used for https://github.com/midnightntwrk/midnight-node/releases/tag/node-0.20.1-rc.1

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
