### PR TITLE
fix: use HashMap iteration order instead of shuffle for legacy sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7464,7 +7464,6 @@ dependencies = [
  "midnight-zswap 7.0.0-rc.2 (git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-7.0.0)",
  "moka 0.11.3",
  "parity-scale-codec",
- "rand 0.8.5",
  "scale-info",
  "scale-info-derive",
  "serde",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -41,7 +41,6 @@ lazy_static = { workspace = true, optional = true }
 moka = { version = "0.11.3", optional = true }
 toml = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
 midnight-node-ledger-helpers = { workspace = true, optional = true }
 scale-info.workspace = true
 
@@ -84,7 +83,6 @@ std = [
     "transient-crypto-hf",
     "zswap-hf",
     "sha2",
-    "rand",
     "toml",
     "midnight-node-ledger-helpers",
     "derive-where"

--- a/ledger/src/versions/common/api/transaction.rs
+++ b/ledger/src/versions/common/api/transaction.rs
@@ -149,20 +149,6 @@ impl UnshieldedUtxos {
 		self.outputs.values().flat_map(|utxos| utxos.iter()).cloned().collect()
 	}
 
-	pub fn outputs_shuffled(&self) -> Vec<UtxoInfo> {
-		use rand::seq::SliceRandom;
-		let mut segments: Vec<_> = self.outputs.values().collect();
-		segments.shuffle(&mut rand::thread_rng());
-		segments.into_iter().flat_map(|utxos| utxos.iter()).cloned().collect()
-	}
-
-	pub fn inputs_shuffled(&self) -> Vec<UtxoInfo> {
-		use rand::seq::SliceRandom;
-		let mut segments: Vec<_> = self.inputs.values().collect();
-		segments.shuffle(&mut rand::thread_rng());
-		segments.into_iter().flat_map(|utxos| utxos.iter()).cloned().collect()
-	}
-
 	/// Checks the integrity of UTXO events against the final Ledger state.
 	///
 	/// This function verifies that:
@@ -228,6 +214,36 @@ impl UnshieldedUtxos {
 		}
 
 		Ok((utxo_outputs, utxo_inputs))
+	}
+}
+
+/// HashMap-based version of UnshieldedUtxos that replicates the iteration order
+/// from before the BTreeMap determinism fix, used during sync to match historical blocks.
+#[derive(Default, Debug)]
+pub struct UnshieldedUtxosLegacy {
+	pub outputs: HashMap<SegmentId, Vec<UtxoInfo>>,
+	pub inputs: HashMap<SegmentId, Vec<UtxoInfo>>,
+}
+
+impl UnshieldedUtxosLegacy {
+	pub fn remove_failed_segments<D: DB>(
+		&mut self,
+		segments: &HashMap<SegmentId, Result<(), TransactionInvalid<D>>>,
+	) {
+		segments.iter().for_each(|(segment_id, maybe_tx_invalid)| {
+			if maybe_tx_invalid.is_err() {
+				self.outputs.remove(segment_id);
+				self.inputs.remove(segment_id);
+			}
+		});
+	}
+
+	pub fn inputs(&self) -> Vec<UtxoInfo> {
+		self.inputs.values().flat_map(|utxos| utxos.iter()).cloned().collect()
+	}
+
+	pub fn outputs(&self) -> Vec<UtxoInfo> {
+		self.outputs.values().flat_map(|utxos| utxos.iter()).cloned().collect()
 	}
 }
 
@@ -392,6 +408,64 @@ impl<S: SignatureKind<D>, D: DB> Transaction<S, D> {
 					}
 				}
 				Some(UnshieldedUtxos { outputs, inputs })
+			},
+			_ => None,
+		};
+
+		utxos.unwrap_or_default()
+	}
+
+	/// Returns unshielded UTXOs using HashMap (pre-determinism-fix behavior).
+	/// The HashMap iteration order matches the original code before the BTreeMap migration.
+	pub(crate) fn unshielded_utxos_legacy(&self) -> UnshieldedUtxosLegacy {
+		let mut outputs: HashMap<u16, Vec<UtxoInfo>> = HashMap::new();
+		let mut inputs: HashMap<u16, Vec<UtxoInfo>> = HashMap::new();
+
+		let mut update_outputs = |segment_id: SegmentId, outputs_info: Vec<UtxoInfo>| {
+			if !outputs_info.is_empty() {
+				outputs.entry(segment_id).or_default().extend(outputs_info);
+			}
+		};
+
+		let mut update_inputs = |segment_id: SegmentId, inputs_info: Vec<UtxoInfo>| {
+			if !inputs_info.is_empty() {
+				inputs.entry(segment_id).or_default().extend(inputs_info);
+			}
+		};
+
+		let utxos = match &self.0 {
+			Tx::Standard(tx) => {
+				for segment_id in tx.segments() {
+					if segment_id == 0 {
+						for intent in tx.intents.values() {
+							let parent = intent.erase_proofs().erase_signatures();
+							let intent_hash = parent.intent_hash(segment_id).0.0;
+
+							let utxo_outputs = intent.guaranteed_outputs();
+							let outputs_info =
+								Self::utxos_info_from_output(utxo_outputs, intent_hash);
+
+							let utxo_inputs = intent.guaranteed_inputs();
+							let inputs_info = Self::utxos_info_from_inputs(utxo_inputs);
+
+							update_outputs(segment_id, outputs_info);
+							update_inputs(segment_id, inputs_info);
+						}
+					} else if let Some(intent) = tx.intents.get(&segment_id) {
+						let parent = intent.erase_proofs().erase_signatures();
+						let intent_hash = parent.intent_hash(segment_id).0.0;
+
+						let utxo_outputs = intent.fallible_outputs();
+						let outputs_info = Self::utxos_info_from_output(utxo_outputs, intent_hash);
+
+						let utxo_inputs = intent.fallible_inputs();
+						let inputs_info = Self::utxos_info_from_inputs(utxo_inputs);
+
+						update_outputs(segment_id, outputs_info);
+						update_inputs(segment_id, inputs_info);
+					}
+				}
+				Some(UnshieldedUtxosLegacy { outputs, inputs })
 			},
 			_ => None,
 		};

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -201,21 +201,29 @@ where
 			if let TransactionAppliedStage::PartialSuccess(segments) = applied_stage {
 				// Remove from `utxos` the `segments` that failed
 				utxos.remove_failed_segments(&segments);
-				Some(segments.keys().copied().collect())
+				let ids = segments.keys().copied().collect();
+				Some((ids, segments))
 			} else {
 				None
 			};
 
-		let operations =
-			tx.calls_and_deploys(should_skip_failed_segments.then_some(failed_segments).flatten());
+		let operations = tx.calls_and_deploys(
+			should_skip_failed_segments
+				.then_some(failed_segments.as_ref().map(|(ids, _)| ids).cloned())
+				.flatten(),
+		);
 
 		let (utxo_outputs, utxo_inputs) =
 			utxos.check_utxos_response_integrity(initial_utxos_size, &ledger)?;
 
-		// During sync, shuffle segment ordering to probabilistically match historical
-		// blocks produced with non-deterministic HashMap iteration order
+		// During sync, use HashMap iteration order to match historical blocks
+		// produced before the non-determinism fix (BTreeMap migration)
 		let (utxo_outputs, utxo_inputs) = if is_syncing {
-			(utxos.outputs_shuffled(), utxos.inputs_shuffled())
+			let mut legacy_utxos = tx.unshielded_utxos_legacy();
+			if let Some((_, ref segments)) = failed_segments {
+				legacy_utxos.remove_failed_segments(segments);
+			}
+			(legacy_utxos.outputs(), legacy_utxos.inputs())
 		} else {
 			(utxo_outputs, utxo_inputs)
 		};


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

Replace random shuffle with HashMap-based iteration to accurately
replicate the pre-determinism-fix behavior during sync.

We were seeing sync issues with the previous shuffle fix; The shuffle
approach may be "more random" than the original HashMap iteration order,
which depends on insertion sequence and internal table layout.


## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
