### PR TITLE
fix: allow sync monitor to toggle UTXO ordering on sync restart

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -566,14 +566,18 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		let sync_service = sync_service.clone();
 		let is_syncing = is_syncing.clone();
 		task_manager.spawn_handle().spawn("sync-status-monitor", None, async move {
+			let mut was_syncing = true;
 			loop {
 				tokio::time::sleep(Duration::from_secs(1)).await;
 				let syncing = sync_service.is_major_syncing();
 				is_syncing.store(syncing, Ordering::Relaxed);
-				if !syncing {
-					log::info!(target: "midnight", "Major sync complete, switching to deterministic UTXO ordering");
-					break;
+				if was_syncing && !syncing {
+					log::info!(target: "midnight", "Sync stopped, switching to deterministic UTXO ordering");
 				}
+				if !was_syncing && syncing {
+					log::info!(target: "midnight", "Sync started, switching to non-deterministic UTXO ordering");
+				}
+				was_syncing = syncing;
 			}
 		});
 	}


### PR DESCRIPTION
Cherry-pick of #715 from release/node-0.20.2. The sync-status-monitor previously broke out of its loop after the first sync completed, permanently switching to deterministic UTXO ordering. If the node fell behind and re-entered major sync, it would fail to sync historical blocks that require non-deterministic ordering. The monitor now continuously tracks sync state transitions in both directions.

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
