### PR TITLE
fix: decouple local-environment from res/qanet config files

### DIFF
--- a/local-environment/src/networks/local-env/configurations/midnight-setup/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-setup/entrypoint.sh
@@ -70,7 +70,7 @@ jq 'env as $env | . + {
     "committee_candidates_address": "addr_test1wr4zpkfvylru9y3zahezf6vvfz7hlhf2pa4h9vxq70xwqzszre3qk",
     "permissioned_candidates_policy_id": $env.PERMISSIONED_CANDIDATES_POLICY_ID
   }
-}' res/qanet/pc-chain-config.json > /tmp/pc-chain-config.json
+}' res/local-environment/pc-chain-config.json > /tmp/pc-chain-config.json
 
 # Create patched federated-authority-config.json with Aiken policy IDs and addresses
 echo "Patching federated-authority-config.json with deployed Aiken contract values..."
@@ -127,7 +127,7 @@ jq '.observed_utxos.end = .observed_utxos.start
   | .mappings = {}
   | .utxo_owners = {}
   | .next_cardano_position = .observed_utxos.start
-  | .system_tx = null' res/qanet/cnight-config.json > /tmp/cnight-config.json
+  | .system_tx = null' res/local-environment/cnight-config.json > /tmp/cnight-config.json
 
 echo "Created cnight-config.json:"
 cat /tmp/cnight-config.json
@@ -141,7 +141,7 @@ export CHAINSPEC_GENESIS_TX=res/genesis/genesis_tx_undeployed.mn  #  0.13.5 comp
 export CHAINSPEC_CHAIN_TYPE=live
 export CHAINSPEC_PC_CHAIN_CONFIG=/tmp/pc-chain-config.json
 export CHAINSPEC_CNIGHT_GENESIS=/tmp/cnight-config.json
-export CHAINSPEC_ICS_CONFIG=res/qanet/ics-config.json
+export CHAINSPEC_ICS_CONFIG=res/local-environment/ics-config.json
 export CHAINSPEC_FEDERATED_AUTHORITY_CONFIG=/tmp/federated-authority-config.json
 export CHAINSPEC_SYSTEM_PARAMETERS_CONFIG=/tmp/system-parameters-config.json
 export CHAINSPEC_PERMISSIONED_CANDIDATES_CONFIG=/tmp/permissioned-candidates-config.json

--- a/res/local-environment/cnight-config.json
+++ b/res/local-environment/cnight-config.json
@@ -1,0 +1,32 @@
+{
+  "addresses": {
+    "mapping_validator_address": "addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng",
+    "auth_token_asset_name": "",
+    "cnight_policy_id": "d2dbff622e509dda256fedbd31ef6e9fd98ed49ad91d5c0e07f68af1",
+    "cnight_asset_name": ""
+  },
+  "observed_utxos": {
+    "start": {
+      "block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "block_number": 0,
+      "block_timestamp": 0,
+      "tx_index_in_block": 0
+    },
+    "end": {
+      "block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "block_number": 0,
+      "block_timestamp": 0,
+      "tx_index_in_block": 0
+    },
+    "utxos": []
+  },
+  "mappings": {},
+  "utxo_owners": {},
+  "next_cardano_position": {
+    "block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "block_number": 0,
+    "block_timestamp": 0,
+    "tx_index_in_block": 0
+  },
+  "system_tx": null
+}

--- a/res/local-environment/ics-config.json
+++ b/res/local-environment/ics-config.json
@@ -1,0 +1,9 @@
+{
+  "illiquid_circulation_supply_validator_address": "addr_test1wzeqa6xrntxk4c27xsac4jsajf66q7csxzlpn5hk5682d0g0u73rd",
+  "asset": {
+    "policy_id": "0xd2dbff622e509dda256fedbd31ef6e9fd98ed49ad91d5c0e07f68af1",
+    "asset_name": "NIGHT"
+  },
+  "utxos": [],
+  "total_amount": 0
+}

--- a/res/local-environment/pc-chain-config.json
+++ b/res/local-environment/pc-chain-config.json
@@ -1,0 +1,17 @@
+{
+  "bootnodes": [
+    "/dns/midnight-node-boot-01/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
+  ],
+  "chain_parameters": {
+    "genesis_utxo": "0000000000000000000000000000000000000000000000000000000000000000#0"
+  },
+  "cardano": {
+    "security_parameter": 432,
+    "active_slots_coeff": 0.05,
+    "first_epoch_number": 0,
+    "first_slot_number": 0,
+    "epoch_duration_millis": 86400000,
+    "first_epoch_timestamp_millis": 1666656000000,
+    "slot_duration_millis": 1000
+  }
+}


### PR DESCRIPTION
# Overview

local-environment referenced `res/qanet/` for `pc-chain-config.json`, `cnight-config.json`, and `ics-config.json`. When qanet configs change, local-environment CI tests break because they depend on qanet-specific chain state. This gives local-environment its own `res/local-environment/` config files to decouple the two.

Extracted from #524 (closed without merge).

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI/local-environment only, no product impact
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

local-environment entrypoint.sh now reads from `res/local-environment/` instead of `res/qanet/`. The `cnight-config.json` is a clean genesis version (all zeroed) since local-environment starts from scratch. `pc-chain-config.json` and `ics-config.json` are snapshots of the current qanet versions.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

- Extracted from #524