### PR TITLE
toolkit: allow DUST address registration without having DUST

### DIFF
--- a/changes/changed/toolkit-allow-dust-registration-without-dust.md
+++ b/changes/changed/toolkit-allow-dust-registration-without-dust.md
@@ -1,0 +1,9 @@
+#toolkit
+# Allow DUST address registration without owning DUST
+
+It uses possiblity that ledger gives us to register DUST address
+paying with virtual DUST that would have been accured if the NIGHT
+was registered for DUST production from UTXO creation.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/849
+JIRA: https://midnight-ntwrk.atlassian.net/browse/PM-21236

--- a/ledger/helpers/src/versions/common/transaction.rs
+++ b/ledger/helpers/src/versions/common/transaction.rs
@@ -47,6 +47,7 @@ pub trait FromContext<D: DB + Clone> {
 pub struct DustRegistrationBuilder {
 	pub signing_key: SigningKey,
 	pub dust_address: Option<DustPublicKey>,
+	pub allow_fee_payment: u128,
 }
 
 impl DustRegistrationBuilder {
@@ -67,7 +68,7 @@ impl DustRegistrationBuilder {
 		DustRegistration {
 			night_key,
 			dust_address: self.dust_address.map(|address| Sp::new(address)),
-			allow_fee_payment: 0,
+			allow_fee_payment: self.allow_fee_payment,
 			signature: Some(Sp::new(signature)),
 		}
 	}
@@ -185,13 +186,12 @@ impl<D: DB + Clone> StandardTrasactionInfo<D> {
 
 		let tx = Transaction::new(network_id.clone(), intents, guaranteed_offer, fallible_offer);
 
-		// Pay the outstanding DUST balance, if we have a wallet seed to pay it
-		if self.funding_seeds.is_empty() {
-			return self.prove_tx(tx).await;
-		};
-
-		let tx = self.pay_fees(tx, now, ttl).await?;
-		Ok(tx)
+		// Pay the outstanding DUST balance, if we have a wallet seed or dust registrations
+		if self.funding_seeds.is_empty() && self.dust_registrations.is_empty() {
+			self.prove_tx(tx).await
+		} else {
+			Ok(self.pay_fees(tx, now, ttl).await?)
+		}
 	}
 
 	async fn pay_fees(

--- a/util/toolkit/src/tx_generator/builder/builders/common/deregister_dust_address.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/deregister_dust_address.rs
@@ -143,6 +143,7 @@ impl BuildTxs for DeregisterDustAddressBuilder {
 			tx_info.add_dust_registration(DustRegistrationBuilder {
 				signing_key: wallet.unshielded.signing_key().clone(),
 				dust_address: None,
+				allow_fee_payment: 0,
 			});
 		});
 

--- a/util/toolkit/src/tx_generator/builder/builders/common/register_dust_address.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/register_dust_address.rs
@@ -3,8 +3,8 @@ use std::{collections::VecDeque, convert::Infallible, sync::Arc};
 use super::ledger_helpers_local::{
 	BuildIntent, BuildUtxoOutput, BuildUtxoSpend, DefaultDB, DustRegistrationBuilder, DustWallet,
 	FromContext, IntentInfo, LedgerContext, NIGHT, ProofProvider, Segment, StandardTrasactionInfo,
-	TransactionWithContext, UnshieldedOfferInfo, UtxoOutputInfo, UtxoSpendInfo, Wallet,
-	WalletAddress,
+	Timestamp, TransactionWithContext, UnshieldedOfferInfo, UtxoOutputInfo, UtxoSpendInfo, Wallet,
+	WalletAddress, WalletSeed,
 };
 use async_trait::async_trait;
 
@@ -20,7 +20,7 @@ pub struct RegisterDustAddressBuilder {
 	prover: Arc<dyn ProofProvider<DefaultDB>>,
 	seed: String,
 	rng_seed: Option<[u8; 32]>,
-	funding_seed: String,
+	funding_seed: Option<String>,
 	destination_dust: Option<WalletAddress>,
 }
 
@@ -44,6 +44,41 @@ impl RegisterDustAddressBuilder {
 	}
 }
 
+/// Compute the retroactive DUST available from generationless NIGHT UTXOs.
+///
+/// NIGHT UTXOs that have never had a registered DUST address accrue virtual DUST
+/// over time that can be used to pay for self DUST address registration.
+/// This function computes the total available DUST using the same formula as the ledger's `generationless_fee_availability`.
+fn generationless_fee_availability(
+	context: &LedgerContext<DefaultDB>,
+	seed: WalletSeed,
+	now: Timestamp,
+) -> u128 {
+	context.with_ledger_state(|ledger_state| {
+		let dust_params = &ledger_state.parameters.dust;
+		context.with_wallet_from_seed(seed, |wallet| {
+			wallet
+				.unshielded_utxos(ledger_state)
+				.iter()
+				.filter(|utxo| utxo.type_ == NIGHT)
+				.map(|utxo| {
+					let vfull = utxo.value.saturating_mul(dust_params.night_dust_ratio.into());
+					let rate = utxo.value.saturating_mul(dust_params.generation_decay_rate.into());
+					let ctime = ledger_state
+						.utxo
+						.utxos
+						.get(utxo)
+						.expect("'utxo' is from this ledger state")
+						.ctime;
+
+					let dt = u128::try_from((now - ctime).as_seconds()).unwrap_or(0);
+					u128::clamp(dt.saturating_mul(rate), 0, vfull)
+				})
+				.fold(0u128, |a, b| a.saturating_add(b))
+		})
+	})
+}
+
 #[async_trait]
 impl BuildTxs for RegisterDustAddressBuilder {
 	type Error = Infallible;
@@ -55,7 +90,8 @@ impl BuildTxs for RegisterDustAddressBuilder {
 		let spin = Spin::new("building register dust address transaction...");
 
 		let seed = Wallet::<DefaultDB>::wallet_seed_decode(&self.seed);
-		let funding_seed = Wallet::<DefaultDB>::wallet_seed_decode(&self.funding_seed);
+		let funding_seed =
+			self.funding_seed.as_ref().map(|s| Wallet::<DefaultDB>::wallet_seed_decode(s));
 
 		let context = self.context.clone();
 
@@ -121,6 +157,14 @@ impl BuildTxs for RegisterDustAddressBuilder {
 		let boxed_intent: Box<dyn BuildIntent<DefaultDB>> = Box::new(intent_info);
 		tx_info.add_intent(Segment::Fallible.into(), boxed_intent);
 
+		// Compute allow_fee_payment for self-funding when no funding seed is provided
+		let allow_fee_payment = if funding_seed.is_none() {
+			let now = context.latest_block_context().tblock;
+			generationless_fee_availability(&context, seed, now)
+		} else {
+			0
+		};
+
 		context.with_wallet_from_seed(seed, |wallet| {
 			let destination_dust = self.destination_dust.clone().map_or(
 				wallet.dust.public_key,
@@ -133,10 +177,11 @@ impl BuildTxs for RegisterDustAddressBuilder {
 			tx_info.add_dust_registration(DustRegistrationBuilder {
 				signing_key: wallet.unshielded.signing_key().clone(),
 				dust_address: Some(destination_dust),
+				allow_fee_payment,
 			});
 		});
 
-		tx_info.set_funding_seeds(vec![funding_seed]);
+		tx_info.set_funding_seeds(funding_seed.into_iter().collect());
 		tx_info.use_mock_proofs_for_fees(true);
 
 		let tx = tx_info.prove().await.expect("Balancing TX failed");

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -253,12 +253,9 @@ pub struct RegisterDustAddressArgs {
 	/// Seed for source wallet
 	#[arg(long)]
 	pub wallet_seed: String,
-	/// Seed for funding wallet
-	#[arg(
-		long,
-		default_value = FUNDING_SEED
-	)]
-	pub funding_seed: String,
+	/// Seed for funding wallet. If not provided, uses retroactive DUST from NIGHT UTXOs.
+	#[arg(long)]
+	pub funding_seed: Option<String>,
 	#[arg(
 		long,
 		value_parser = cli::wallet_address,
@@ -424,8 +421,11 @@ impl Builder {
 			},
 			Builder::RegisterDustAddress(args) => {
 				let seed = Wallet::<DefaultDB>::wallet_seed_decode(&args.wallet_seed);
-				let funding_seed = Wallet::<DefaultDB>::wallet_seed_decode(&args.funding_seed);
-				vec![seed, funding_seed]
+				if let Some(ref funding_seed) = args.funding_seed {
+					vec![seed, Wallet::<DefaultDB>::wallet_seed_decode(funding_seed)]
+				} else {
+					vec![seed]
+				}
 			},
 			Builder::DeregisterDustAddress(args) => {
 				let seed = Wallet::<DefaultDB>::wallet_seed_decode(&args.wallet_seed);


### PR DESCRIPTION
# Overview

Make it possible to register DUST address without owning DUST. Uses mechanism that ledger already supports as "generationless_fee_availability".

JIRA: https://midnight-ntwrk.atlassian.net/browse/PM-21236

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version 
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
