### PR TITLE
Fix: Remove srtool-sha256sum

### DIFF
--- a/.github/workflows/srtool-build.yml
+++ b/.github/workflows/srtool-build.yml
@@ -68,7 +68,6 @@ jobs:
             sha256sum midnight_node_runtime.wasm
             sha256sum midnight_node_runtime.compact.wasm
             sha256sum midnight_node_runtime.compact.compressed.wasm
-            sha256sum srtool-digest.json
           } >> SHA256SUMS-srtool
 
           echo "Generated checksums:"


### PR DESCRIPTION
# Overview

`srtool-digest.json` is not deterministic (it includes information such as the execution timestamp). Therefore its sha256sum hash shouldn't be part of the final `SHA256SUMS` file asset attached to the release. 

https://github.com/midnightntwrk/midnight-node/pull/1132

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
