### PR TITLE
feat: added flush of parity-db logs after block import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -5869,10 +5881,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.1",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width 0.2.1",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -7382,8 +7407,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf29bc144421a429a3c6fff48ca4dec3e5e78d652e10d9c438f58c8f4388f2ff"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "anyhow",
  "atomic-write-file",
@@ -7394,7 +7418,7 @@ dependencies = [
  "flate2",
  "futures",
  "group",
- "indicatif",
+ "indicatif 0.18.4",
  "k256",
  "lazy_static",
  "midnight-base-crypto-derive",
@@ -7415,8 +7439,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d0904a6357c953a55316b0ea7fac93d971f2d00c94d51e082817ae24872126"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7923,11 +7946,11 @@ dependencies = [
  "async-trait",
  "backoff",
  "clap",
- "console",
+ "console 0.15.11",
  "futures",
  "hex",
  "hex-literal 1.0.0",
- "indicatif",
+ "indicatif 0.17.11",
  "log",
  "midnight-node-ledger-helpers",
  "midnight-node-metadata",
@@ -8244,8 +8267,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf09a5e7e71e9cda92d6a401448cccaf6147ecb2b473bda2bb0afcccebdfd12"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "crypto",
  "konst",
@@ -8258,8 +8280,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize-macros"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d470675b20968294a11b14680c540c1ba9cccdbe89437ac939dfa688e91baf4"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -8306,8 +8327,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-core"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc1be493c1a38918c0629d4b0ab8725ef0b759a6243410c5f7504700c851feb"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "archery",
  "crypto",
@@ -8332,8 +8352,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-macros"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeb4dc8c8ea5a6495036a88943c38cce40c23fc0181e0073ca52b7124800960"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?branch=feat%2Fparity_db_pipeline_flush#5917f924ac95972e83e978b9bc65f33d38dff5bf"
 dependencies = [
  "midnight-serialize-macros",
  "proc-macro2",
@@ -13487,7 +13506,7 @@ name = "sc-informant"
 version = "0.52.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509#5ab401310d2fbd808b3ffbcfc8735ad8f1c8fe10"
 dependencies = [
- "console",
+ "console 0.15.11",
  "futures",
  "futures-timer",
  "log",
@@ -14085,7 +14104,7 @@ version = "42.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2509#5ab401310d2fbd808b3ffbcfc8735ad8f1c8fe10"
 dependencies = [
  "chrono",
- "console",
+ "console 0.15.11",
  "is-terminal",
  "libc",
  "log",
@@ -16972,7 +16991,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata 0.15.4",
- "console",
+ "console 0.15.11",
  "filetime",
  "frame-metadata 23.0.0",
  "jobserver",
@@ -18667,6 +18686,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ rayon = "1.11"
 sha2 = "0.10.8"
 toml = "0.9.0"
 bip32 = "0.5.3"
-derive-where = "1.5.0"
+derive-where = "1.6.1"
 tempfile = "3.27.0"
 impl-trait-for-tuples = "0.2.2"
 test-log = "0.2"
@@ -408,6 +408,11 @@ zeroize = { opt-level = 3 }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/midnightntwrk/rust-yamux", branch = "yamux-v0.12.2" }
+midnight-base-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", branch = "feat/parity_db_pipeline_flush", package = "midnight-base-crypto" }
+midnight-base-crypto-derive = { git = "https://github.com/midnightntwrk/midnight-ledger", branch = "feat/parity_db_pipeline_flush", package = "midnight-base-crypto-derive" }
+midnight-serialize = { git = "https://github.com/midnightntwrk/midnight-ledger", branch = "feat/parity_db_pipeline_flush", package = "midnight-serialize" }
+midnight-serialize-macros = { git = "https://github.com/midnightntwrk/midnight-ledger", branch = "feat/parity_db_pipeline_flush", package = "midnight-serialize-macros" }
+midnight-storage-core = { git = "https://github.com/midnightntwrk/midnight-ledger", branch = "feat/parity_db_pipeline_flush", package = "midnight-storage-core" }
 
 [workspace.metadata.cargo-shear]
 ignored = []

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -87,6 +87,12 @@ pub fn drop_all_default_storage() {
 	ledger_8::storage::drop_default_storage_if_exists();
 }
 
+#[cfg(feature = "std")]
+pub fn flush_log_pipeline_on_default_storage() {
+	ledger_7::storage::flush_log_pipeline_on_default_storage_if_exists();
+	ledger_8::storage::flush_log_pipeline_on_default_storage_if_exists();
+}
+
 mod common;
 
 pub mod types {

--- a/ledger/src/versions/common/storage.rs
+++ b/ledger/src/versions/common/storage.rs
@@ -30,6 +30,12 @@ pub fn drop_default_storage_if_exists() {
 	}
 }
 
+pub fn flush_log_pipeline_on_default_storage_if_exists() {
+	if let Some(storage) = try_get_default_storage::<ParityDb>() {
+		storage.with_backend(|backend| backend.flush_log_pipeline());
+	}
+}
+
 #[cfg(feature = "std")]
 use {
 	super::ledger_storage_local::db::DB,

--- a/node/src/ledger_log_pipeline.rs
+++ b/node/src/ledger_log_pipeline.rs
@@ -1,0 +1,92 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::service::FullClient;
+use futures::StreamExt;
+use log::{debug, error, trace};
+use sc_client_api::BlockchainEvents;
+use sc_service::TaskManager;
+use std::{
+	panic::{self, AssertUnwindSafe},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
+	time::Instant,
+};
+use tokio::sync::Notify;
+
+const LOG_TARGET: &str = "ledger-parity-db-wal";
+
+pub(crate) fn spawn(task_manager: &TaskManager, client: Arc<FullClient>) {
+	let flush_requested = Arc::new(AtomicBool::new(false));
+	let flush_notify = Arc::new(Notify::new());
+
+	task_manager.spawn_handle().spawn("ledger-parity-db-wal-imports", None, {
+		let flush_requested = flush_requested.clone();
+		let flush_notify = flush_notify.clone();
+
+		async move {
+			let mut import_notifications = client.every_import_notification_stream();
+
+			while let Some(notification) = import_notifications.next().await {
+				flush_requested.store(true, Ordering::Release);
+				flush_notify.notify_one();
+				trace!(
+					target: LOG_TARGET,
+					"queued WAL flush: import {:?} origin {:?}",
+					notification.hash,
+					notification.origin,
+				);
+			}
+		}
+	});
+
+	task_manager.spawn_handle().spawn("ledger-parity-db-wal-flush", None, {
+		let flush_requested = flush_requested.clone();
+		let flush_notify = flush_notify.clone();
+
+		async move {
+			loop {
+				flush_notify.notified().await;
+
+				while flush_requested.swap(false, Ordering::AcqRel) {
+					debug!(target: LOG_TARGET, "WAL flush start");
+					let started_at = Instant::now();
+					let result = tokio::task::spawn_blocking(|| {
+						panic::catch_unwind(AssertUnwindSafe(|| {
+							midnight_node_ledger::flush_log_pipeline_on_default_storage();
+						}))
+					})
+					.await;
+
+					match result {
+						Ok(Ok(())) => debug!(
+							target: LOG_TARGET,
+							"WAL flush done in {} ms",
+							started_at.elapsed().as_millis()
+						),
+						Ok(Err(_)) => error!(
+							target: LOG_TARGET,
+							"WAL flush panicked; will retry on next import"
+						),
+						Err(error) => error!(
+							target: LOG_TARGET,
+							"WAL flush task join failed: {error}"
+						),
+					}
+				}
+			}
+		}
+	});
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -23,6 +23,7 @@ pub mod extensions;
 mod filtering_pool;
 pub mod genesis;
 pub mod inherent_data;
+mod ledger_log_pipeline;
 pub mod main_chain_follower;
 pub mod memory_monitor;
 pub mod metrics_push;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -667,6 +667,8 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		telemetry: telemetry.as_mut(),
 	})?;
 
+	crate::ledger_log_pipeline::spawn(&task_manager, client.clone());
+
 	if role.is_authority() {
 		let basic_authorship_proposer_factory = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),


### PR DESCRIPTION
# Summary

Adds a background pipeline that flushes the ledger ParityDB log after each block import, exposes a small `midnight-node-ledger` API to perform that flush safely, and temporarily patches several `midnight-*` crates to a `midnight-ledger` branch that provides `flush_log_pipeline` on the storage backend.

## Motivation

ParityDB keeps work in a log pipeline; flushing it regularly after imports reduces reliance on shutdown-only behavior and aligns with durability expectations for ledger state on disk.

## What changed

- **`node/src/ledger_log_pipeline.rs` (new)**  
  - Subscribes to `every_import_notification_stream()`.  
  - Uses an `AtomicBool` plus `tokio::sync::Notify` so wakeups coalesce with a drain loop: each wake runs `flush_requested.swap(false)` until quiescent, with the actual flush in `spawn_blocking`.  
  - Wraps the flush in `catch_unwind` so a panic is logged and the next import can retry.  
  - Logging target: `ledger-parity-db-wal` (trace for queue, debug for timing, error on panic/join failure).

- **`ledger/src/lib.rs`**  
  - Adds `flush_log_pipeline_on_default_storage()` (ledger v7 and v8 paths).

- **`ledger/src/versions/common/storage.rs`**  
  - Adds `flush_log_pipeline_on_default_storage_if_exists()` using `if let Some(storage) = try_get_default_storage::<ParityDb>()` and `storage.with_backend(...)` so the flush holds an `Arc` for the whole call and avoids a TOCTOU with `default_storage()` if default storage is dropped concurrently.

- **`node/src/service.rs`**  
  - Spawns the pipeline after `spawn_tasks`, with the rest of full client setup unchanged.

- **Workspace dependencies**  
  - `[patch.crates-io]` in root `Cargo.toml` points `midnight-base-crypto`, `midnight-base-crypto-derive`, `midnight-serialize`, `midnight-serialize-macros`, and `midnight-storage-core` at `midnight-ledger` branch `feat/parity_db_pipeline_flush`.  
  - `derive-where` bumped to `1.6.1`; `Cargo.lock` updated (including duplicate `console` / `indicatif` versions from the dependency graph).

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
