### PR TITLE
ci: add remote cache and 16-core runner to test workflow

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Log in to GHCR (for remote cache)
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
# Overview

The `+test` CI workflow currently takes ~45 minutes, with 91% of that time spent on cold cargo compilation. Two root causes:

1. **No persistent cache** — `use-cache: false` was set on the Earthly action, and the Earthly `CACHE` directives only persist within a single BuildKit session (useless on ephemeral runners).
2. **2-core runner** — the test workflow used `ubuntu-latest` while the build workflow already uses 16-core runners.

This PR:
- Upgrades the runner to `ubuntu-latest-16-core-x64`
- Enables Earthly remote cache via GHCR (`ghcr.io/midnightntwrk/midnight-node:cache-test`)
- Cache is written on `main` builds (`--push`) and read-only on PRs
- Adds `packages: write` permission and GHCR login for cache push/pull
- Removes the explicit `use-cache: false`

First run will still be cold (~10-15m on 16 cores). Once main populates the cache, subsequent runs should drop to ~5-10 minutes.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: change only affects CI
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

CI will validate on this PR itself. First run = cold cache (expect ~10-15m on 16 cores). Second push to the same PR or any subsequent main build will demonstrate cache hit.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] N/A

## Links

Related job showing the 45m build: https://github.com/midnightntwrk/midnight-node/actions/runs/23654470222/job/68907838421?pr=1106