### PR TITLE
fix: obscuring secrets toolkit

### DIFF
--- a/ledger/helpers/src/versions/common/types.rs
+++ b/ledger/helpers/src/versions/common/types.rs
@@ -23,17 +23,34 @@ use rand::RngCore;
 use std::str::FromStr;
 use std::{
 	collections::HashMap,
+	fmt,
 	marker::PhantomData,
 	time::{SystemTime, UNIX_EPOCH},
 };
 use subxt_signer::{SecretUri, SecretUriError, sr25519};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Storable, Serializable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Storable, Serializable)]
 #[storable(base)]
 pub enum WalletSeed {
 	Short([u8; 16]),
 	Medium([u8; 32]),
 	Long([u8; 64]),
+}
+
+impl fmt::Debug for WalletSeed {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Short(_) => write!(f, "WalletSeed::Short(REDACTED)"),
+			Self::Medium(_) => write!(f, "WalletSeed::Medium(REDACTED)"),
+			Self::Long(_) => write!(f, "WalletSeed::Long(REDACTED)"),
+		}
+	}
+}
+
+impl fmt::Display for WalletSeed {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "REDACTED")
+	}
 }
 
 #[derive(Clone, Debug, thiserror::Error)]

--- a/ledger/helpers/src/versions/common/wallet/unshielded.rs
+++ b/ledger/helpers/src/versions/common/wallet/unshielded.rs
@@ -65,13 +65,23 @@ impl std::str::FromStr for UtxoId {
 	}
 }
 
-#[derive(Clone, Debug, Storable, Serializable)]
+#[derive(Clone, Storable, Serializable)]
 #[tag = "unshielded-wallet"]
 #[storable(base)]
 pub struct UnshieldedWallet {
 	pub user_address: UserAddress,
 	pub verifying_key: Option<VerifyingKey>,
 	signing_key: Option<SigningKey>,
+}
+
+impl std::fmt::Debug for UnshieldedWallet {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("UnshieldedWallet")
+			.field("user_address", &self.user_address)
+			.field("verifying_key", &self.verifying_key)
+			.field("signing_key", &"REDACTED")
+			.finish()
+	}
 }
 
 impl DeriveSeed for UnshieldedWallet {}


### PR DESCRIPTION
# Overview

A security audit identified that signing keys and wallet seeds were being exposed through derived `Debug` implementations — leaking raw secret bytes into logs and error messages.

This PR replaces derived `Debug` with custom implementations that redact secret material, following the existing pattern established by `ViewingKey` in the indexer (`ViewingKey(REDACTED)`).

Closes: https://shielded.atlassian.net/browse/PM-21956

## Changes

- **`WalletSeed`** (`ledger/helpers/src/versions/common/types.rs`): Replaced derived `Debug` with a custom impl that prints `WalletSeed::Short(REDACTED)` / `Medium` / `Long`. Added a `Display` impl that prints `REDACTED` to prevent future leakage via `{}` format strings.
- **`UnshieldedWallet`** (`ledger/helpers/src/versions/common/wallet/unshielded.rs`): Replaced derived `Debug` with a custom impl that prints `user_address` and `verifying_key` normally but redacts `signing_key`.

These changes automatically fix the following log statements that were printing seed bytes:
- `util/toolkit/src/commands/generate_intent.rs` — `log::info!("...seed {:?}", wallet_seed)`
- `util/toolkit/src/commands/dust_balance.rs` — `log::info!("...seed {:?}", args.seed)`
- `util/toolkit/src/commands/show_wallet.rs` — `log::info!("...seed {:?}", seed)`

### Note on Zeroize/ZeroizeOnDrop

The audit also flagged that `WalletSeed` is a `Copy` enum with no zeroize handling, and that secret material is converted into ordinary heap buffers (`String`, `Vec<u8>`) that are not zeroized on drop.

This has been intentionally deferred because:

1. **`Copy` and `ZeroizeOnDrop` are incompatible** — removing `Copy` from `WalletSeed` would be a large breaking change across dozens of files.
2. **The toolkit is a short-lived CLI tool**, not a long-running wallet or signing service. The process exits quickly and the OS reclaims all memory.
3. **The threat model is narrow** — exploiting unzeroized memory requires process-level memory access (core dumps, `/proc/pid/mem`), at which point the attacker likely already has access to the seed input itself (CLI args, env vars, files).
4. **Even with `zeroize`, coverage is imperfect** — intermediate copies in registers or by third-party libs (bip32, hex encoding) are outside our control.

The Debug/logging fixes in this PR address the higher-impact vector (persistent, searchable logs), while zeroize remains a defense-in-depth measure that can be pursued separately if the toolkit threat model evolves.

## TODO before merging

- [ ] Ready

## Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## Testing Evidence

- `cargo check` passes cleanly
- No API changes — only trait impl swap (derived to manual), fully backward-compatible
- No tests assert on `Debug` output of `WalletSeed` or `UnshieldedWallet`

- [ ] Additional tests are provided (if possible)

## Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links