### PR TITLE
fix: verify and close PM-22024 default wallet seed audit finding

### DIFF
--- a/changes/changed/audit-verify-walletseed-default-removal.md
+++ b/changes/changed/audit-verify-walletseed-default-removal.md
@@ -5,5 +5,5 @@ Verify the audit finding (A2 Issue D) remediation from PR #804 that removed
 the all-zero Default implementation for WalletSeed. Confirms no residual
 zero-seed usage in key derivation paths.
 
-PR: TBD
+PR: https://github.com/midnightntwrk/midnight-node/pull/1109
 JIRA: https://shielded.atlassian.net/browse/PM-22024

--- a/changes/changed/audit-verify-walletseed-default-removal.md
+++ b/changes/changed/audit-verify-walletseed-default-removal.md
@@ -6,4 +6,5 @@ the all-zero Default implementation for WalletSeed. Confirms no residual
 zero-seed usage in key derivation paths.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1109
+Issue: https://github.com/midnight-security/midnight-security/issues/112
 JIRA: https://shielded.atlassian.net/browse/PM-22024

--- a/changes/changed/audit-verify-walletseed-default-removal.md
+++ b/changes/changed/audit-verify-walletseed-default-removal.md
@@ -1,0 +1,9 @@
+#ledger
+# Verify removal of WalletSeed Default implementation
+
+Verify the audit finding (A2 Issue D) remediation from PR #804 that removed
+the all-zero Default implementation for WalletSeed. Confirms no residual
+zero-seed usage in key derivation paths.
+
+PR: TBD
+JIRA: https://shielded.atlassian.net/browse/PM-22024

--- a/ledger/helpers/src/versions/common/types.rs
+++ b/ledger/helpers/src/versions/common/types.rs
@@ -29,6 +29,20 @@ use std::{
 };
 use subxt_signer::{SecretUri, SecretUriError, sr25519};
 
+/// Wallet seed for HD key derivation (BIP-32/44). Holds 16, 32, or 64 bytes
+/// of seed material from which all wallet keys are derived.
+///
+/// # Security: no `Default` implementation
+///
+/// `WalletSeed` intentionally does not implement [`Default`]. A previous
+/// implementation returned `Medium([0; 32])` — an all-zero seed that would
+/// produce predictable wallet keys. Removed per Least Authority audit
+/// finding A2-D (Feb 2026, PR #804).
+///
+/// ```compile_fail,E0599
+/// // WalletSeed must not implement Default — this must fail to compile.
+/// let _ = midnight_node_ledger_helpers::WalletSeed::default();
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Storable, Serializable)]
 #[storable(base)]
 pub enum WalletSeed {


### PR DESCRIPTION
## Summary

Verify and formally close the Least Authority audit finding (A2 Issue D) regarding the `Default` implementation on `WalletSeed` that produced an all-zero seed. The core fix was merged in PR #804; this PR adds a compile-time regression test preventing re-introduction.


🎫 [Ticket](https://shielded.atlassian.net/browse/PM-22024)  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/main/.engineering/artifacts/planning/2026-03-27-default-wallet-seed/README.md)  🧪 [Test Plan](https://github.com/shieldedtech/midnight-agent-eng/blob/main/.engineering/artifacts/planning/2026-03-27-default-wallet-seed/06-test-plan.md)

---

## Motivation

The Least Authority Node DIFF Audit (Feb 2026) identified that `WalletSeed::default()` returned `Self::Medium([0; 32])` — a deterministic all-zero seed that could lead to predictable wallet key material and recoverable secret keys. This was classified as High severity.

PR #804 removed the `Default` impl and replaced the single internal placeholder usage with an explicit initializer. Code analysis confirms the fix is complete: the placeholder `WalletSeed::Short([0; 16])` in `ClaimMintInfo::from_context()` is always overwritten by `set_rewards()` before `build()` uses it for key derivation. The Least Authority auditor (Mirco) confirmed the fix.

---

## Changes

- **Regression test** — `compile_fail` doctest on `WalletSeed` verifying `.default()` does not compile (E0599), preventing re-introduction of the vulnerability. Runs for both ledger_7 and ledger_8 module variants.
- **Change file** — Changelog entry documenting the audit verification.

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: included
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

---

## 🗹 TODO before merging

- [x] Regression test passes (2/2 compile_fail doctests + 16 unit tests)
- [x] Verification evidence posted to PM-22024
- [x] Auditor acknowledged fix
- [x] Ready for review