### PR TITLE
docs: document SBOM trimming for attestation size limit

### DIFF
--- a/docs/security/image-signing.md
+++ b/docs/security/image-signing.md
@@ -21,10 +21,20 @@ GitHub artifact attestations use Sigstore under the hood but are fully managed b
 
 SBOMs are generated using [Syft](https://github.com/anchore/syft) in SPDX-JSON format:
 
-1. **Scan**: Syft analyzes the container image layers
+1. **Scan**: Syft analyzes the container image layers (file cataloger disabled to reduce size)
 2. **Extract**: Package information is extracted from package managers (apt, npm, cargo, etc.)
 3. **Generate**: An SPDX-JSON document is created listing all components
-4. **Attest**: The SBOM is attached to the image as an attestation using `actions/attest-sbom`
+4. **Trim**: SPDX relationships are stripped and JSON is minified to fit under the 16MB `actions/attest-sbom` predicate limit (full SBOM preserved as build artifact)
+5. **Attest**: The trimmed SBOM is attached to the image as an attestation using `actions/attest-sbom`
+
+#### SBOM Size Constraints
+
+GitHub's attestation API enforces a hard 16MB predicate size limit ([actions/attest-sbom#168](https://github.com/actions/attest-sbom/issues/168)). The midnight-node image contains ~2,000 packages, producing SBOMs that exceed this limit. To fit:
+
+- **File cataloger disabled**: `--select-catalogers '-file'` excludes filesystem entries (~22MB to ~19MB)
+- **Relationships stripped**: `jq -c 'del(.relationships)'` removes inter-package dependency edges and minifies JSON (~19MB to ~12MB)
+
+The **full unmodified SBOM** is uploaded as a build artifact for detailed analysis. The **attested SBOM** retains all package identifiers, versions, licenses, and checksums — only relationship edges and JSON whitespace are removed.
 
 ### Vulnerability Scanning
 
@@ -69,7 +79,7 @@ Both architecture variants are individually attested, and the manifest list itse
 
 | Script | Purpose |
 |--------|---------|
-| `.github/scripts/sbom-scan.sh` | SBOM generation and vulnerability scanning with retry logic |
+| `.github/scripts/sbom-scan.sh` | SBOM generation, trimming for attestation, and vulnerability scanning with retry logic |
 
 ### Release Gates
 

--- a/docs/security/signing-runbook.md
+++ b/docs/security/signing-runbook.md
@@ -175,6 +175,27 @@ Same as attestation failures — ensure `id-token: write` and `attestations: wri
 
 Attestation is automatically skipped for fork PRs (they don't have the required permissions). This is expected behavior.
 
+### SBOM Size Limit Exceeded
+
+#### Symptoms
+
+- `sbom-scan` job fails during "Attest SBOM" step
+- Error: `predicate file exceeds maximum allowed size: 16777216 bytes`
+
+#### Investigation
+
+1. Check the "Trim SBOM for attestation" step output for size details
+2. If the trimmed SBOM exceeds 16MB, the image has grown significantly in package count
+
+#### Resolution
+
+The `trim_sbom_for_attestation` function in `.github/scripts/sbom-scan.sh` strips SPDX relationships and minifies JSON before attestation. If the trimmed SBOM still exceeds 16MB:
+
+1. Check whether new catalogers were enabled in Syft (the file cataloger should remain disabled via `--select-catalogers '-file'`)
+2. Consider stripping additional optional SPDX fields (e.g., `annotations`, `externalDocumentRefs`)
+3. Review whether the base image can be slimmed down to reduce package count
+4. Track upstream progress on increasing the limit: [actions/attest-sbom#168](https://github.com/actions/attest-sbom/issues/168)
+
 ## Managing CVE Ignores
 
 ### Adding an Ignore


### PR DESCRIPTION
# Overview

Documents the SBOM trimming strategy introduced in #809 to handle the 16MB `actions/attest-sbom` predicate size limit. Updates the image signing overview and operational runbook so operators know about the constraint and how to troubleshoot it.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: docs-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Docs-only change, no testing required.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

- JIRA: https://shielded.atlassian.net/browse/SRE-1910
- Related: #809