### PR TITLE
ci: remove compactc from CI image, rely on toolkit-js fetch-compactc

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -649,40 +649,12 @@ node-ci-image-single-platform:
         mv "gh_2.62.0_linux_${GH_ARCH}/bin/gh" /usr/local/bin/ && \
         rm -rf gh_2.62.0_linux_${GH_ARCH}* gh.tar.gz
 
-    # Download compactc compiler from public midnightntwrk/compact releases
-    COPY COMPACTC_VERSION .
-    RUN set -e && \
-        ARCH=$(uname -m) && \
-        if [ "$ARCH" = "aarch64" ]; then COMPACTC_ARCH="aarch64"; else COMPACTC_ARCH="x86_64"; fi && \
-        VERSION=$(cat COMPACTC_VERSION) && \
-        ASSET="compactc_v${VERSION}_${COMPACTC_ARCH}-unknown-linux-musl.zip" && \
-        URL="https://github.com/midnightntwrk/compact/releases/download/compactc-v${VERSION}/${ASSET}" && \
-        mkdir -p /compactc-bin && \
-        echo "Downloading compactc: ${URL}" && \
-        curl -fsSL "${URL}" -o /tmp/compactc.zip && \
-        unzip /tmp/compactc.zip -d /compactc-bin && \
-        chmod +x /compactc-bin/compactc && \
-        rm /tmp/compactc.zip
-    ENV COMPACT_HOME=/compactc-bin
-
     ENV CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true
     ENV CARGO_TERM_COLOR=always
 
-    COPY ledger/test-data/simple-merkle-tree.compact simple-merkle-tree.compact
-    RUN $COMPACT_HOME/compactc simple-merkle-tree.compact simple-merkle-tree
-    # Keys should not have 0 size (but will have if we ran out of memory):
-    RUN [ -s /simple-merkle-tree/keys/check.prover ]
-    RUN [ -s /simple-merkle-tree/keys/check.verifier ]
-    RUN [ -s /simple-merkle-tree/keys/store.prover ]
-    RUN [ -s /simple-merkle-tree/keys/store.verifier ]
-
-    SAVE ARTIFACT /compactc-bin
-    SAVE ARTIFACT /simple-merkle-tree AS LOCAL target/contracts/simple-merkle-tree
-
-    # SAVE IMAGE under the rust version and compactc version.
+    # SAVE IMAGE under the rust version.
     # We rebuild the image weekly to apply security patches.
-    ARG COMPACTC_VER=$(cat COMPACTC_VERSION)
-    ENV IMAGE_TAG="${RUST_VERSION}-${COMPACTC_VER}"
+    ENV IMAGE_TAG="${RUST_VERSION}"
     LABEL org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-node
     LABEL org.opencontainers.image.title=node-ci
     LABEL org.opencontainers.image.description="Midnight Node CI Image"
@@ -693,21 +665,18 @@ node-ci-image-single-platform:
 prep-no-copy:
     # Read versions from files (multi-FROM so we don't depend on env vars propagating)
     FROM alpine:3.20
-    COPY rust-toolchain.toml COMPACTC_VERSION .
+    COPY rust-toolchain.toml .
     ARG NATIVEARCH
     ARG RUST_VERSION=$(grep '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
-    ARG COMPACTC_VER=$(cat COMPACTC_VERSION)
     # If you need to alter the CI image, here is where you can build it locally rather than
     # referring to the pre-built image:
     # FROM --platform=$NATIVEPLATFORM +node-ci-image-single-platform
-    FROM midnightntwrk/midnight-node-ci:${RUST_VERSION}-${COMPACTC_VER}-$NATIVEARCH
+    FROM midnightntwrk/midnight-node-ci:${RUST_VERSION}-$NATIVEARCH
 
     # ca-certificates and curl-minimal already present in the CI base image
 
     RUN cargo --version
     RUN cargo binstall --no-confirm cargo-auditable
-
-    SAVE ARTIFACT /compactc-bin
 
 prep:
     FROM +prep-no-copy
@@ -750,7 +719,7 @@ toolkit-js-prep:
     WORKDIR /toolkit-js
     RUN npm ci
     RUN npm run build
-    # Compile compact contracts (fetch-compactc skipped via COMPACT_HOME from CI image)
+    # Compile compact contracts (fetch-compactc downloads compactc via COMPACTC_VERSION)
     RUN npm run compact
     # Verify keys were generated
     RUN ls -la ./test/contract/managed/counter/keys/ && [ -s ./test/contract/managed/counter/keys/increment.verifier ]
@@ -1233,10 +1202,6 @@ toolkit-image:
         rm node.tar.xz && \
         node --version && npm --version && \
         npm install -g npm@11.11.0 && npm --version
-
-    # Copy compactc from pre-built CI image (via prep-no-copy)
-    COPY +prep-no-copy/compactc-bin /compactc-bin
-    ENV COMPACT_HOME=/compactc-bin
 
     # Add toolkit-js (only when INCLUDE_TOOLKIT_JS=true)
     IF [ "$INCLUDE_TOOLKIT_JS" = "true" ]


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

The CI image no longer needs to download the compactc binary or
pre-compile simple-merkle-tree.compact. The compiled output was saved
to target/contracts/simple-merkle-tree, which nothing consumes —
toolkit-image uses static/contracts/simple-merkle-tree, populated by
rebuild-genesis-state via `npx run-compactc`.

Instead, toolkit-js-prep lets fetch-compactc (from
@midnight-ntwrk/midnight-js-compact) download the binary automatically
into node_modules when `npm run compact` runs. COMPACTC_VERSION is
already set in that target, and without COMPACT_HOME being set,
fetch-compactc will perform the download. The managed directory is
captured by `SAVE ARTIFACT /toolkit-js` and flows into toolkit-image,
where run-compactc finds it at runtime.

The CI image tag now only includes the Rust toolchain version, since
the compactc version no longer affects the image contents.

Supporting https://github.com/midnightntwrk/midnight-node/pull/946

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
