### PR TITLE
docs: document intentional panic paths in NTO pallet (PM-20268)

### DIFF
--- a/pallets/cnight-observation/src/lib.rs
+++ b/pallets/cnight-observation/src/lib.rs
@@ -223,6 +223,12 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
+			// Genesis configuration validation: BuildGenesisConfig::build() returns () and
+			// cannot propagate errors via Result. Panicking on invalid configuration values
+			// is the standard Substrate genesis fail-fast convention — an invalid chain spec
+			// must halt node startup rather than silently produce incorrect chain state.
+			// Each expect() below validates a bounded-length conversion from the chain spec;
+			// failure indicates a misconfigured genesis that must be corrected before launch.
 			MainChainMappingValidatorAddress::<T>::set(
 				self.config
 					.addresses
@@ -310,8 +316,10 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		// Intentionally panic on codec error — corrupted inherent data is an unrecoverable
-		// programming error; silently returning None would drop token movements for this block.
+		// Intentionally panic on codec error. Inherent data is produced by the node's own
+		// inherent data provider — a decoding failure here indicates a node-internal programming
+		// error, not malformed external input. Silently returning None would drop token movements
+		// for the entire block, a strictly worse failure mode than surfacing the error immediately.
 		#[allow(clippy::unwrap_in_result)]
 		fn get_data_from_inherent_data(
 			data: &InherentData,


### PR DESCRIPTION
## Summary

Address Least Authority audit Issue T (Medium severity) for the cNight Observation (NTO) pallet. After analysis, the 5 remaining `expect()` calls are **intentional fail-fast behavior** in genesis configuration and inherent data codec contexts — standard Substrate conventions where panicking is the correct response. This PR adds documentation comments explaining why each panic path is deliberate.

Two of the four original audit findings were already resolved in prior work:
- `set_mapping_validator_contract_address` — now returns a typed error via `map_err`
- `get_registrations_for` — function was removed from the codebase

## Problem

The audit flagged `expect()` and `unwrap()` calls in the NTO pallet as panic risks. Upon analysis:

- **Genesis build** (4 `expect()` calls): `BuildGenesisConfig::build()` returns `()` and cannot propagate errors via `Result`. Panicking on invalid chain spec values is the standard Substrate genesis fail-fast convention — an invalid chain spec must halt startup rather than silently produce incorrect chain state.
- **Inherent data codec** (1 `expect()` call): Inherent data is produced by the node's own inherent data provider. A codec error indicates a node-internal programming error, not malformed external input. Silently returning `None` would drop token movements for the block — a strictly worse failure mode.

## Changes

- `pallets/cnight-observation/src/lib.rs` — documentation comments only, no logic changes
- Genesis `build()`: Added block comment explaining fail-fast rationale (covers lines 233, 242, 249, 259)
- `get_data_from_inherent_data`: Expanded existing justification comment (line 320)

**Diff:** +10/-2 lines, all comments.

## Acceptance Criteria

- [x] `set_mapping_validator_contract_address` returns typed error on overlong address (already resolved in prior work)
- [x] `get_registrations_for` returns error when registrations exceed max (function removed in prior work)
- [x] Genesis build `expect()` calls documented with fail-fast rationale
- [x] `get_data_from_inherent_data` justification comment expanded
- [x] Diff contains only comment changes — no behavior modifications
- [x] Existing tests pass (`cargo test -p pallet-cnight-observation`)

## Testing

| Check | Result |
|-------|--------|
| `cargo test -p pallet-cnight-observation` | 10 passed, 0 failed, 1 ignored (pre-existing) |
| `cargo check -p pallet-cnight-observation` | Clean |
| `cargo clippy -p pallet-cnight-observation -- -D warnings` | 0 warnings |

## References

- Jira: [PM-20268](https://shielded.atlassian.net/browse/PM-20268)
- Parent Epic: [PM-19974](https://shielded.atlassian.net/browse/PM-19974) — Q4 2025 Least Authority Node Audit Findings
- Audit: Least Authority — Midnight Network Node Initial Audit Report (Oct 2025), Issue T
- Affected file: `pallets/cnight-observation/src/lib.rs`

[PM-20268]: https://shielded.atlassian.net/browse/PM-20268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ