### PR TITLE
fix: validate derivation path roles in `DerivationPath`

### DIFF
--- a/ledger/helpers/src/versions/common/wallet/dust.rs
+++ b/ledger/helpers/src/versions/common/wallet/dust.rs
@@ -2,12 +2,13 @@ use derive_where::derive_where;
 use thiserror::Error;
 
 use super::super::{
-	ArenaKey, DB, DerivationPath, DeriveSeed, Deserializable, DustLocalState, DustNullifier,
-	DustOutput, DustParameters, DustPublicKey, DustSecretKey, DustSpend, Event, EventReplayError,
-	HRP_CONSTANT, HRP_CREDENTIAL_DUST, HashSet, IntoWalletAddress, LedgerParameters, Loader,
-	MnLedgerDustSpendError, ProofPreimageMarker, QualifiedDustOutput, Role, Serializable, Sp,
-	Storable, Tagged, Timestamp, WalletAddress, WalletSeed, deserialize_untagged,
-	mn_ledger_serialize as serialize, mn_ledger_storage as storage, serialize_untagged,
+	ArenaKey, DB, DerivationPath, DerivationPathError, DeriveSeed, Deserializable, DustLocalState,
+	DustNullifier, DustOutput, DustParameters, DustPublicKey, DustSecretKey, DustSpend, Event,
+	EventReplayError, HRP_CONSTANT, HRP_CREDENTIAL_DUST, HashSet, IntoWalletAddress,
+	LedgerParameters, Loader, MnLedgerDustSpendError, ProofPreimageMarker, QualifiedDustOutput,
+	Role, Serializable, Sp, Storable, Tagged, Timestamp, WalletAddress, WalletSeed,
+	deserialize_untagged, mn_ledger_serialize as serialize, mn_ledger_storage as storage,
+	serialize_untagged,
 };
 
 #[derive(Debug, Storable)]
@@ -60,10 +61,10 @@ impl<D: DB> DustWallet<D> {
 		root_seed: WalletSeed,
 		path: &DerivationPath,
 		params: Option<&LedgerParameters>,
-	) -> Self {
+	) -> Result<Self, DerivationPathError> {
+		path.validate_role(&[Role::Dust])?;
 		let derived_seed = Self::derive_seed(root_seed, path);
-
-		Self::from_seed(derived_seed, params)
+		Ok(Self::from_seed(derived_seed, params))
 	}
 
 	pub fn replay_events<'a>(

--- a/ledger/helpers/src/versions/common/wallet/hd.rs
+++ b/ledger/helpers/src/versions/common/wallet/hd.rs
@@ -59,7 +59,7 @@ impl std::str::FromStr for WalletAddress {
 	}
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Role {
 	UnshieldedExternal,
 	UnshieldedInternal,
@@ -68,37 +68,68 @@ pub enum Role {
 	Metadata,
 }
 
+impl TryFrom<u32> for Role {
+	type Error = DerivationPathError;
+
+	fn try_from(value: u32) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(Role::UnshieldedExternal),
+			1 => Ok(Role::UnshieldedInternal),
+			2 => Ok(Role::Dust),
+			3 => Ok(Role::Zswap),
+			4 => Ok(Role::Metadata),
+			_ => Err(DerivationPathError::UnknownRole(value)),
+		}
+	}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DerivationPathError {
+	#[error("Invalid derivation path format: {0}")]
+	InvalidFormat(String),
+	#[error("Invalid role value: {0}")]
+	InvalidRoleValue(String),
+	#[error("Unknown role value: {0}")]
+	UnknownRole(u32),
+	#[error("Role mismatch: expected one of {expected:?}, got {actual:?}")]
+	RoleMismatch { expected: Vec<Role>, actual: Role },
+}
+
 pub struct DerivationPath {
 	pub path: String,
 	pub role: Role,
 }
 
 impl DerivationPath {
-	pub fn new(path: String) -> Self {
+	pub fn new(path: String) -> Result<Self, DerivationPathError> {
 		// Split the path by '/' and collect the elements
 		let parts: Vec<&str> = path.split('/').collect();
 
 		if parts.len() != 6 || parts[0] != "m" {
-			panic!("Invalid derivation path format {path}");
+			return Err(DerivationPathError::InvalidFormat(path));
 		}
 
 		// Parse the role component (4th index)
 		let role_part = parts[4];
 
 		// Attempt to parse role_part into an integer
-		let role_index: u32 =
-			role_part.parse().unwrap_or_else(|err| panic!("Invalid role value {err}"));
+		let role_index: u32 = role_part
+			.parse()
+			.map_err(|_| DerivationPathError::InvalidRoleValue(role_part.to_string()))?;
 
-		let role = match role_index {
-			0 => Role::UnshieldedExternal,
-			1 => Role::UnshieldedInternal,
-			2 => Role::Dust,
-			3 => Role::Zswap,
-			4 => Role::Metadata,
-			_ => panic!("Unknown role value: {role_index}"),
-		};
+		let role = Role::try_from(role_index)?;
 
-		Self { path, role }
+		Ok(Self { path, role })
+	}
+
+	pub fn validate_role(&self, expected: &[Role]) -> Result<(), DerivationPathError> {
+		if !expected.contains(&self.role) {
+			return Err(DerivationPathError::RoleMismatch {
+				expected: expected.to_vec(),
+				actual: self.role.clone(),
+			});
+		}
+		Ok(())
 	}
 
 	pub fn default_for_role(role: Role) -> Self {
@@ -131,4 +162,110 @@ pub trait IntoWalletAddress {
 	}
 
 	fn address(&self, network: &str) -> WalletAddress;
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_derivation_path_valid_all_roles() {
+		for (role_index, expected_role) in [
+			(0, Role::UnshieldedExternal),
+			(1, Role::UnshieldedInternal),
+			(2, Role::Dust),
+			(3, Role::Zswap),
+			(4, Role::Metadata),
+		] {
+			let path = format!("m/44'/2400'/0'/{role_index}/0");
+			let dp = DerivationPath::new(path.clone()).expect("should be valid");
+			assert_eq!(dp.role, expected_role);
+			assert_eq!(dp.path, path);
+		}
+	}
+
+	#[test]
+	fn test_derivation_path_invalid_format_too_few_parts() {
+		let result = DerivationPath::new("m/44'/2400'/0'".to_string());
+		assert!(matches!(result, Err(DerivationPathError::InvalidFormat(_))));
+	}
+
+	#[test]
+	fn test_derivation_path_invalid_format_wrong_prefix() {
+		let result = DerivationPath::new("x/44'/2400'/0'/0/0".to_string());
+		assert!(matches!(result, Err(DerivationPathError::InvalidFormat(_))));
+	}
+
+	#[test]
+	fn test_derivation_path_invalid_role_value() {
+		let result = DerivationPath::new("m/44'/2400'/0'/abc/0".to_string());
+		assert!(matches!(result, Err(DerivationPathError::InvalidRoleValue(_))));
+	}
+
+	#[test]
+	fn test_derivation_path_unknown_role() {
+		let result = DerivationPath::new("m/44'/2400'/0'/5/0".to_string());
+		assert!(matches!(result, Err(DerivationPathError::UnknownRole(5))));
+
+		let result = DerivationPath::new("m/44'/2400'/0'/99/0".to_string());
+		assert!(matches!(result, Err(DerivationPathError::UnknownRole(99))));
+	}
+
+	#[test]
+	fn test_role_try_from_valid() {
+		assert_eq!(Role::try_from(0).unwrap(), Role::UnshieldedExternal);
+		assert_eq!(Role::try_from(1).unwrap(), Role::UnshieldedInternal);
+		assert_eq!(Role::try_from(2).unwrap(), Role::Dust);
+		assert_eq!(Role::try_from(3).unwrap(), Role::Zswap);
+		assert_eq!(Role::try_from(4).unwrap(), Role::Metadata);
+	}
+
+	#[test]
+	fn test_role_try_from_invalid() {
+		assert!(matches!(Role::try_from(5), Err(DerivationPathError::UnknownRole(5))));
+		assert!(matches!(Role::try_from(99), Err(DerivationPathError::UnknownRole(99))));
+		assert!(matches!(
+			Role::try_from(u32::MAX),
+			Err(DerivationPathError::UnknownRole(u32::MAX))
+		));
+	}
+
+	#[test]
+	fn test_validate_role_single_match() {
+		let dp = DerivationPath::default_for_role(Role::Zswap);
+		assert!(dp.validate_role(&[Role::Zswap]).is_ok());
+	}
+
+	#[test]
+	fn test_validate_role_single_mismatch() {
+		let dp = DerivationPath::default_for_role(Role::Dust);
+		let result = dp.validate_role(&[Role::Zswap]);
+		assert!(matches!(result, Err(DerivationPathError::RoleMismatch { .. })));
+	}
+
+	#[test]
+	fn test_validate_role_multiple_accepts_any_match() {
+		let dp_ext = DerivationPath::default_for_role(Role::UnshieldedExternal);
+		assert!(
+			dp_ext
+				.validate_role(&[Role::UnshieldedExternal, Role::UnshieldedInternal])
+				.is_ok()
+		);
+
+		let dp_int = DerivationPath::default_for_role(Role::UnshieldedInternal);
+		assert!(
+			dp_int
+				.validate_role(&[Role::UnshieldedExternal, Role::UnshieldedInternal])
+				.is_ok()
+		);
+	}
+
+	#[test]
+	fn test_validate_role_multiple_rejects_non_match() {
+		let dp = DerivationPath::default_for_role(Role::Dust);
+		assert!(matches!(
+			dp.validate_role(&[Role::UnshieldedExternal, Role::UnshieldedInternal]),
+			Err(DerivationPathError::RoleMismatch { .. })
+		));
+	}
 }

--- a/ledger/helpers/src/versions/common/wallet/shielded.rs
+++ b/ledger/helpers/src/versions/common/wallet/shielded.rs
@@ -14,9 +14,9 @@
 #![cfg(feature = "can-panic")]
 
 use super::super::{
-	CoinPublicKey, DB, DerivationPath, DeriveSeed, Deserializable, EncryptionPublicKey,
-	HRP_CONSTANT, HRP_CREDENTIAL_SHIELDED, HRP_CREDENTIAL_SHIELDED_ESK, HashOutput,
-	IntoWalletAddress, Role, SecretKeys, Seed, Serializable, WalletAddress, WalletSeed,
+	CoinPublicKey, DB, DerivationPath, DerivationPathError, DeriveSeed, Deserializable,
+	EncryptionPublicKey, HRP_CONSTANT, HRP_CREDENTIAL_SHIELDED, HRP_CREDENTIAL_SHIELDED_ESK,
+	HashOutput, IntoWalletAddress, Role, SecretKeys, Seed, Serializable, WalletAddress, WalletSeed,
 	WalletState,
 };
 use bech32::{Bech32m, Hrp};
@@ -67,9 +67,13 @@ impl<D: DB + Clone> ShieldedWallet<D> {
 		Self::from_seed(derived_seed)
 	}
 
-	pub fn from_path(root_seed: WalletSeed, path: &DerivationPath) -> Self {
+	pub fn from_path(
+		root_seed: WalletSeed,
+		path: &DerivationPath,
+	) -> Result<Self, DerivationPathError> {
+		path.validate_role(&[Role::Zswap])?;
 		let derived_seed = Self::derive_seed(root_seed, path);
-		Self::from_seed(derived_seed)
+		Ok(Self::from_seed(derived_seed))
 	}
 
 	pub fn from_pub_keys(

--- a/ledger/helpers/src/versions/common/wallet/unshielded.rs
+++ b/ledger/helpers/src/versions/common/wallet/unshielded.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use super::super::{
-	ArenaKey, DB, DerivationPath, DeriveSeed, Deserializable, HRP_CONSTANT,
+	ArenaKey, DB, DerivationPath, DerivationPathError, DeriveSeed, Deserializable, HRP_CONSTANT,
 	HRP_CREDENTIAL_UNSHIELDED, HashOutput, IntentHash, IntoWalletAddress, Loader, Role,
 	Serializable, SigningKey, Storable, Tagged, UserAddress, VerifyingKey, WalletAddress,
 	WalletSeed, deserialize_untagged, serialize_untagged,
@@ -110,10 +110,13 @@ impl UnshieldedWallet {
 		Self::from_seed(derived_seed)
 	}
 
-	pub fn from_path(root_seed: WalletSeed, path: &DerivationPath) -> Self {
+	pub fn from_path(
+		root_seed: WalletSeed,
+		path: &DerivationPath,
+	) -> Result<Self, DerivationPathError> {
+		path.validate_role(&[Role::UnshieldedExternal, Role::UnshieldedInternal])?;
 		let derived_seed = Self::derive_seed(root_seed, path);
-
-		Self::from_seed(derived_seed)
+		Ok(Self::from_seed(derived_seed))
 	}
 
 	#[cfg(feature = "can-panic")]

--- a/util/toolkit/src/commands/show_viewing_key.rs
+++ b/util/toolkit/src/commands/show_viewing_key.rs
@@ -15,7 +15,9 @@ pub struct ShowViewingKeyArgs {
 pub fn execute(args: ShowViewingKeyArgs) -> String {
 	let derivation_path = DerivationPath::default_for_role(Role::Zswap);
 
-	ShieldedWallet::<DefaultDB>::from_path(args.seed, &derivation_path).viewing_key(&args.network)
+	ShieldedWallet::<DefaultDB>::from_path(args.seed, &derivation_path)
+		.expect("invalid Zswap derivation path")
+		.viewing_key(&args.network)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Overview

`DerivationPath::new` accepted arbitrary `u32` role values and panicked on invalid ones instead of returning an error. Additionally, wallet `from_path` constructors (`ShieldedWallet`, `DustWallet`, `UnshieldedWallet`) accepted any `DerivationPath` without validating that the role matched the wallet type — e.g. a `DustWallet` could be constructed with a `Zswap` role path, silently deriving keys under the wrong path and potentially making funds unrecoverable.

### Changes

- **`DerivationPath::new`** now returns `Result<Self, DerivationPathError>` instead of panicking on invalid formats, non-numeric roles, or unknown role indices.
- **`DerivationPathError`** enum added with variants: `InvalidFormat`, `InvalidRoleValue`, `UnknownRole`, `RoleMismatch`.
- **`TryFrom<u32>` for `Role`** extracts role-index-to-variant mapping into a proper trait impl.
- **`DerivationPath::validate_role(&[Role])`** validates the path's role against a set of expected roles.
- **Wallet `from_path` methods** now return `Result<Self, DerivationPathError>` and validate the role before deriving:
  - `ShieldedWallet`: accepts `Zswap`
  - `DustWallet`: accepts `Dust`
  - `UnshieldedWallet`: accepts `UnshieldedExternal` or `UnshieldedInternal`
  
  Closes: https://shielded.atlassian.net/browse/PM-20014

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

10 new unit tests added covering:
- Valid/invalid derivation path formats
- Unknown and non-numeric role values
- `Role::TryFrom<u32>` for all valid indices and invalid ones
- `validate_role` with single and multiple expected roles (match and mismatch)

cargo test -p midnight-node-ledger-helpers --features can-panic  # 68 passed
cargo test -p midnight-node-toolkit                               # all passed
cargo clippy -p midnight-node-ledger-helpers --features can-panic # clean



- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links