### PR TITLE
fix: ensure consistent RuntimeExecutor host functions across build features (PM-19965)

### DIFF
--- a/changes/changed/audit-runtime-benchmark-host-functions.md
+++ b/changes/changed/audit-runtime-benchmark-host-functions.md
@@ -1,0 +1,9 @@
+#node
+# Always register benchmark host functions in RuntimeExecutor
+
+Unify the HostFunctions type alias to always include frame_benchmarking host functions,
+regardless of the runtime-benchmarks Cargo feature. This prevents consensus divergence
+between nodes compiled with different feature sets.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1070
+Ticket: https://shielded.atlassian.net/browse/PM-19965

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -72,7 +72,7 @@ sc-basic-authorship.workspace = true
 substrate-frame-rpc-system.workspace = true
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = {workspace = true, optional = true}
+frame-benchmarking = {workspace = true}
 frame-benchmarking-cli = {workspace = true, optional = true, default-features = true }
 
 # Local Dependencies
@@ -160,7 +160,7 @@ substrate-build-script-utils.workspace = true
 [features]
 default = []
 
-# Dependencies that are only required if runtime benchmarking should be build.
+# Enable runtime benchmarking support in the runtime, frame-benchmarking, and CLI.
 runtime-benchmarks = [
     "midnight-node-runtime/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -211,18 +211,12 @@ pub fn construct_genesis_block<Block: BlockT>(
 	)
 }
 
-/// Only enable the benchmarking host functions when we actually want to benchmark.
-#[cfg(feature = "runtime-benchmarks")]
+/// Host functions registered with the Wasm executor. Benchmark host functions are always
+/// included to ensure all nodes expose an identical set regardless of build features,
+/// preventing consensus divergence (see Least Authority audit Issue AH).
 pub type HostFunctions = (
 	sp_io::SubstrateHostFunctions,
 	frame_benchmarking::benchmarking::HostFunctions,
-	midnight_node_ledger::host_api::ledger_7::ledger_bridge::HostFunctions,
-	midnight_node_ledger::host_api::ledger_8::ledger_8_bridge::HostFunctions,
-);
-/// Otherwise we only use the default Substrate host functions.
-#[cfg(not(feature = "runtime-benchmarks"))]
-pub type HostFunctions = (
-	sp_io::SubstrateHostFunctions,
 	midnight_node_ledger::host_api::ledger_7::ledger_bridge::HostFunctions,
 	midnight_node_ledger::host_api::ledger_8::ledger_8_bridge::HostFunctions,
 );
@@ -914,5 +908,18 @@ mod tests {
 		let values: Vec<serde_json::Value> = vec![];
 		let result = parse_genesis_extrinsic_values(&values).unwrap();
 		assert!(result.is_empty());
+	}
+
+	#[test]
+	fn host_functions_always_include_benchmarking() {
+		// Compile-time type assertion: HostFunctions must be the 4-tuple including
+		// frame_benchmarking. If someone re-introduces a #[cfg] gate that excludes
+		// benchmark host functions, this identity closure fails to compile.
+		let _: fn(HostFunctions) -> (
+			sp_io::SubstrateHostFunctions,
+			frame_benchmarking::benchmarking::HostFunctions,
+			midnight_node_ledger::host_api::ledger_7::ledger_bridge::HostFunctions,
+			midnight_node_ledger::host_api::ledger_8::ledger_8_bridge::HostFunctions,
+		) = |x| x;
 	}
 }


### PR DESCRIPTION
## Summary

Ensure the `RuntimeExecutor` exposes a consistent set of Wasm host functions regardless of build features, preventing consensus divergence between differently-compiled nodes.


🎫 [PM-19965](https://shielded.atlassian.net/browse/PM-19965)  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/main/.engineering/artifacts/planning/2026-03-24-runtime-benchmark-host-functions/README.md)

---

## Motivation

The `RuntimeExecutor` conditionally included `frame_benchmarking::benchmarking::HostFunctions` based on the `runtime-benchmarks` Cargo feature. A node compiled with benchmarking features would expose additional host functions, meaning transactions relying on these functions would succeed on benchmark-enabled nodes but fail on standard nodes. This creates a consensus-critical divergence risk if benchmark-enabled nodes participate in production.

This finding was identified by Least Authority in their October 2025 Node audit (Issue AH, Low severity). The fix ensures all consensus-participating nodes register identical host function sets.

---

## Changes

- **node/Cargo.toml** — Made `frame-benchmarking` a non-optional dependency (removed `optional = true`)
- **node/src/service.rs** — Unified `HostFunctions` type alias: replaced two conditional definitions (`#[cfg(feature = "runtime-benchmarks")]` / `#[cfg(not(...))]`) with a single unconditional 4-tuple that always includes `frame_benchmarking::benchmarking::HostFunctions`
- **node/src/service.rs** — Added compile-time regression test `host_functions_always_include_benchmarking` that verifies the type composition
- **changes/changed/** — Added change file documenting the fix

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: [reason]
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other
- [ ] N/A

---

## 🗹 TODO before merging

- [x] Ready for review

[PM-19965]: https://shielded.atlassian.net/browse/PM-19965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ