### PR TITLE
feat: adjusted ledger weight to include pre_dispatch validation

### DIFF
--- a/ledger/helpers/src/versions/common/context.rs
+++ b/ledger/helpers/src/versions/common/context.rs
@@ -332,9 +332,12 @@ impl<D: DB + Clone> LedgerContext<D> {
 				let valid_tx: VerifiedTransaction<_> = tx
 					.well_formed(&tx_context.ref_state, strictness, tx_context.block_context.tblock)
 					.map_err(|e| LedgerContextError::InvalidTransaction(format!("{e:?}")))?;
-				let cost = tx
-					.cost(&tx_context.ref_state.parameters, false)
+				let base_synthetic = tx
+					.cost(&tx_context.ref_state.parameters, true)
 					.map_err(|e| LedgerContextError::CostCalculation(format!("{e:?}")))?;
+				let (_, application_total) =
+					tx.application_cost(&tx_context.ref_state.parameters.cost_model);
+				let cost = base_synthetic + application_total;
 
 				let (new_ledger_state, result) = tx_context.ref_state.apply(&valid_tx, &tx_context);
 				let offers = Self::successful_shielded_offers(tx, &result);

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -732,21 +732,21 @@ where
 		let api = api::new();
 		let tx = api.tagged_deserialize::<Transaction<S, D>>(tx)?;
 		let ledger = Self::get_ledger(&api, state_key)?;
+		let params = &ledger.state.parameters;
 
-		let cost =
-			tx.0.cost(&ledger.state.parameters, true)
-				.map_err(|_| LedgerApiError::FeeCalculationError)?;
+		let base_synthetic =
+			tx.0.cost(params, true).map_err(|_| LedgerApiError::FeeCalculationError)?;
+		let (_, application_total) = tx.0.application_cost(&params.cost_model);
+		let cost = base_synthetic + application_total;
 
 		log::trace!(target: LOG_TARGET, "⏱️  Estimated cost: {cost:?}");
 
-		let limits = ledger.state.parameters.limits.block_limits;
+		let limits = params.limits.block_limits;
 		let normalized = cost.normalize(limits).ok_or(LedgerApiError::BlockLimitExceededError)?;
 
 		log::trace!(target: LOG_TARGET, "⏱️  Normalized cost: {normalized:?}");
 
-		let gas_cost = scale_normalized_cost(&normalized, max_weight);
-
-		Ok(gas_cost)
+		Ok(scale_normalized_cost(&normalized, max_weight))
 	}
 
 	fn get_deserialized_ledger_parameters(state: &Ledger<D>) -> LedgerParameters {

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -577,7 +577,6 @@ pub mod pallet {
 			Self::get_transaction_cost(tx)
 				.map(|gas_cost| Weight::from_parts(gas_cost, 0))
 				.unwrap_or(crate::EXTRA_WEIGHT_TX_SIZE)
-				+ ConfigurableTransactionSizeWeight::<T>::get()
 		}
 	}
 }

--- a/util/toolkit/src/genesis_generator.rs
+++ b/util/toolkit/src/genesis_generator.rs
@@ -584,7 +584,9 @@ impl GenesisGenerator {
 
 		let valid_tx =
 			tx.well_formed(&tx_context.ref_state, strictness, tx_context.block_context.tblock)?;
-		self.fullness = self.fullness + tx.cost(&self.state.parameters, false)?;
+		let base_synthetic = tx.cost(&self.state.parameters, true)?;
+		let (_, application_total) = tx.application_cost(&self.state.parameters.cost_model);
+		self.fullness = self.fullness + base_synthetic + application_total;
 		let (state, result) = self.state.apply(&valid_tx, &tx_context);
 		match result {
 			TransactionResult::Success(_) => {


### PR DESCRIPTION
# Overview

`midnight-ledger`’s `Transaction::cost()` models **one** validation pass plus **one** application pass. In the node, a single `send_mn_transaction` inclusion does more work than that:

1. **`ValidateUnsigned::pre_dispatch`** (default) calls `validate_guaranteed_execution`, which dry-runs `LedgerState::apply` on the verified transaction.
2. **Dispatch** calls `apply_verified_transaction`, which runs a full `apply` again.

FRAME does **not** charge `pre_dispatch` separately from `#[pallet::weight]`, so extrinsic weight that only mirrored `Transaction::cost()` could **under-account** for real block execution.

This change updates **`get_transaction_cost`** in `ledger/src/versions/common/mod.rs` to add a second **application** synthetic cost (`application_cost` total) before `normalize` / `scale_normalized_cost`, i.e. `cost = tx.cost(…) + application_total`. `pallet_midnight::get_tx_weight` already uses `get_transaction_cost`, so `send_mn_transaction` weight now aligns with validation + two application passes.

**Consumer impact:** The runtime host call and any logic that uses `get_transaction_cost` (including `validate_transaction` transaction details when gas is attached) now returns this **higher** ref-time scalar. It is no longer numerically identical to the single-pass `Transaction::cost()` used for Dust fee math inside the ledger; callers that need strictly “fee formula” cost should use ledger fee APIs / `Transaction::fees` semantics instead of this host mapping.
## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
