### PR TITLE
chore: clean up toolkit input handling

### DIFF
--- a/changes/changed/toolkit-input-cleanup.md
+++ b/changes/changed/toolkit-input-cleanup.md
@@ -1,0 +1,6 @@
+#toolkit
+# Clean up toolkit input handling
+
+Use tagged-only decoding in hex_ledger_decode, switch to checked
+arithmetic in transaction builder, and add file size limits when
+reading input files.

--- a/util/toolkit/src/cli_parsers.rs
+++ b/util/toolkit/src/cli_parsers.rs
@@ -63,11 +63,7 @@ pub fn keypair_from_str(input: &str) -> Result<Keypair, clap::error::Error> {
 }
 
 pub fn hex_ledger_decode<T: Deserializable + Tagged>(input: &str) -> Result<T, clap::error::Error> {
-	if let Ok(addr) = hex_ledger_tagged_decode::<T>(input) {
-		Ok(addr)
-	} else {
-		hex_ledger_untagged_decode::<T>(input)
-	}
+	hex_ledger_tagged_decode::<T>(input)
 }
 
 pub fn coin_public_decode(input: &str) -> Result<CoinPublicKey, clap::error::Error> {

--- a/util/toolkit/src/tx_generator/builder/builders/contract_custom.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/contract_custom.rs
@@ -104,7 +104,20 @@ impl CustomContractBuilder {
 	fn read_zswap_file(
 		&self,
 	) -> Result<Option<EncodedZswapLocalState>, CustomContractBuilderError> {
+		/// Maximum file size for zswap state files (64 MB)
+		const MAX_ZSWAP_FILE_SIZE: u64 = 64 * 1024 * 1024;
+
 		if let Some(file_path) = &self.zswap_state_file {
+			let metadata = std::fs::metadata(file_path)
+				.map_err(CustomContractBuilderError::FailedReadingZswapStateFile)?;
+			if metadata.len() > MAX_ZSWAP_FILE_SIZE {
+				return Err(CustomContractBuilderError::FailedReadingZswapStateFile(
+					std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						format!("zswap state file exceeds maximum size of {} bytes", MAX_ZSWAP_FILE_SIZE),
+					),
+				));
+			}
 			let bytes = std::fs::read(file_path)
 				.map_err(CustomContractBuilderError::FailedReadingZswapStateFile)?;
 			let zswap_state = serde_json::from_slice(&bytes)

--- a/util/toolkit/src/tx_generator/builder/builders/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/single_tx.rs
@@ -176,7 +176,9 @@ impl SingleTxBuilder {
 		output_wallets: Vec<ShieldedWallet<DefaultDB>>,
 		amount: u128,
 	) -> OfferInfo<DefaultDB> {
-		let total_required = amount * output_wallets.len() as u128;
+		let total_required = amount
+			.checked_mul(output_wallets.len() as u128)
+			.expect("shielded amount overflow");
 
 		let input_info = InputInfo {
 			origin: funding_seed,
@@ -203,7 +205,9 @@ impl SingleTxBuilder {
 
 		let funding_wallet = context.clone().wallet_from_seed(funding_seed);
 		let input_amount = input_info.min_match_coin(&funding_wallet.shielded.state).value;
-		let remaining_coins = input_amount - total_required;
+		let remaining_coins = input_amount
+			.checked_sub(total_required)
+			.expect("insufficient shielded input for total required amount");
 
 		// Create an `Output` to its self with the remaining coins to avoid spending the whole `Input`
 		let output_info_refund: Box<dyn BuildOutput<DefaultDB>> = Box::new(OutputInfo {
@@ -224,7 +228,9 @@ impl SingleTxBuilder {
 		output_wallets: Vec<UnshieldedWallet>,
 		amount_to_send_per_output: u128,
 	) -> HashMap<u16, Box<dyn BuildIntent<DefaultDB>>> {
-		let total_required = amount_to_send_per_output * output_wallets.len() as u128;
+		let total_required = amount_to_send_per_output
+			.checked_mul(output_wallets.len() as u128)
+			.expect("unshielded amount overflow");
 
 		let utxo_spend_info = UtxoSpendInfo {
 			value: total_required,
@@ -253,7 +259,9 @@ impl SingleTxBuilder {
 			.collect();
 
 		let input_amount = min_match_utxo.value;
-		let remaining_nights = input_amount - total_required;
+		let remaining_nights = input_amount
+			.checked_sub(total_required)
+			.expect("insufficient unshielded input for total required amount");
 
 		// Create an `UtxoOutput` to its self with the remaining nights to avoid spending the whole `UtxoSpend`
 		let output_info_refund: Box<dyn BuildUtxoOutput<DefaultDB>> = Box::new(UtxoOutputInfo {

--- a/util/toolkit/src/tx_generator/source.rs
+++ b/util/toolkit/src/tx_generator/source.rs
@@ -227,8 +227,18 @@ where
 			}
 			Ok(SourceTransactions::from_txs_with_context(txs, self.dust_warp))
 		} else {
+			/// Maximum file size for transaction files (64 MB)
+			const MAX_TX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+
 			let mut txs = vec![];
 			for file in &self.files {
+				let metadata = std::fs::metadata(file)?;
+				if metadata.len() > MAX_TX_FILE_SIZE {
+					return Err(Box::new(std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						format!("transaction file {:?} exceeds maximum size of {} bytes", file, MAX_TX_FILE_SIZE),
+					)));
+				}
 				let bytes = std::fs::read(file)?;
 				// files can either be one TransactionWithContext or many of them
 				let mut file_txs = mn_ledger_serialize::tagged_deserialize(bytes.as_slice())


### PR DESCRIPTION
Use tagged-only decoding in hex_ledger_decode instead of silently falling back to untagged.

Switch to checked_mul and checked_sub in shielded and unshielded transaction builders.

Add file size limits when reading zswap state and transaction files.

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
