### PR TITLE
fix: local-env uses tree hash to resolve image

### DIFF
--- a/local-environment/.envrc
+++ b/local-environment/.envrc
@@ -19,7 +19,7 @@ export ARCHITECTURE=${ARCHITECTURE:-linux/${ARCH}}
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 export MIDNIGHT_RESERVE_CONTRACTS_PATH="${GIT_ROOT}/../midnight-reserve-contracts"
 NODE_VERSION="$(cat ${GIT_ROOT}/node/Cargo.toml | grep -m 1 version | sed 's/version *= *"\([^\"]*\)".*/\1/')"
-GIT_SHORT_TAG="$(git rev-parse --short=8 HEAD)"
+GIT_SHORT_TAG="$(git rev-parse HEAD^{tree} | cut -c1-12)"
 
 export MIDNIGHT_NODE_TAG="${MIDNIGHT_NODE_TAG:-${NODE_VERSION}-${GIT_SHORT_TAG}}"
 export MIDNIGHT_NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:${MIDNIGHT_NODE_TAG}-${ARCH}"


### PR DESCRIPTION
# Overview

fixes:
- local-env's .envrc now uses tree hash to resolve correct image to use, not commit hash

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
