### PR TITLE
fix: reduce steady-state memory footprint on fully synced validators

### DIFF
--- a/changes/changed/reduce-steady-state-memory-footprint.md
+++ b/changes/changed/reduce-steady-state-memory-footprint.md
@@ -2,21 +2,28 @@
 # Reduce steady-state memory footprint on fully synced validators
 
 Heaptrack profiling and production monitoring show that fully synced validators
-exhibit linear memory growth over time, eventually approaching pod memory limits.
+exhibit linear memory growth over time, eventually approaching memory limits.
 The previous fix (storage_cache_size bounded LRU) addressed the dominant allocator
-during chain sync, but three other memory sources continue growing on synced nodes:
+during chain sync, but several other memory sources continue growing on synced nodes.
 
-1. **Substrate trie cache (1 GiB → 256 MiB):** The trie cache fills gradually and
-   never shrinks. At 1 GiB it consumed a fixed ~1 GiB on every node. 256 MiB is
-   sufficient for 6-second block validators.
+Tuned for an 8 GiB memory budget (~1.2 GiB baseline, ~6.8 GiB headroom):
+
+1. **Substrate trie cache (1 GiB → 128 MiB):** The trie cache fills gradually and
+   never shrinks. 128 MiB is sufficient for 6-second block validators.
 
 2. **WASM runtime instances (8 → 2):** Each pooled instance reserves 128 MiB of
    heap that is allocated on demand and never released. Default of 8 = up to 1 GiB.
    Validators only need 1–2 concurrent instances.
 
-3. **Transaction validation caches (add 5-minute TTI):** The moka caches for
-   VerifiedTransaction objects had no time-based eviction. On low-traffic networks
-   stale entries (50–200 KiB each, containing ZK proof data) persisted indefinitely.
-   Adding time_to_idle eviction prevents accumulation during quiet periods.
+3. **Midnight ledger arena cache (1M → 512K nodes):** Halved to ~40 MiB resident.
+   Synced validators rarely need more; sync takes a minor cache-miss penalty.
 
-Combined savings: ~1.5 GiB reduction in steady-state memory per validator.
+4. **Transaction validation caches (1000 → 200 entries, add 5-minute TTI):** The
+   moka caches for VerifiedTransaction objects had no time-based eviction and an
+   oversized capacity. Each entry holds ZK proof data (50–200 KiB). Reduced capacity
+   and added time_to_idle eviction to prevent stale entries from accumulating.
+
+5. **Transaction pool (8192 → 1024):** Low-traffic validator networks don't need
+   8192 pooled transactions.
+
+Combined savings: ~1.8 GiB reduction in steady-state memory per validator.

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -79,8 +79,10 @@ pub const LOG_TARGET: &str = "midnight::ledger_v2";
 pub const MINT_COINS_DOMAIN_SEPARATOR: &[u8; 10] = b"mint_coins";
 
 /// Maximum number of entries in each transaction validation cache.
+/// Each VerifiedTransaction entry holds ZK proof data (50-200 KiB). Capped at 200 entries
+/// to keep worst-case memory under ~40 MiB — sufficient for low-traffic validator networks.
 #[cfg(feature = "std")]
-const TX_VALIDATION_CACHE_MAX_CAPACITY: u64 = 1000;
+const TX_VALIDATION_CACHE_MAX_CAPACITY: u64 = 200;
 
 /// Time-to-idle for transaction validation cache entries.
 /// Entries not accessed within this duration are evicted, preventing stale VerifiedTransaction

--- a/res/cfg/default.toml
+++ b/res/cfg/default.toml
@@ -36,16 +36,19 @@ polling_period = 5
 # Setting of 0 means storage cache size is unlimited.
 # Will cause OOM errors if too much data is loaded.
 
-# Setting to a non-default value derived from the DEFAULT_CACHE_SIZE of the midnight-ledger crate:
-# https://github.com/midnightntwrk/midnight-ledger/blob/ledger-7.0.0-rc.2/storage/src/storage.rs#L54
-storage_cache_size = 1048576
+# Storage cache size measured in number of arena nodes (~80 bytes each).
+# Setting of 0 means unlimited — will cause OOM during sync.
+# 524288 nodes ≈ 40 MiB. Sufficient for synced validators; sync takes a minor
+# cache-miss penalty vs 1M but halves the arena's resident memory.
+# Ref: https://github.com/midnightntwrk/midnight-ledger/blob/ledger-7.0.0-rc.2/storage/src/storage.rs#L54
+storage_cache_size = 524288
 
 # Substrate trie cache size in bytes for in-memory state trie nodes.
-# Previously 1 GiB (1073741824), reduced to 256 MiB to lower steady-state memory footprint.
+# Previously 1 GiB (1073741824), reduced to 128 MiB to lower steady-state memory footprint.
 # On fully synced validators the trie cache fills gradually and never shrinks — at 1 GiB this
-# contributed a fixed ~1 GiB overhead on every node. 256 MiB is sufficient for validator
-# workloads with 6-second block times and keeps total memory well within 12 Gi pod limits.
-trie_cache_size = 268435456
+# consumed a fixed ~1 GiB on every node. 128 MiB is sufficient for validator workloads with
+# 6-second block times and keeps total memory well within an 8 GiB memory budget.
+trie_cache_size = 134217728
 
 argv = []
 args = []
@@ -55,5 +58,7 @@ args = []
 #   Each instance reserves 128 MiB of heap, so 8 instances = 1 GiB of WASM memory that is
 #   allocated on demand and never released. Validators only need 1 concurrent instance for
 #   block import and 1 for authoring — 2 is sufficient and saves ~768 MiB.
-append_args = ["--max-runtime-instances", "2"]
+# --pool-limit 1024: Caps transaction pool from default of 8192. Low-traffic validator
+#   networks don't need 8192 pooled transactions; 1024 saves ~30 MiB.
+append_args = ["--max-runtime-instances", "2", "--pool-limit", "1024"]
 bootnodes = []


### PR DESCRIPTION
## Overview

This PR optimises the node for a maximum memory allocation of 8Gi, optimising all caching parameters around this memory budget

 - `trie_cache_size`: 1 GiB → 128 MiB — The trie cache fills gradually and never shrinks. At 1 GiB it was the single largest
  memory consumer. 128 MiB is sufficient for 6-second block validators and frees ~900 MiB for the 8G budget.
  - `storage_cache_size`: 1M nodes (~80 MiB) → 512K nodes (~40 MiB) — Halved the midnight-ledger arena LRU cache. Synced validators rarely need more than 512K nodes hot; the tradeoff is slightly more disk reads during sync. Saves 40 MiB that matters when every MiB counts toward 8G.
  - `max_runtime_instances`: 8 → 2 — Each pooled WASM instance reserves 128 MiB of heap that is allocated on demand and never released. Default of 8 = up to 1 GiB. Validators only need 1 instance for block import and 1 for authoring. Saves ~768 MiB which is critical for fitting in 8G.
  - `TX_VALIDATION_CACHE_MAX_CAPACITY`: 1000 (no TTL) → 200 entries + 5-minute time-to-idle — Each VerifiedTransaction entry holds ZK proof data (50-200 KiB). At 1000 entries with no TTL, stale entries for old state hashes accumulated up to ~200 MiB. Reduced to 200 entries (plenty for low-traffic validator networks) and added idle eviction so quiet periods actively reclaim memory. Keeps worst-case under ~40 MiB.
  - `pool-limit`: 8192 → 1024 — Default Substrate tx pool of 8192 is sized for public networks. Our 6-validator testnets
  generate minimal transactions. 1024 is more than sufficient and saves ~30 MiB of pooled transaction overhead.

  These values target an estimated ~1.2 GiB baseline with ~6.8 GiB headroom for allocator fragmentation and ParityDB mmap growth — enough for multiple days of uptime before memory pressure.



## Background

Fully synced validators exhibit continuous memory growth, approaching pod limits (12 Gi) within days. Heaptrack profiling confirmed the midnight_storage arena as the dominant allocator (94% of heap never freed), which was previously addressed by bounding `storage_cache_size`. However, three additional memory sources continue growing on synced nodes:

| Change | Before | After | Savings |
|--------|--------|-------|---------|
| `trie_cache_size` | 1 GiB | 256 MiB | ~768 MiB |
| `max_runtime_instances` | 8 (default) | 2 | ~768 MiB |
| TX validation cache TTI | none (count-only) | 5 min idle eviction | variable |

**Combined: ~1.5 GiB reduction in steady-state memory per validator.**

### 1. Substrate trie cache: 1 GiB → 256 MiB (`res/cfg/default.toml`)

The trie cache fills gradually as state is accessed and never shrinks. At 1 GiB it consumed a fixed ~1 GiB on every node. 256 MiB is sufficient for validator workloads with 6-second block times.

### 2. WASM runtime instances: 8 → 2 (`res/cfg/default.toml`)

Each pooled WASM instance reserves 128 MiB of heap that is allocated on demand and never released. The Substrate default of 8 instances = up to 1 GiB. Validators only need 1 concurrent instance for block import and 1 for authoring.

### 3. Moka cache TTI: add 5-minute time_to_idle (`ledger/src/versions/common/mod.rs`)

The `STRICT_TX_VALIDATION_CACHE` stores `VerifiedTransaction` objects (50–200 KiB each containing ZK proof data) keyed by `(state_hash, tx_hash)`. Since `state_hash` changes every block, the same transaction gets a new cache key each block — old entries for stale state hashes accumulated until the 1000-entry cap forced LRU eviction. On low-traffic networks, entries persisted indefinitely. Adding `time_to_idle(5 min)` evicts stale entries during quiet periods.

## Current production data (qanet, 12 Gi limit)

| Validator | Memory | Uptime | Growth Rate |
|-----------|--------|--------|-------------|
| V1 | 7,399 Mi (60%) | 2d4h | ~3.5 Gi/day |
| V2 | 7,378 Mi (60%) | 2d4h | ~3.5 Gi/day |
| V4 | 7,418 Mi (61%) | 2d4h | ~3.5 Gi/day |

At this rate, pods would OOM within ~4 days.

## TODO before merging

- [ ] CI build + test pass
- [ ] Verify `--max-runtime-instances 2` doesn't cause runtime instance contention under load

## Submission Checklist

- [x] This is backward-compatible (config/CLI changes only; no runtime migration needed)
- [ ] I have self-reviewed the diff
- [x] A change file has been added (`changes/changed/reduce-steady-state-memory-footprint.md`)
- [x] No version bump needed (config-only change)
- [x] `AGENTS.md` does not need updating

## Testing Evidence

Deploy to qanet first and monitor memory over 48h. Expected: memory stabilizes around 3-4 Gi instead of growing past 7 Gi.

- [ ] Additional tests are not needed (no logic changes, only cache configuration)

## Fork Strategy

- [x] N/A

## Links

Related commit: 69fe806c (fix-unbounded-ledger-storage-cache)