### PR TITLE
fix: Only set dust_actions if there's actual content

### DIFF
--- a/ledger/helpers/src/versions/common/transaction.rs
+++ b/ledger/helpers/src/versions/common/transaction.rs
@@ -308,14 +308,16 @@ impl<D: DB + Clone> StandardTrasactionInfo<D> {
 			.dust_registrations
 			.iter()
 			.map(|registration| registration.build(&intent, &mut rng, segment_id))
-			.collect::<Vec<_>>()
-			.into();
+			.collect::<Vec<_>>();
 
-		intent.dust_actions = Some(Sp::new(DustActions {
-			spends: spends.to_vec().into(),
-			registrations,
-			ctime: now,
-		}));
+		// Only set dust_actions if there's actual content (normalization requirement)
+		if !spends.is_empty() || !registrations.is_empty() {
+			intent.dust_actions = Some(Sp::new(DustActions {
+				spends: spends.to_vec().into(),
+				registrations: registrations.into(),
+				ctime: now,
+			}));
+		}
 		stx.intents = stx.intents.insert(segment_id, intent);
 
 		// Re-compute the binding randomness


### PR DESCRIPTION
# Overview

As suggested by bob: 

> The toolkit's apply_dust function creates a DustActions structure even when there are no dust spends and no
>  dust registrations. This creates an empty DustActions which violates the ledger's normalization requirement.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
