### PR TITLE
feat: add attestation permissions (#829)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -788,6 +788,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/sbom-scan-image.yml
     with:
       image: ghcr.io/midnightntwrk/midnight-node:${{ needs.publish-amd64.outputs.IMAGE_TAG }}-amd64
@@ -803,6 +804,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/sbom-scan-image.yml
     with:
       image: ghcr.io/midnightntwrk/midnight-node:${{ needs.publish-amd64.outputs.IMAGE_TAG }}-arm64
@@ -818,6 +820,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/sbom-scan-image.yml
     with:
       image: ghcr.io/midnightntwrk/midnight-node-toolkit:${{ needs.publish-amd64.outputs.IMAGE_TAG }}-amd64
@@ -833,6 +836,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/sbom-scan-image.yml
     with:
       image: ghcr.io/midnightntwrk/midnight-node-toolkit:${{ needs.publish-amd64.outputs.IMAGE_TAG }}-arm64


### PR DESCRIPTION
Cutting a release had a permissions bug that's fixed on `release/node-0.22.0` branch.

`git cherry-pick 3ccfdc5bcaf9ffb6087c22e2d51dfd3df958a551`

( See https://github.com/midnightntwrk/midnight-node/pull/829 )