### PR TITLE
perf: add weight check to pre_dispatch to quickly dismiss big transactions during block building

### DIFF
--- a/changes/changed/pre-dispatch-weight-check.md
+++ b/changes/changed/pre-dispatch-weight-check.md
@@ -1,0 +1,11 @@
+#node
+# Early weight check in midnight pallet pre_dispatch
+
+Add an early block weight check in `ValidateUnsigned::pre_dispatch` before
+expensive ledger validation. Substrate's `Bare` extrinsic path runs the pallet's
+`pre_dispatch` before the `CheckWeight` extension, which means transactions that
+won't fit in the block still undergo costly ledger validation before being
+rejected. The new check mirrors the logic in `calculate_consumed_weight` and
+exits early with `ExhaustsResources` when the block is full.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1305

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -43,7 +43,7 @@ pub mod migrations;
 pub mod pallet {
 	use crate::alloc::string::ToString;
 	use frame_support::dispatch::GetDispatchInfo;
-	use frame_support::{pallet_prelude::*, sp_runtime::traits::UniqueSaturatedInto};
+	use frame_support::{ensure, pallet_prelude::*, sp_runtime::traits::UniqueSaturatedInto};
 	use frame_system::pallet_prelude::*;
 	use midnight_primitives::LedgerBlockContextProvider;
 	use scale_info::prelude::{string::String, vec::Vec};
@@ -549,11 +549,8 @@ pub mod pallet {
 			let block_limit_hit = all_weight.total().any_gt(maximum_weight.max_block)
 				&& per_class.any_gt(reserved_limit);
 
-			if class_limit_hit || block_limit_hit {
-				Err(InvalidTransaction::ExhaustsResources.into())
-			} else {
-				Ok(())
-			}
+			ensure!(!class_limit_hit && !block_limit_hit, InvalidTransaction::ExhaustsResources);
+			Ok(())
 		}
 
 		//todo annotate with exclude for non test runs

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -42,6 +42,7 @@ pub mod migrations;
 #[frame_support::pallet]
 pub mod pallet {
 	use crate::alloc::string::ToString;
+	use frame_support::dispatch::GetDispatchInfo;
 	use frame_support::{pallet_prelude::*, sp_runtime::traits::UniqueSaturatedInto};
 	use frame_system::pallet_prelude::*;
 	use midnight_primitives::LedgerBlockContextProvider;
@@ -457,6 +458,11 @@ pub mod pallet {
 				return Err(Self::invalid_transaction(Default::default()));
 			};
 
+			// Substrate's Bare extrinsic path runs pallet pre_dispatch before the
+			// CheckWeight extension, so we pre-check here to avoid expensive ledger
+			// validation for txs that won't fit in the block.
+			Self::check_weight(call)?;
+
 			let block_context = Self::get_block_context();
 			let state_key = StateKey::<T>::get();
 			let runtime_version = <frame_system::Pallet<T>>::runtime_version().spec_version;
@@ -512,6 +518,43 @@ pub mod pallet {
 			LedgerApi::get_zswap_chain_state(&state_key, contract_address)
 		}
 		// grcov-excl-stop
+
+		/// Early block weight check to avoid expensive ledger validation for
+		/// transactions that won't fit. It is slightly more relaxed than
+		/// `frame_system::extensions::check_weight::calculate_consumed_weight`.
+		/// Assumes that Dispatch class has both max_total and reserved limits set.
+		/// Assumes that `frame_system::extensions::check_weight::calculate_consumed_weight` is
+		/// called later
+		fn check_weight(call: &Call<T>) -> Result<(), TransactionValidityError> {
+			let info = call.get_dispatch_info();
+			let maximum_weight = T::BlockWeights::get();
+			let mut all_weight = <frame_system::Pallet<T>>::block_weight();
+
+			let limit_per_class = maximum_weight.get(info.class);
+			let extrinsic_weight =
+				info.total_weight().saturating_add(limit_per_class.base_extrinsic);
+
+			let (max_total_limit, reserved_limit) =
+				match (limit_per_class.max_total, limit_per_class.reserved) {
+					(Some(max_total), Some(reserved)) => (max_total, reserved),
+					_ => return Ok(()),
+				};
+
+			all_weight
+				.checked_accrue(extrinsic_weight, info.class)
+				.map_err(|_| InvalidTransaction::ExhaustsResources)?;
+
+			let per_class = *all_weight.get(info.class);
+			let class_limit_hit = per_class.any_gt(max_total_limit);
+			let block_limit_hit = all_weight.total().any_gt(maximum_weight.max_block)
+				&& per_class.any_gt(reserved_limit);
+
+			if class_limit_hit || block_limit_hit {
+				Err(InvalidTransaction::ExhaustsResources.into())
+			} else {
+				Ok(())
+			}
+		}
 
 		//todo annotate with exclude for non test runs
 		fn invalid_transaction(error_code: u8) -> TransactionValidityError {


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

Weight check in pre_dispatch allows to save on repeating costly validations for too big transactions.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

Run on the local node and confirmed that it indeed reject too big transactions earlier

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [x] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
