### PR TITLE
Performance/toolkit add no fetch arg

### DIFF
--- a/util/toolkit/src/tx_generator/source.rs
+++ b/util/toolkit/src/tx_generator/source.rs
@@ -317,7 +317,7 @@ where
 					.await
 					.expect("no cached data found in db — run a fetch first");
 				let mut blocks: Vec<_> = storage
-					.get_block_data_range(chain_id, (0..max_height).into_iter())
+					.get_block_data_range(chain_id, (0..max_height + 1).into_iter())
 					.await
 					.into_iter()
 					.enumerate()


### PR DESCRIPTION
# Overview

I added a nofetch argument for using with multithreaded scripts, so the user can fetch the data once and distribute to multiple threads. As long as the utxo set hasn't changed we don't need to pull the data again.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

I tested locally with 0.22 node, generated txs with no fetch and submitted successfully.

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
