### PR TITLE
ci: speed up generate metadata

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -740,8 +740,8 @@ prep-no-copy:
     ARG NATIVEARCH
     # If you need to alter the CI image, here is where you can build it locally rather than
     # referring to the pre-built image:
-    FROM --platform=$NATIVEPLATFORM +node-ci-image-single-platform
-    # FROM midnightntwrk/midnight-node-ci:1.93-$NATIVEARCH
+    # FROM --platform=$NATIVEPLATFORM +node-ci-image-single-platform
+    FROM midnightntwrk/midnight-node-ci:1.93-$NATIVEARCH
 
     RUN cargo --version
 


### PR DESCRIPTION
# Overview

Consolidates tool installations (subxt-cli, cargo-auditable, Docker-in-Docker, Node.js 22) into the CI image so they don't need to be installed on every CI run. This speeds up metadata generation and other Earthly targets by removing redundant install steps.

Key changes:
- Move `subxt-cli`, `cargo-auditable`, and Docker into `node-ci-image-single-platform`
- Install Node.js 22 in the CI image, replacing three separate per-target Node.js installations with a single one (also unifies the version — was 22.13.1 in some places, now 22.22.0 everywhere)
- Remove redundant `microdnf install` calls from `prep-no-copy`, `build-test-toolkit`, `toolkit-js-prep`, and `check-deps`
- Metadata targets (`get-metadata`, `rebuild-metadata`, `check-metadata`) now use `+prep-no-copy` instead of the separate `+subxt` base + DIND

## 🗹 TODO before merging

- [x] Get approval
- [x] Republish CI image using this definition
- [x] Switch this PR back to using published CI image

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: change only affects CI
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

CI will validate the Earthly targets still function correctly with the consolidated CI image.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

## Links

https://github.com/midnightntwrk/midnight-node/pull/825