### PR TITLE
fix: tell renovate not to pin at Cargo.toml level as we have a lock file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,10 @@
       "rangeStrategy": "replace"
     }
   ],
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "dockerfile": {
     "managerFilePatterns": [
       "//Earthfile//"


### PR DESCRIPTION
The Cargo.toml changes in https://github.com/midnightntwrk/midnight-node/pull/1088 aren't something we want. This change should amend renovate's behaviour.

Also don't try and update a dependency until it's at least 3 days old to give others a chance to try it out.

https://github.com/midnightntwrk/midnight-node/pull/1097