### PR TITLE
ci: improve check perf

### DIFF
--- a/.github/workflows/continuous-integration-checks.yml
+++ b/.github/workflows/continuous-integration-checks.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Merge Conflict Finder
         uses: olivernybroe/action-conflict-finder@78f7add155e0bf97e9c71cb0383ef5691f72868c # v4.0
 
+      - name: Free disk space
+        run: scripts/free-disk-space.sh
+
       - name: Run build
         run: |
           . ./.envrc && earthly --ci +check

--- a/Earthfile
+++ b/Earthfile
@@ -797,22 +797,16 @@ check-rust:
     # ensure runtime benchmark feature enable to check they compile.
     RUN cargo clippy --workspace --all-targets --features runtime-benchmarks -- -D warnings
 
-    # unfortunately we need to do cargo clean here to run within disk space limits
-      RUN status=0; count=0; \
-          for pkg in $(cargo metadata --no-deps --format-version 1 \
-              | jq -r '.packages[].name'); do \
-              echo "===> Checking $pkg"; \
-              if ! cargo check -p "$pkg"; then \
-                  echo "Failed: $pkg"; \
-                  status=1; \
-              fi; \
-              count=$((count + 1)); \
-              if [ $((count % 16)) -eq 0 ]; then \
-                  echo "===> Cleaning (batch $((count / 16)))"; \
-                  cargo clean; \
-              fi; \
-          done; \
-          exit $status
+    RUN status=0; \
+        for pkg in $(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[].name'); do \
+            echo "===> Checking $pkg"; \
+            if ! cargo check -p "$pkg"; then \
+                echo "Failed: $pkg"; \
+                status=1; \
+            fi; \
+        done; \
+        exit $status
 
 # check-metadata confirms that metadata in the repo matches a given node image
 check-metadata:


### PR DESCRIPTION
There's 35 crates and checking each one took a while from clean. We only have 30Gb disk space to work with (reliably) so we clean every so often rather than after each crate which is slow. 

If we free up diskspace first, that takes the time down from 1h 20m to 42m.

(On my machine it was 11min rather than 12min if `CARGO_INCREMENTAL=0` was set.)

https://github.com/midnightntwrk/midnight-node/pull/609