### PR TITLE
feat: parity-db flush on shutdown

### DIFF
--- a/changes/changed/ledger-storage-drop-on-shutdown.md
+++ b/changes/changed/ledger-storage-drop-on-shutdown.md
@@ -1,0 +1,7 @@
+#ledger #node
+# Drop ledger default storage on node shutdown
+
+Call `midnight_node_ledger::drop_all_default_storage()` after `run_node_until_exit` returns so DB-backed default storages are explicitly released during graceful shutdown.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/886
+Ticket: https://shielded.atlassian.net/browse/PM-22219

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -100,7 +100,12 @@ pub mod ledger_8 {
 pub use ledger_8 as latest;
 
 #[cfg(feature = "std")]
-fn drop_all_default_storage() {
+/// Drops all versioned default ledger storages.
+///
+/// Intended to be called from the embedding application shutdown path (for
+/// example after Tokio/node shutdown completes) to ensure DB-backed storage is
+/// released deterministically.
+pub fn drop_all_default_storage() {
 	ledger_7::storage::drop_default_storage_if_exists();
 	hard_fork_test::storage::drop_default_storage_if_exists();
 	ledger_8::storage::drop_default_storage_if_exists();

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -222,7 +222,7 @@ fn run_node(cfg: Cfg) -> sc_cli::Result<()> {
 		log::info!("CROSS_CHAIN pubkey: {}", &keypair.public())
 	}
 
-	runner.run_node_until_exit(|config| async move {
+	let run_result = runner.run_node_until_exit(|config| async move {
 		let epoch_config: MainchainEpochConfig = cfg.midnight_cfg.clone().into();
 		let midnight_cfg = cfg.midnight_cfg.clone();
 
@@ -261,7 +261,12 @@ fn run_node(cfg: Cfg) -> sc_cli::Result<()> {
 		)
 		.await
 		.map_err(sc_cli::Error::Service)
-	})
+	});
+
+	// Explicitly release global ledger storage on shutdown.
+	midnight_node_ledger::drop_all_default_storage();
+
+	run_result
 }
 
 /// Returns the CFG_PRESET from environment, defaulting to "dev"


### PR DESCRIPTION
# Overview

This PR adds drop of parity-db once runner goes out of scope, for instance when `SIGINT` or `SIGTERM` is generated:
https://paritytech.github.io/polkadot-sdk/master/sc_cli/struct.Runner.html#method.run_node_until_exit

Before changes:
```
^C2026-03-09 09:41:11.147 ERROR tokio-runtime-worker sc_service::task_manager: Essential task `txpool-background` failed. Shutting down service.
```

After changes:
```
^C2026-03-09 09:41:56.886 ERROR tokio-runtime-worker sc_service::task_manager: Essential task `txpool-background` failed. Shutting down service.
2026-03-09 09:41:56.898 DEBUG ThreadId(26) parity-db: Log worker shutdown
2026-03-09 09:41:56.898 DEBUG ThreadId(25) parity-db: Flush worker shutdown
2026-03-09 09:41:56.898 TRACE ThreadId(24) parity-db: No active reader
2026-03-09 09:41:56.899 DEBUG ThreadId(24) parity-db: End of log
2026-03-09 09:41:56.899 DEBUG ThreadId(24) parity-db: Commit worker shutdown
2026-03-09 09:41:56.898 DEBUG ThreadId(27) parity-db: Cleanup worker shutdown
2026-03-09 09:41:56.899 DEBUG                 main parity-db: Processing leftover commits
2026-03-09 09:41:56.899 TRACE                 main parity-db: No active reader
2026-03-09 09:41:56.899 DEBUG                 main parity-db: End of log
2026-03-09 09:41:56.899 DEBUG                 main parity-db: Flush: Flushing log to disk
2026-03-09 09:41:56.907 DEBUG                 main parity-db: Flush: Flushing log completed
2026-03-09 09:41:56.907 DEBUG                 main parity-db: Enacting log record 1
2026-03-09 09:41:56.907 DEBUG                 main parity-db: Created value table t00-5d
...
```

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
