### PR TITLE
fix: add --bundle flag to cosign sign-blob for v3.x compatibility

### DIFF
--- a/.github/scripts/sign-binary.sh
+++ b/.github/scripts/sign-binary.sh
@@ -9,6 +9,7 @@
 #   sign_blob_with_retry "path/to/file.tar.gz"
 #
 # Outputs:
+#   - ${FILE}.bundle - The Sigstore bundle (required by cosign v2.5+)
 #   - ${FILE}.sig - The detached signature
 #   - ${FILE}.pem - The certificate (public key) used for signing
 
@@ -24,11 +25,13 @@ sign_blob_with_retry() {
 
     if cosign sign-blob "$FILE" \
         --yes \
+        --bundle "${FILE}.bundle" \
         --output-signature "${FILE}.sig" \
         --output-certificate "${FILE}.pem"; then
       echo "Successfully signed $FILE"
       echo "  Signature: ${FILE}.sig"
       echo "  Certificate: ${FILE}.pem"
+      echo "  Bundle: ${FILE}.bundle"
       return 0
     fi
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -365,8 +365,8 @@ jobs:
 
           echo "Uploading assets to release: $RELEASE_TAG"
           gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" \
-            "$NODE_FILE" "${NODE_FILE}.sig" "${NODE_FILE}.pem" \
-            "$TOOLKIT_FILE" "${TOOLKIT_FILE}.sig" "${TOOLKIT_FILE}.pem" \
+            "$NODE_FILE" "${NODE_FILE}.sig" "${NODE_FILE}.pem" "${NODE_FILE}.bundle" \
+            "$TOOLKIT_FILE" "${TOOLKIT_FILE}.sig" "${TOOLKIT_FILE}.pem" "${TOOLKIT_FILE}.bundle" \
             "SHA256SUMS-${{ matrix.platform }}"
 
   finalize-checksums:
@@ -417,7 +417,8 @@ jobs:
           gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" \
             SHA256SUMS \
             SHA256SUMS.sig \
-            SHA256SUMS.pem
+            SHA256SUMS.pem \
+            SHA256SUMS.bundle
 
   sbom-scan-ghcr-node:
     name: SBOM/Scan Node GHCR (${{ matrix.arch }})


### PR DESCRIPTION
# Overview

`cosign-installer@v4.0.0` installs cosign v3.x which defaults `--use-signing-config=true`, requiring `--bundle` for `sign-blob`. This broke the release workflow at the signing step.

Adds `--bundle` to the signing script and uploads `.bundle` files alongside `.sig`/`.pem` in release assets.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- Verified all `cosign sign-blob` flags (`--bundle`, `--output-signature`, `--output-certificate`, `--yes`) exist in cosign v3.0.4 via `--help`
- Verified pinned action SHAs match their tags

## 🔱 Fork Strategy

- [ ] N/A

## Links

- JIRA: https://shielded.atlassian.net/browse/SRE-1859
- Failed run: https://github.com/midnightntwrk/midnight-node/actions/runs/21989109732/job/63536694502