### PR TITLE
ci: skip audit check on merge queue so PRs don't fail to merge 

### DIFF
--- a/.github/workflows/security-audit-scan.yml
+++ b/.github/workflows/security-audit-scan.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   run:
     name: cargo audit job
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1


### PR DESCRIPTION
skip audit check on merge queue so PRs don't fail to merge due to intermittent network errors.

Audit jobs run at PR level.
Audit jobs have to check against up to date security databases and thus are more likely to fail than other jobs.

https://github.com/midnightntwrk/midnight-node/pull/660