### PR TITLE
chore(renovate): migrate to org-wide hardened preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,43 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    "security:openssf-scorecard",
-    ":semanticCommits"
+    "github>midnightntwrk/renovate-config",
+    "github>midnightntwrk/renovate-config:earthfile"
   ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "dependencyDashboard": true,
-  "enabled": true,
-  "labels": [
-    "renovate"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update _version ARGs and ENVs in Earthfile",
-      "managerFilePatterns": [
-        "//^Earthfile$//"
-      ],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+?)(?:\\s+depName=(?<depName>.+?))?\\s+packageName=(?<packageName>.+?)(?:\\s+versioning=(?<versioning>[a-z-]+?))?\\s+(?:ENV|ARG)\\s+.+?(_VERSION|_VER|_version)=(?<currentValue>.+?)\\s"
-      ]
-    }
-  ],
-  "packageRules": [
-    {
-      "matchManagers": ["cargo"],
-      "rangeStrategy": "replace"
-    }
-  ],
-  "minimumReleaseAge": "3 days",
-  "vulnerabilityAlerts": {
-    "minimumReleaseAge": "0 days"
-  },
-  "dockerfile": {
-    "managerFilePatterns": [
-      "//Earthfile//"
-    ]
-  }
+  "git-submodules": { "enabled": true }
 }

--- a/changes/changed/renovate-migrate-to-org-preset.md
+++ b/changes/changed/renovate-migrate-to-org-preset.md
@@ -1,0 +1,10 @@
+#sre
+# Migrate Renovate to org-wide hardened preset
+
+Replace interim hardening config with the shared `github>midnightntwrk/renovate-config`
+preset. Delegates supply chain hardening (7-day cooldown, strict internal checks
+filter, OSV vulnerability scanning, major version gating) to the org preset.
+Retains Earthfile custom manager and git-submodules support.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1118
+JIRA: https://shielded.atlassian.net/browse/SRE-2078


### PR DESCRIPTION
## Summary

- Replaces interim hardening config with the org-wide preset
- Delegates all supply chain hardening to `github>midnightntwrk/renovate-config`
- Retains `earthfile` preset for Earthfile version tracking
- Retains `git-submodules: enabled`

The org preset provides:
- 7-day minimum release age for supply chain hardening
- `internalChecksFilter: strict` (enforces the cooldown)
- OSV vulnerability scanning (security PRs bypass cooldown)
- Major updates require Dependency Dashboard approval
- GitHub Actions pinned to SHA digests
- Cargo `rangeStrategy: replace` (preserves semver ranges, lock file handles pinning)
- Weekly schedule (Monday 7am)

Part of SRE-2078.

https://github.com/midnightntwrk/midnight-node/pull/1118