### PR TITLE
chore: changed storage_cache_size to ledger default

### DIFF
--- a/res/cfg/default.toml
+++ b/res/cfg/default.toml
@@ -43,7 +43,7 @@ polling_period = 5
 
 # Setting to a non-default value derived from the DEFAULT_CACHE_SIZE of the midnight-ledger crate:
 # https://github.com/midnightntwrk/midnight-ledger/blob/ledger-7.0.0-rc.2/storage/src/storage.rs#L54
-storage_cache_size = 1048576
+storage_cache_size = 10000
 
 # Set to default: 1024 * 1024 * 1024
 trie_cache_size = 1073741824


### PR DESCRIPTION
# Overview

This PR is changing cache_size to default ledger value 10000 elements. We see a better memory profile with this setting.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
https://github.com/midnightntwrk/midnight-node/pull/862