### PR TITLE
feat: split out renovate PR so more likely to be green

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,35 @@
     "github>midnightntwrk/renovate-config",
     "github>midnightntwrk/renovate-config:earthfile"
   ],
-  "git-submodules": { "enabled": true }
+  "git-submodules": { "enabled": true },
+  "packageRules": [
+    {
+      "description": "Rust crates: individual PRs (breaking API changes are common)",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": null,
+      "groupSlug": null
+    },
+    {
+      "description": "GitHub Actions: group minor+patch together",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "npm/pnpm: group minor+patch together",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "JS dependencies",
+      "groupSlug": "js-deps"
+    },
+    {
+      "description": "Docker: group minor+patch together",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Docker images",
+      "groupSlug": "docker-images"
+    }
+  ]
 }


### PR DESCRIPTION
If you look at https://github.com/midnightntwrk/midnight-wallet/pull/286 it tries to do too much in one PR and is never going to land (or go green in CI).

This PR tweaks config to split these kinds of PRs into more finegrained PRs. We might be able to upgrade all the JS in one PR - so we'll try that, but all the crates upgraded is never going to work - that needs to be more pick and mix.

https://github.com/midnightntwrk/midnight-node/pull/1256