### PR TITLE
fix: include chain field in SubstrateCfg::argv()

### DIFF
--- a/changes/changed/fix-substrate-cfg-argv-chain.md
+++ b/changes/changed/fix-substrate-cfg-argv-chain.md
@@ -1,0 +1,13 @@
+#node
+# Include `chain` field in `SubstrateCfg::argv()`
+
+`SubstrateCfg::argv()` builds the argument vector used to parse node CLI arguments. It
+included `args` and `append_args` but silently omitted the `chain` field. This caused
+`chain` to be ignored when `argv()` was used as the sole source for `RunCmd` (as happened
+in 0.22.0-rc.8), leading nodes to start with an empty chain ID, fall back to building a
+chain spec from scratch, and panic when trying to JSON-parse a binary genesis block file.
+
+The fix adds `--chain <value>` to the front of the argv vector when `chain` is set, so
+the field is honoured regardless of which code path consumes `argv()`.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/TBD

--- a/node/src/cfg/substrate_cfg/mod.rs
+++ b/node/src/cfg/substrate_cfg/mod.rs
@@ -48,7 +48,11 @@ pub struct SubstrateCfg {
 
 impl SubstrateCfg {
 	pub fn argv(&self) -> Vec<String> {
-		[&["midnight-node".to_string()], &self.args[..], &self.append_args[..]].concat()
+		let chain_args: Vec<String> = match &self.chain {
+			Some(chain) => vec!["--chain".to_string(), chain.clone()],
+			None => vec![],
+		};
+		[&["midnight-node".to_string()], &chain_args[..], &self.args[..], &self.append_args[..]].concat()
 	}
 }
 


### PR DESCRIPTION
## Overview

`SubstrateCfg::argv()` builds the argument vector used to parse node CLI arguments. It included `args` and `append_args` but silently omitted the `chain` field.

This caused a regression in 0.22.0-rc.8 where `run_node()` was changed to derive `run_cmd` directly from `RunMidnight::try_parse_from(argv())` rather than going through `TryFrom<SubstrateCfg> for RunCmd`. Since `argv()` didn't include `--chain`, nodes started with an empty chain ID, called `load_spec("")`, and panicked trying to JSON-parse a binary genesis block file (`serde_json::from_slice` on a SCALE-encoded `.mn` file).

The fix adds `--chain <value>` at the front of the argv vector when `chain` is set, so the field is honoured regardless of which code path consumes `argv()`. This makes the config robust against future refactors.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Validated on live guardnet and ddosnet EC2 instances: when `APPEND_ARGS` includes `--chain res/guardnet/chain-spec.json`, nodes start and produce blocks correctly. The `argv()` fix makes this the default when `chain` is set in the toml config.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other:
- [ ] N/A

## Links