### PR TITLE
[PM-22086] Fix member association corruption when sorting authority lists

### DIFF
--- a/changes/changed/fix-member-association-sort-corruption.md
+++ b/changes/changed/fix-member-association-sort-corruption.md
@@ -3,5 +3,5 @@
 
 In `reset_members`, sort the paired `(AccountId, MainchainMember)` vectors by AccountId before calling `.unzip()` to preserve the positional correspondence. The previous approach sorted only the AccountId vector after unzipping, which corrupted the mapping between accounts and their mainchain identities in CouncilMainchainMembers storage, emitted events, and set_members_sorted calls.
 
-PR: 
+PR: https://github.com/midnightntwrk/midnight-node/pull/941
 Ticket: https://shielded.atlassian.net/browse/PM-22086


### PR DESCRIPTION
## Summary

Fix a data-integrity bug in `reset_members` where sorting account IDs after unzipping paired vectors breaks the positional correspondence between AccountIds and MainchainMember identities.


🎫 [Ticket](https://shielded.atlassian.net/browse/PM-22086)  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/main/.engineering/artifacts/planning/2026-03-13-fix-member-association-sort-corruption/README.md)

---

## Motivation

The federated authority observation pallet receives paired (AccountId, MainchainMember) data for Council and Technical Committee members. The current code calls `.unzip()` to split these pairs into separate vectors, then sorts only the AccountId vector. This breaks the positional mapping: after the sort, each index in the account list no longer corresponds to the correct index in the mainchain member list, causing incorrect identity attribution in on-chain storage, emitted events, and governance operations.

---

## Changes

**Implementation (coming next):**
- Sort the paired `Vec<(AccountId, MainchainMember)>` by AccountId *before* calling `.unzip()`
- Remove the now-unnecessary post-unzip sort calls
- Add tests to verify that paired associations are preserved after sorting

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: [reason]
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🔱 Fork Strategy

- [x] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [ ] N/A

---

## 🗹 TODO before merging

- [ ] Ready for review