### PR TITLE
fix(rpc): Return ContractNotPresent error for missing contracts (PM-19973)

### DIFF
--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,0 +1,8 @@
+# Work Package: Issue AD - ContractNotPresent Error
+
+This PR addresses the following:
+- Return `ContractNotPresent` error for missing contracts
+- Replace silent default-state behavior
+- Implement error propagation through RPC layer
+
+Implementation details will be added in the next commits.


### PR DESCRIPTION
## Summary

Return an explicit `ContractNotPresent` error from `do_get_contract_state` when queried for a non-existent contract, replacing the silent default-state return.


🎫 [PM-19973](https://shielded.atlassian.net/browse/PM-19973)  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/main/.engineering/artifacts/planning/2026-03-12-issue-ad-return-contract-not-present-error/README.md)

---

## Motivation

Currently, `do_get_contract_state` silently returns a default state when queried for a non-existent contract address. Callers cannot distinguish between "contract exists with empty state" and "contract does not exist," causing downstream logic to operate on incorrect assumptions. The RPC layer provides no error signal for this case.

This change addresses Least Authority audit finding Issue AD (rated low severity) and improves API clarity by providing explicit error feedback when contracts are missing.

---

## Changes

**Implementation (coming next):**
- Add `ContractNotPresent` error variant to the return type
- Update `do_get_contract_state` to return error when contract not found
- Propagate error through RPC layer with descriptive message
- Update callers to handle the new error case
- Add tests for missing-contract path

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: [reason]
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🗹 TODO before merging

- [ ] Ready for review

[PM-19973]: https://shielded.atlassian.net/browse/PM-19973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ