### PR TITLE
ci: faster tests - use debug mode.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -912,7 +912,7 @@ test-pallet-fixtures:
     COPY static/contracts/simple-merkle-tree /test-static/simple-merkle-tree
     ENV MIDNIGHT_LEDGER_TEST_STATIC_DIR=/test-static
 
-    # Run pallet-midnight fixture tests in debug mode (cranelift backend compiles faster)
+    # Run pallet-midnight fixture tests in debug mode (compiles much faster)
     RUN MIDNIGHT_LEDGER_EXPERIMENTAL=1 cargo nextest r --profile ci --locked \
         -E 'test(/^tests::test_get_contract_state$/) | test(/^tests::test_send_mn_transaction$/) | test(/^tests::test_validation_works$/)'
     # RUN cargo llvm-cov report --html --release --output-dir /test-artifacts-pallet-fixtures-$NATIVEARCH/html


### PR DESCRIPTION
`test-pallet-fixtures` is one of our longest running jobs as it's compiling on a free 4 core runner, but I don't think it needs to compile the WASM so we should be able to pull in this time considerably.

UPDATE: That didn't reduce the time considerably. But not building in release mode brought the time down from 1h 5min to 25min.

https://github.com/midnightntwrk/midnight-node/pull/752