### PR TITLE
chore: update compact-js to 2.4.2 in toolkit-js

### DIFF
--- a/util/toolkit-js/package.json
+++ b/util/toolkit-js/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "@effect/platform-node": "^0.98.3",
     "@effect/cli": "^0.71.0",
-    "@midnight-ntwrk/compact-js": "2.4.0-rc.10",
-    "@midnight-ntwrk/compact-js-command": "2.4.0-rc.10",
-    "@midnight-ntwrk/compact-js-node": "2.4.0-rc.10",
+    "@midnight-ntwrk/compact-js": "2.4.2",
+    "@midnight-ntwrk/compact-js-command": "2.4.2",
+    "@midnight-ntwrk/compact-js-node": "2.4.2",
     "effect": "^3.18.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Update `@midnight-ntwrk/compact-js`, `compact-js-command`, and `compact-js-node` from `2.4.0-rc.10` to `2.4.2` (latest stable on npmjs.org) in `util/toolkit-js/package.json`.

## Changes

- `util/toolkit-js/package.json`: compact-js dependencies updated to latest stable release

## Verification

- `cargo check` on midnight-node exceeds container RAM (15G limit) — OOM on `midnight-node-metadata` crate
- toolkit-js has pre-existing upstream TypeScript errors (`@effect/cli` TypeId mismatch) unrelated to this change
- Verified that compact-js 2.4.2 is the correct latest version on npmjs.org

## Context

Part of the midnight-devenviorment version alignment sweep. The compact-js packages migrated from GitHub Packages to npmjs.org, and `2.4.0-rc.10` is not available on the public registry.