### PR TITLE
ci(feat): remove url requirement

### DIFF
--- a/.github/workflows/changes_check.yml
+++ b/.github/workflows/changes_check.yml
@@ -85,19 +85,3 @@ jobs:
           FILENAME=$(grep -R 'changes' -e "pull/$PR_NUMBER" | head -1 | cut -d':' -f1)
           echo "Checking if $FILENAME contains a link to a JIRA ticket - fail if it does not"
           if [ ! -z "$FILENAME" ]; then grep -q "atlassian\.net" "$FILENAME"; fi
-
-      - name: Check PR description for a link
-        if: >
-          github.event_name != 'merge_group' &&
-          contains(fromJSON(steps.pr.outputs.labels), 'skip-changes-check-all')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const prBody = context.payload.pull_request.body;
-            const urlRegex = /(https?:\/\/[^\s]+|#[0-9]+)/g;
-
-            if (!prBody || !urlRegex.test(prBody)) {
-              core.setFailed("Pull request description must contain a 'why' link (to a jira or the PR that caused this PR).");
-            } else {
-              console.log("PR description contains a link.");
-            }


### PR DESCRIPTION
I think these days this is getting in the way more than it's helping contextualise things.

https://github.com/midnightntwrk/midnight-node/pull/1052