### PR TITLE
fix: audit vite CVEs + split audit into cargo/npm jobs

### DIFF
--- a/.github/workflows/security-audit-scan.yml
+++ b/.github/workflows/security-audit-scan.yml
@@ -14,8 +14,8 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.head_ref) || github.run_id }}
   cancel-in-progress: true
 jobs:
-  run:
-    name: cargo audit job
+  audit-rust:
+    name: audit job cargo
     permissions:
       contents: read
       security-events: write
@@ -35,9 +35,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Run cargo deny and npm audit
+      - name: Run cargo deny
         run: |
-          . ./.envrc && earthly --use-inline-cache --strict +audit
+          . ./.envrc && earthly --use-inline-cache --strict +audit-rust
 
       - name: Fix cargo-deny SARIF format
         if: hashFiles('scan_reports/cargo-deny.sarif') != ''
@@ -54,6 +54,31 @@ jobs:
         with:
           sarif_file: scan_reports/cargo-deny.sarif
           category: cargo-deny
+
+  audit-typescript:
+    name: audit job npm
+    permissions:
+      contents: read
+      security-events: write
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
+        with:
+          version: v0.8.16
+          github-token: ${{ github.token }}
+          use-cache: false
+
+      - name: Checkout node repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+
+      - name: Run npm audit
+        run: |
+          . ./.envrc && earthly --use-inline-cache --strict +audit-nodejs
 
       - name: Upload npm-audit-local-environment SARIF
         uses: github/codeql-action/upload-sarif@ce729e4d353d580e6cacd6a8cf2921b72e5e310a #codeql-bundle-v2.23.6

--- a/util/toolkit-js/package-lock.json
+++ b/util/toolkit-js/package-lock.json
@@ -64,6 +64,7 @@
       "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.56.4.tgz",
       "integrity": "sha512-7Je5/JlbZOlsSxsbKjr97dJed2cNGWsb+TLNgMcr5mRDbcWlFOTUGvsrisEJV6waosYLIg+2omPdvnvRoYKdhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
@@ -104,6 +105,7 @@
       "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.94.5.tgz",
       "integrity": "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -155,6 +157,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.47.0.tgz",
       "integrity": "sha512-VgR8e+YWWhMEAh9qFOjwiZ3OXluAbcVLIOtvp2S5di1nSrPOZxj78g8LE77JSvyfp5y5bS2gmFW+G7xD5uU+2Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@effect/typeclass": "^0.38.0",
         "effect": "^3.19.0"
@@ -165,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.47.0.tgz",
       "integrity": "sha512-tDEQ9XJpXDNYoWMQJHFRMxKGmEOu6z32x3Kb8YLOV5nkauEKnKmWNs7NBp8iio/pqoJbaSwqDwUg9jXVquxfWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@effect/printer": "^0.47.0"
       },
@@ -178,6 +182,7 @@
       "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.73.2.tgz",
       "integrity": "sha512-td7LHDgBOYKg+VgGWEelD8rSAmvjXz7am17vfxZROX5qIYuvH7drL/z4p5xQFadhHZ7DYdlFpqdO9ggc77OCIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.4"
       },
@@ -191,6 +196,7 @@
       "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.49.0.tgz",
       "integrity": "sha512-9UEKR+z+MrI/qMAmSvb/RiD9KlgIazjZUCDSpwNgm0lEK9/Q6ExEyfziiYFVCPiptp52cBw8uBHRic8hHnwqXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
@@ -205,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.38.0.tgz",
       "integrity": "sha512-lMUcJTRtG8KXhXoczapZDxbLK5os7M6rn0zkvOgncJW++A0UyelZfMVMKdT5R+fgpZcsAU/1diaqw3uqLJwGxA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "effect": "^3.19.0"
       }
@@ -694,6 +701,7 @@
       "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.4.3.tgz",
       "integrity": "sha512-1DkzkT9q6sBNMElmYpzjMoVlAtmB3dw9dAQkMBUsz56mlRvnAMgMSaqtWdPBsZlsdUkw+yOvBGs8pY+cnIwQfQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@effect/platform": "^0.94.2",
         "@midnight-ntwrk/compact-runtime": "0.14.0",
@@ -1788,6 +1796,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
       "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2077,6 +2086,7 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
       "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -3067,6 +3077,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3279,6 +3290,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3322,11 +3334,12 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3443,6 +3456,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3666,6 +3680,7 @@
       "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.57.0.tgz",
       "integrity": "sha512-VjZoZ4hmgDb0GtGjktypTk/nArA3ntsXU2O9vOBzDjJLRKVBt7IS0/cllHrHwK5Jxkfz86B2k+Prw4/+nrLFlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
@@ -3705,6 +3720,7 @@
       "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
       "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -3756,6 +3772,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.48.0.tgz",
       "integrity": "sha512-f/+QVyqACuLkoB+HDDX2XxloslmgMDL+C6ecHBV0cB0zJzJmLCOybwOkRcCI2xJ/DWHEIpoRyvq+Bfdza0AIrA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@effect/typeclass": "^0.39.0",
         "effect": "^3.20.0"
@@ -3766,6 +3783,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.48.0.tgz",
       "integrity": "sha512-CzQ5kiomjR9DZ6LPfKAaWmys6JU65c2Q/VQcTKRK4RfaDWeTAehpAVmgOIyKSPkcr9XBhjo2cJx4xyZ4E5nN7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@effect/printer": "^0.48.0"
       },
@@ -3779,6 +3797,7 @@
       "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.74.0.tgz",
       "integrity": "sha512-EV/cHQqJxLtY+RTlPlVQU1KyTzml1wFne+Sh91RacGRRVh6uTm4UdhRh9TNtbYHD4rM9yD3T6zqUgKr0AH8MvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.4"
       },
@@ -3792,6 +3811,7 @@
       "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.50.0.tgz",
       "integrity": "sha512-sOTzsC+ICASgSmX1RITYo6ut7ZbkX+hMG6YagJEyhtptxco9MgSflpF/ix/L92haJ+YTS5Zur/Dm2bDNfVes4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
@@ -3806,6 +3826,7 @@
       "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.39.0.tgz",
       "integrity": "sha512-V8qGpm4BTMS4pW9e7aCdxC0sy/TYsdxmnpWtokkNWnggZ6kvh1Psp3AfUuuZLyNmUk4T+lYB/ItEsga/+hryig==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "effect": "^3.20.0"
       }
@@ -3815,6 +3836,7 @@
       "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.17.0.tgz",
       "integrity": "sha512-JiayvFTTMrp36P0cVFcgu6Nb7ZJxQv+FRqs3DPORkVAcCZlWOKa3KyuYebN3qZbRsmLzS7cxuC8BAeMuqb+WaQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@effect/experimental": "^0.59.0",
         "@effect/platform": "^0.95.0",
@@ -3827,6 +3849,7 @@
       "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.0.tgz",
       "integrity": "sha512-vCLbndc3GtSTjZE30NtNqINOrrjZ2O/m8q4jCVeyx9t+rTLwwFqGXUOYobKbM34rwfnTz95ZAI6vVixYnarfrA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@effect/platform": "^0.95.0",
         "@midnight-ntwrk/compact-runtime": "0.15.0",


### PR DESCRIPTION
# Overview

Fix 3 high-severity vite CVEs (GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583) by bumping vite 7.3.1 → 7.3.2 in toolkit-js lockfile, and split the single audit CI job into two parallel jobs so cargo deny and npm audit run independently.

Fixes https://github.com/midnightntwrk/midnight-node/issues/1051

## 🗹 TODO before merging

- [x] Ready


## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only + lockfile fix
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `npm audit --audit-level high` in `util/toolkit-js/` returns 0 vulnerabilities after the lockfile update
- Workflow YAML validated — two independent jobs with correct earthly targets and SARIF uploads

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links