### PR TITLE
Cherry-pick Prometheus per-query metrics to release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8272,6 +8272,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sqlx",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/changes/added/dbsync-query-metrics.md
+++ b/changes/added/dbsync-query-metrics.md
@@ -1,0 +1,11 @@
+#node
+# Add per-SQL-query Prometheus timing for midnight data source queries
+
+Midnight-specific data sources (cNight observation, federated authority,
+candidates) now record individual Prometheus timing histograms for each
+SQL query executed against DBSync. 13 sub-query timers provide per-query
+latency visibility at `:9615/metrics` under the
+`midnight_data_source_query_time_elapsed` metric with `query_name` labels.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/904
+JIRA: https://shielded.atlassian.net/browse/PM-22100

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -13,6 +13,7 @@
 
 use authority_selection_inherents::AuthoritySelectionDataSource;
 use midnight_primitives_mainchain_follower::CandidatesDataSourceImpl;
+use midnight_primitives_mainchain_follower::MidnightDataSourceMetrics;
 use pallet_sidechain_rpc::SidechainRpcDataSource;
 use partner_chains_db_sync_data_sources::{
 	BlockDataSourceImpl, CachedTokenBridgeDataSourceImpl, DbSyncBlockDataSourceConfig,
@@ -61,7 +62,8 @@ pub struct DbPoolCfg {
 
 pub(crate) async fn create_cached_main_chain_follower_data_sources(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	mc_metrics_opt: Option<McFollowerMetrics>,
+	midnight_metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> std::result::Result<DataSources, ServiceError> {
 	if cfg.use_main_chain_follower_mock {
 		let mock = create_mock_data_sources(cfg.clone()).await.map_err(|err| {
@@ -73,11 +75,13 @@ pub(crate) async fn create_cached_main_chain_follower_data_sources(
 
 		Ok(mock)
 	} else {
-		create_cached_data_sources(cfg, metrics_opt).await.map_err(|err| {
-			ServiceError::Application(
-				format!("Failed to create db-sync main chain follower: {err}").into(),
-			)
-		})
+		create_cached_data_sources(cfg, mc_metrics_opt, midnight_metrics_opt)
+			.await
+			.map_err(|err| {
+				ServiceError::Application(
+					format!("Failed to create db-sync main chain follower: {err}").into(),
+				)
+			})
 	}
 }
 
@@ -160,7 +164,8 @@ const ICS_POOL_CFG: DbPoolCfg =
 
 pub async fn create_cached_data_sources(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	mc_metrics_opt: Option<McFollowerMetrics>,
+	midnight_metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<DataSources, Box<dyn Error + Send + Sync + 'static>> {
 	let postgres_uri = &cfg
 		.db_sync_postgres_connection_string
@@ -195,7 +200,7 @@ pub async fn create_cached_data_sources(
 	create_index_if_not_exists(&candidates_pool).await;
 
 	let candidates_data_source =
-		CandidatesDataSourceImpl::new(candidates_pool, metrics_opt.clone()).await?;
+		CandidatesDataSourceImpl::new(candidates_pool, midnight_metrics_opt.clone()).await?;
 	let candidates_data_source_cached =
 		candidates_data_source.cached(CANDIDATES_FOR_EPOCH_CACHE_SIZE)?;
 
@@ -206,8 +211,10 @@ pub async fn create_cached_data_sources(
 		db_sync_block_data_source_config.clone(),
 		&mc,
 	));
-	let sidechain_rpc =
-		SidechainRpcDataSourceImpl::new(sidechain_block_data_source.clone(), metrics_opt.clone());
+	let sidechain_rpc = SidechainRpcDataSourceImpl::new(
+		sidechain_block_data_source.clone(),
+		mc_metrics_opt.clone(),
+	);
 
 	let mc_hash_pool = get_connection(postgres_uri, MC_HASH_POOL_CFG, cfg.allow_non_ssl).await?;
 	let mc_hash_block_data_source = BlockDataSourceImpl::from_config(
@@ -216,13 +223,13 @@ pub async fn create_cached_data_sources(
 		&mc,
 	);
 	let mc_hash =
-		McHashDataSourceImpl::new(Arc::new(mc_hash_block_data_source), metrics_opt.clone());
+		McHashDataSourceImpl::new(Arc::new(mc_hash_block_data_source), mc_metrics_opt.clone());
 
 	let cnight_observation_pool =
 		get_connection(postgres_uri, CNIGHT_OBSERVATION_POOL_CFG, cfg.allow_non_ssl).await?;
 	let cnight_observation = MidnightCNightObservationDataSourceImpl::new(
 		cnight_observation_pool,
-		metrics_opt.clone(),
+		midnight_metrics_opt.clone(),
 		1000,
 	);
 
@@ -231,7 +238,7 @@ pub async fn create_cached_data_sources(
 			.await?;
 	let federated_authority_observation = FederatedAuthorityObservationDataSourceImpl::new(
 		federated_authority_observation_pool,
-		metrics_opt.clone(),
+		midnight_metrics_opt,
 		1000,
 	);
 
@@ -239,7 +246,7 @@ pub async fn create_cached_data_sources(
 
 	let bridge = CachedTokenBridgeDataSourceImpl::new(
 		bridge_pool,
-		metrics_opt,
+		mc_metrics_opt,
 		sidechain_block_data_source,
 		BRIDGE_TRANSFER_CACHE_LOOKAHEAD,
 	);
@@ -257,7 +264,7 @@ pub async fn create_cached_data_sources(
 // Helper for users who only need native token observation data source
 pub async fn create_cnight_observation_data_source(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<Arc<dyn MidnightCNightObservationDataSource>, Box<dyn Error + Send + Sync + 'static>> {
 	let pool = get_connection(
 		&cfg.db_sync_postgres_connection_string
@@ -269,12 +276,12 @@ pub async fn create_cnight_observation_data_source(
 
 	midnight_primitives_mainchain_follower::db::create_cnight_observation_indexes(&pool).await?;
 
-	Ok(Arc::new(MidnightCNightObservationDataSourceImpl::new(pool, metrics_opt.clone(), 1000)))
+	Ok(Arc::new(MidnightCNightObservationDataSourceImpl::new(pool, metrics_opt, 1000)))
 }
 
 pub async fn create_federated_authority_observation_data_source(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<Arc<dyn FederatedAuthorityObservationDataSource>, Box<dyn Error + Send + Sync + 'static>>
 {
 	let pool = get_connection(
@@ -285,12 +292,12 @@ pub async fn create_federated_authority_observation_data_source(
 	)
 	.await?;
 
-	Ok(Arc::new(FederatedAuthorityObservationDataSourceImpl::new(pool, metrics_opt.clone(), 1000)))
+	Ok(Arc::new(FederatedAuthorityObservationDataSourceImpl::new(pool, metrics_opt, 1000)))
 }
 
 pub async fn create_authority_selection_data_source(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<
 	Arc<dyn AuthoritySelectionDataSource + Send + Sync>,
 	Box<dyn Error + Send + Sync + 'static>,
@@ -302,7 +309,7 @@ pub async fn create_authority_selection_data_source(
 
 pub async fn create_authority_selection_data_source_with_pool(
 	cfg: MidnightCfg,
-	metrics_opt: Option<McFollowerMetrics>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<
 	(Arc<dyn AuthoritySelectionDataSource + Send + Sync>, sqlx::PgPool),
 	Box<dyn Error + Send + Sync + 'static>,
@@ -315,8 +322,7 @@ pub async fn create_authority_selection_data_source_with_pool(
 	)
 	.await?;
 
-	let candidates_data_source =
-		CandidatesDataSourceImpl::new(pool.clone(), metrics_opt.clone()).await?;
+	let candidates_data_source = CandidatesDataSourceImpl::new(pool.clone(), metrics_opt).await?;
 	let candidates_data_source_cached =
 		candidates_data_source.cached(CANDIDATES_FOR_EPOCH_CACHE_SIZE)?;
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -26,6 +26,7 @@ use futures::FutureExt;
 use midnight_node_runtime::storage::child::StateVersion;
 use midnight_node_runtime::{self, RuntimeApi, opaque::Block};
 use midnight_primitives_ledger::{LedgerMetrics, LedgerStorage};
+use midnight_primitives_mainchain_follower::MidnightDataSourceMetrics;
 use parity_scale_codec::{Decode, Encode};
 use partner_chains_db_sync_data_sources::register_metrics_warn_errors;
 use sc_client_api::{Backend, BlockImportOperation, ExecutorProvider};
@@ -267,10 +268,13 @@ pub fn new_partial(
 	tx_filter_config: TxFilterConfig,
 ) -> Result<MidnightService, ServiceError> {
 	let mc_follower_metrics = register_metrics_warn_errors(config.prometheus_registry());
+	let midnight_metrics =
+		MidnightDataSourceMetrics::register_warn_errors(config.prometheus_registry());
 	let data_sources = tokio::task::block_in_place(|| {
 		config.tokio_handle.block_on(create_cached_main_chain_follower_data_sources(
 			midnight_cfg.clone(),
 			mc_follower_metrics.clone(),
+			midnight_metrics.clone(),
 		))
 	})?;
 

--- a/primitives/mainchain-follower/Cargo.toml
+++ b/primitives/mainchain-follower/Cargo.toml
@@ -25,6 +25,7 @@ derive-new.workspace = true
 partner-chains-db-sync-data-sources = { default-features = false, workspace = true, optional = true }
 scale-info.workspace = true
 log.workspace = true
+prometheus-endpoint = { workspace = true, optional = true }
 rand = { version = "0.9.1", default-features = false }
 itertools = { workspace = true, optional = true }
 authority-selection-inherents = { workspace = true, features = ["std"], optional = true }
@@ -58,6 +59,7 @@ std = [
     "db-sync-sqlx",
     "log/std",
     "partner-chains-db-sync-data-sources",
+    "prometheus-endpoint",
     "rand/std",
     "rand/thread_rng",
     "itertools",

--- a/primitives/mainchain-follower/src/data_source/candidates_data_source/mod.rs
+++ b/primitives/mainchain-follower/src/data_source/candidates_data_source/mod.rs
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 //! Db-Sync data source used by Partner Chain committee selection
+use crate::data_source::metrics::{MidnightDataSourceMetrics, start_sub_query_timer};
 use authority_selection_inherents::*;
 use db_sync_sqlx::{Address, Asset, BlockNumber, EpochNumber};
 use itertools::Itertools;
 use log::error;
-use partner_chains_db_sync_data_sources::McFollowerMetrics;
 use partner_chains_plutus_data::{
 	permissioned_candidates::PermissionedCandidateDatums,
 	registered_candidates::RegisterValidatorDatum,
@@ -55,7 +55,7 @@ pub struct CandidatesDataSourceImpl {
 	/// Postgres connection pool
 	pool: PgPool,
 	/// Prometheus metrics client
-	metrics_opt: Option<McFollowerMetrics>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
 	/// Configuration used by Db-Sync
 	db_sync_config: db_model::DbSyncConfigurationProvider,
 }
@@ -71,8 +71,10 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 		let epoch = EpochNumber::from(self.get_epoch_of_data_storage(epoch)?);
 		let permissioned_candidate_asset = Asset::new(permissioned_candidate_policy);
 
+		let _sq_timer = start_sub_query_timer(&self.metrics_opt, "candidates_get_token_utxo_for_epoch");
 		let candidates_output_opt =
 			db_model::get_token_utxo_for_epoch(&self.pool, &permissioned_candidate_asset, epoch).await?;
+		drop(_sq_timer);
 
 		// DParameter is now read from pallet_system_parameters storage, not from mainchain.
 		// This hardcoded value is unused - the actual d_parameter comes from the runtime.
@@ -98,7 +100,10 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 	)-> Result<Vec<CandidateRegistrations>, Box<dyn std::error::Error + Send + Sync>> {
 		let epoch = EpochNumber::from(self.get_epoch_of_data_storage(epoch)?);
 		let candidates = self.get_registered_candidates(epoch, committee_candidate_address).await?;
-		let stake_map = Self::make_stake_map(db_model::get_stake_distribution(&self.pool, epoch).await?);
+		let _stake_timer = start_sub_query_timer(&self.metrics_opt, "candidates_get_stake_distribution");
+		let stake_entries = db_model::get_stake_distribution(&self.pool, epoch).await?;
+		drop(_stake_timer);
+		let stake_map = Self::make_stake_map(stake_entries);
 		Ok(Self::group_candidates_by_mc_pub_key(candidates).into_iter().map(|(mainchain_pub_key, candidate_registrations)| {
 			CandidateRegistrations {
 				stake_pool_public_key: mainchain_pub_key.clone(),
@@ -110,7 +115,9 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 
 	async fn get_epoch_nonce(&self, epoch: McEpochNumber) -> Result<Option<EpochNonce>, Box<dyn std::error::Error + Send + Sync>> {
 		let epoch = self.get_epoch_of_data_storage(epoch)?;
+		let _sq_timer = start_sub_query_timer(&self.metrics_opt, "candidates_get_epoch_nonce");
 		let nonce = db_model::get_epoch_nonce(&self.pool, EpochNumber(epoch.0)).await?;
+		drop(_sq_timer);
 		Ok(nonce.map(|n| EpochNonce(n.0)))
 	}
 
@@ -123,7 +130,7 @@ impl CandidatesDataSourceImpl {
 	/// Creates new instance of the data source
 	pub async fn new(
 		pool: PgPool,
-		metrics_opt: Option<McFollowerMetrics>,
+		metrics_opt: Option<MidnightDataSourceMetrics>,
 	) -> Result<CandidatesDataSourceImpl, Box<dyn std::error::Error + Send + Sync>> {
 		db_model::create_idx_ma_tx_out_ident(&pool).await?;
 		db_model::create_idx_tx_out_address(&pool).await?;
@@ -148,7 +155,10 @@ impl CandidatesDataSourceImpl {
 		&self,
 		epoch: EpochNumber,
 	) -> Result<Option<BlockNumber>, Box<dyn std::error::Error + Send + Sync>> {
+		let _sq_timer =
+			start_sub_query_timer(&self.metrics_opt, "candidates_get_latest_block_for_epoch");
 		let block_option = db_model::get_latest_block_for_epoch(&self.pool, epoch).await?;
+		drop(_sq_timer);
 		Ok(block_option.map(|b| b.block_no))
 	}
 
@@ -161,13 +171,17 @@ impl CandidatesDataSourceImpl {
 		let address: Address = Address(committee_candidate_address.to_string());
 		let active_utxos = match registrations_block_for_epoch {
 			Some(block) => {
-				db_model::get_utxos_for_address(
+				let _sq_timer =
+					start_sub_query_timer(&self.metrics_opt, "candidates_get_utxos_for_address");
+				let utxos = db_model::get_utxos_for_address(
 					&self.pool,
 					&address,
 					block,
 					self.db_sync_config.get_tx_in_config().await?,
 				)
-				.await?
+				.await?;
+				drop(_sq_timer);
+				utxos
 			},
 			None => vec![],
 		};
@@ -329,7 +343,7 @@ impl CandidatesDataSourceImpl {
 /// Has to be made at the level of trait, because otherwise #[async_trait] is expanded first.
 /// '&self' matching yields "__self" identifier not found error, so "&$self:tt" is required.
 /// Works only if return type is Result.
-/// Note: Metrics tracking is disabled because McFollowerMetrics methods are crate-private in partner-chains.
+/// Records Prometheus call count and timing histogram when metrics are available.
 macro_rules! observed_async_trait {
 	(impl $(<$($type_param:tt),+>)? $trait_name:ident $(<$($type_arg:ident),+>)? for $target_type:ty
 		$(where $($where_type:ident : $where_bound:tt ,)+)?
@@ -347,7 +361,7 @@ macro_rules! observed_async_trait {
 		$(
 			async fn $method(&$self $(,$param_name: $param_type)*,) -> $res {
 				let method_name = stringify!($method);
-				let _ = &$self.metrics_opt; // Silence unused field warning
+				let _ = &$self.metrics_opt;
 				let params: Vec<String> = vec![$(format!("{:?}", $param_name.clone()),)*];
 				log::debug!("{} called with parameters: {:?}", method_name, params);
 				let result = $body;

--- a/primitives/mainchain-follower/src/data_source/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use crate::data_source::candidates_data_source::observed_async_trait;
+use crate::data_source::metrics::{MidnightDataSourceMetrics, start_sub_query_timer};
 use crate::db::{get_deregistrations, get_registrations};
 use crate::{
 	CreateData, DeregistrationData, MidnightCNightObservationDataSource, ObservedUtxo,
@@ -25,7 +26,6 @@ use derive_new::new;
 use midnight_primitives_cnight_observation::{
 	CNightAddresses, CardanoPosition, CardanoRewardAddressBytes, DustPublicKeyBytes, ObservedUtxos,
 };
-use partner_chains_db_sync_data_sources::McFollowerMetrics;
 use sidechain_domain::{McBlockHash, McBlockNumber, McTxHash, McTxIndexInBlock, TX_HASH_SIZE};
 pub use sqlx::PgPool;
 use std::fmt::Debug;
@@ -87,7 +87,7 @@ pub enum RegistrationDatumDecodeError {
 #[derive(new)]
 pub struct MidnightCNightObservationDataSourceImpl {
 	pub pool: PgPool,
-	pub metrics_opt: Option<McFollowerMetrics>,
+	pub metrics_opt: Option<MidnightDataSourceMetrics>,
 	#[allow(dead_code)]
 	cache_size: u16,
 }
@@ -128,10 +128,12 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 				))?;
 
 		// Get end position from cardano block hash
+		let _block_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_block_by_hash");
 		let end: CardanoPosition = crate::db::get_block_by_hash(&self.pool, current_tip.clone())
 			.await?
 			.ok_or(MidnightCNightObservationDataSourceError::MissingBlockReference(current_tip))?
 			.into();
+		drop(_block_timer);
 		// Increment the end position to tx_index + 1 of the current mainchain position
 		let end = end.increment();
 
@@ -146,6 +148,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 
 		let (registration_utxos, deregistration_utxos, asset_create_utxos, asset_spend_utxos) = tokio::try_join!(
 			async {
+				let _sq_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_registrations");
 				self.get_registration_utxos(
 					cardano_network,
 					&mapping_validator_policy_id,
@@ -160,6 +163,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 				.map_err(Into::<Box<dyn std::error::Error + Send + Sync>>::into)
 			},
 			async {
+				let _sq_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_deregistrations");
 				self.get_deregistration_utxos(
 					cardano_network,
 					&config.mapping_validator_address,
@@ -172,6 +176,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 				.map_err(Into::<Box<dyn std::error::Error + Send + Sync>>::into)
 			},
 			async {
+				let _sq_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_asset_creates");
 				self.get_asset_create_utxos(
 					cardano_network,
 					config.cnight_policy_id,
@@ -185,6 +190,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 				.map_err(Into::<Box<dyn std::error::Error + Send + Sync>>::into)
 			},
 			async {
+				let _sq_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_asset_spends");
 				self.get_asset_spend_utxos(
 					cardano_network,
 					config.cnight_policy_id,

--- a/primitives/mainchain-follower/src/data_source/federated_authority_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/federated_authority_observation.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::data_source::metrics::{MidnightDataSourceMetrics, start_sub_query_timer};
 use crate::{
 	FederatedAuthorityObservationDataSource,
 	data_source::candidates_data_source::observed_async_trait, db::get_governance_body_utxo,
@@ -21,14 +22,13 @@ use midnight_primitives_federated_authority_observation::{
 	AuthoritiesData, AuthorityMemberPublicKey, FederatedAuthorityData,
 	FederatedAuthorityObservationConfig, GovernanceAuthorityDatumR0, GovernanceAuthorityDatums,
 };
-use partner_chains_db_sync_data_sources::McFollowerMetrics;
 use sidechain_domain::{McBlockHash, PolicyId};
 pub use sqlx::PgPool;
 
 #[derive(new)]
 pub struct FederatedAuthorityObservationDataSourceImpl {
 	pub pool: PgPool,
-	pub metrics_opt: Option<McFollowerMetrics>,
+	pub metrics_opt: Option<MidnightDataSourceMetrics>,
 	#[allow(dead_code)]
 	cache_size: u16,
 }
@@ -41,7 +41,9 @@ impl FederatedAuthorityObservationDataSource for FederatedAuthorityObservationDa
 		mc_block_hash: &McBlockHash,
 	) -> Result<FederatedAuthorityData, Box<dyn std::error::Error + Send + Sync>> {
 		// Get block number from hash
+		let _block_timer = start_sub_query_timer(&self.metrics_opt, "fedauth_get_block_by_hash");
 		let block = crate::db::get_block_by_hash(&self.pool, mc_block_hash.clone()).await?;
+		drop(_block_timer);
 
 		let block_number = match block {
 			Some(b) => b.block_number.0,
@@ -51,6 +53,7 @@ impl FederatedAuthorityObservationDataSource for FederatedAuthorityObservationDa
 		};
 
 		// Query council UTXO
+		let _council_timer = start_sub_query_timer(&self.metrics_opt, "fedauth_get_council_utxo");
 		let council_utxo = get_governance_body_utxo(
 			&self.pool,
 			&config.council.address,
@@ -58,6 +61,7 @@ impl FederatedAuthorityObservationDataSource for FederatedAuthorityObservationDa
 			block_number,
 		)
 		.await?;
+		drop(_council_timer);
 
 		let council_authorities: AuthoritiesData = match council_utxo {
 			Some(utxo) => match Self::decode_governance_datum(&utxo.full_datum.0) {
@@ -83,6 +87,7 @@ impl FederatedAuthorityObservationDataSource for FederatedAuthorityObservationDa
 		};
 
 		// Query technical committee UTXO
+		let _techcomm_timer = start_sub_query_timer(&self.metrics_opt, "fedauth_get_technical_committee_utxo");
 		let technical_committee_utxo = get_governance_body_utxo(
 			&self.pool,
 			&config.technical_committee.address,
@@ -90,6 +95,7 @@ impl FederatedAuthorityObservationDataSource for FederatedAuthorityObservationDa
 			block_number,
 		)
 		.await?;
+		drop(_techcomm_timer);
 
 		let technical_committee_authorities: AuthoritiesData = match technical_committee_utxo {
 			Some(utxo) => match Self::decode_governance_datum(&utxo.full_datum.0) {

--- a/primitives/mainchain-follower/src/data_source/metrics.rs
+++ b/primitives/mainchain-follower/src/data_source/metrics.rs
@@ -1,0 +1,74 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use log::warn;
+use prometheus_endpoint::{HistogramOpts, HistogramVec, PrometheusError, Registry, register};
+
+pub type MetricsRegistry = Registry;
+
+/// Prometheus metrics for Midnight-specific data source SQL queries.
+#[derive(Clone)]
+pub struct MidnightDataSourceMetrics {
+	time_elapsed: HistogramVec,
+}
+
+impl MidnightDataSourceMetrics {
+	pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			time_elapsed: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"midnight_data_source_query_time_elapsed",
+						"Time spent in a midnight data source SQL query",
+					),
+					&["query_name"],
+				)?,
+				registry,
+			)?,
+		})
+	}
+
+	pub fn register_warn_errors(metrics_registry_opt: Option<&Registry>) -> Option<Self> {
+		metrics_registry_opt.and_then(|registry| match Self::register(registry) {
+			Ok(metrics) => Some(metrics),
+			Err(err) => {
+				warn!("Failed registering midnight data source metrics: {}", err);
+				None
+			},
+		})
+	}
+}
+
+/// Starts a Prometheus sub-query timer if metrics are available.
+/// The returned guard records the elapsed time to the histogram when dropped.
+pub fn start_sub_query_timer(
+	metrics_opt: &Option<MidnightDataSourceMetrics>,
+	label: &str,
+) -> Option<SubQueryTimer> {
+	metrics_opt.as_ref().map(|m| SubQueryTimer {
+		start: std::time::Instant::now(),
+		histogram: m.time_elapsed.with_label_values(&[label]),
+	})
+}
+
+/// RAII guard that records elapsed time to a Prometheus histogram on drop.
+pub struct SubQueryTimer {
+	start: std::time::Instant,
+	histogram: prometheus_endpoint::Histogram,
+}
+
+impl Drop for SubQueryTimer {
+	fn drop(&mut self) {
+		self.histogram.observe(self.start.elapsed().as_secs_f64());
+	}
+}

--- a/primitives/mainchain-follower/src/data_source/mod.rs
+++ b/primitives/mainchain-follower/src/data_source/mod.rs
@@ -20,6 +20,7 @@ pub mod cnight_observation;
 pub mod cnight_observation_mock;
 pub mod federated_authority_observation;
 pub mod federated_authority_observation_mock;
+pub mod metrics;
 
 pub use candidates_data_source::CandidatesDataSourceImpl;
 pub use candidates_data_source::cached::CandidateDataSourceCached;

--- a/primitives/mainchain-follower/src/lib.rs
+++ b/primitives/mainchain-follower/src/lib.rs
@@ -32,6 +32,7 @@ pub use {
 		CNightObservationDataSourceMock, CandidateDataSourceCached, CandidatesDataSourceImpl,
 		FederatedAuthorityObservationDataSourceImpl, FederatedAuthorityObservationDataSourceMock,
 		MidnightCNightObservationDataSourceImpl, get_epoch_for_block_hash,
+		metrics::MidnightDataSourceMetrics,
 	},
 	inherent_provider::*,
 	partner_chains_db_sync_data_sources,


### PR DESCRIPTION
…22100] (#904)

* feat: add Prometheus per-query metrics to midnight data sources

Introduce MidnightDataSourceMetrics with public accessor methods, replacing the upstream McFollowerMetrics whose accessors are crate-private in partner-chains v1.8.1. The local observed_async_trait! macro now records call counts and timing histograms for all six midnight-specific data source methods (candidates, cnight observation, federated authority observation).

JIRA: PM-22100
Made-with: Cursor

* ci: normalise scan job name (#823)

* update scanner action to latest version



* update scanner action to latest version



* ci: rename workflow name from build to scan



---------



* chore: add change file for PM-22100 dbsync query metrics

Made-with: Cursor

* feat: add sub-query SQL-level Prometheus timing for midnight data sources

Add individual Prometheus timing histograms for each SQL query inside midnight-node data source methods. This provides per-query latency visibility alongside the existing method-level timing, enabling precise identification of slow DBSync queries on mainnet.

13 sub-query timers added across 3 data sources:
- cNight observation: 5 queries (block lookup + 4 concurrent UTXO queries)
- Federated authority: 3 queries (block lookup + 2 governance UTXOs)
- Candidates: 5 queries across 3 methods

Ref: PM-22100
Made-with: Cursor

* refactor: extract sub-query timer helper to reduce repetition

Replace 13 inline timer patterns with a shared start_sub_query_timer() helper and SubQueryTimer RAII guard in the metrics module. Each call site reduces from 3 lines to 1.

Made-with: Cursor

* refactor: remove method-level timing, keep SQL-level sub-query timers only

Remove the observed_async_trait! macro timing (method-level) since per-SQL-query timing provides more useful granularity. Simplify MidnightDataSourceMetrics to histogram-only (remove unused call counter). Rename metric to midnight_data_source_query_time_elapsed with query_name label for clarity.

Made-with: Cursor

* style: apply rustfmt to candidates data source

Made-with: Cursor

* chore: update changes file to reflect SQL-level sub-query timing

Made-with: Cursor

---------

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
