### PR TITLE
ci: split long running job

### DIFF
--- a/.github/workflows/continuous-integration-checks.yml
+++ b/.github/workflows/continuous-integration-checks.yml
@@ -68,12 +68,19 @@ jobs:
           . ./.envrc && earthly --ci +check
 
   feature-unification:
-    name: Feature Unification Check
+    name: Feature Unification Check (shard ${{ matrix.shard }}/2)
+    # Only run at PR time — skipped in merge queue and on push to main.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
     env:
       FORCE_COLOR: 1
+      SHARDS: 2
     steps:
       - name: Checkout node repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -115,5 +122,7 @@ jobs:
 
       - name: Run feature unification check
         if: steps.check_images.outputs.skip_check != 'true'
+        env:
+          SHARD: ${{ matrix.shard }}
         run: |
-          . ./.envrc && earthly --ci +check-feature-unification
+          . ./.envrc && earthly --ci +check-feature-unification --SHARD="$SHARD" --SHARDS="$SHARDS"

--- a/Earthfile
+++ b/Earthfile
@@ -800,8 +800,13 @@ check-rust:
 
 # check-feature-unification verifies each crate compiles without dev-deps,
 # catching issues where workspace feature unification masks missing dependencies.
+# Shardable: pass --SHARD=<i> --SHARDS=<n> to check a deterministic subset of
+# workspace crates (partitioned by cksum(name) % SHARDS). Defaults run the full
+# workspace in a single pass.
 check-feature-unification:
     FROM +check-rust-prepare
+    ARG SHARD=0
+    ARG SHARDS=1
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
     COPY --keep-ts --dir \
@@ -812,7 +817,21 @@ check-feature-unification:
     ENV SKIP_WASM_BUILD=1
     ENV CARGO_INCREMENTAL=0
     RUN cargo binstall --no-confirm cargo-hack
-    RUN cargo hack check --workspace --no-dev-deps
+    RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
+    RUN set -eu; \
+        if [ "$SHARDS" = "1" ]; then \
+            cargo hack check --workspace --no-dev-deps; \
+        else \
+            names=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[].name'); \
+            pkgs=""; \
+            for n in $names; do \
+                h=$(printf '%s' "$n" | cksum | awk '{print $1}'); \
+                if [ "$((h % SHARDS))" = "$SHARD" ]; then pkgs="$pkgs -p $n"; fi; \
+            done; \
+            echo "Shard ${SHARD}/${SHARDS}:${pkgs}"; \
+            # shellcheck disable=SC2086
+            cargo hack check --no-dev-deps $pkgs; \
+        fi
 
 # check-metadata confirms that metadata in the repo matches a given node image
 check-metadata:


### PR DESCRIPTION
# Overview

Splits the `Feature Unification Check` CI job into 2 parallel shards to reduce wall-clock time. Workspace crates are partitioned deterministically by `cksum(name) % SHARDS`, so each shard checks a stable subset.

Also restricts the job to `pull_request` events only — it's skipped in the merge queue and on push to `main` - as long as this passes at the PR level that's enough checks (so total cpu used will be reduced with this change). No cost impact as it's running on github standard runners.

## Changes

- `Earthfile`: `+check-feature-unification` now accepts `--SHARD` / `--SHARDS` args. Default (`SHARDS=1`) preserves existing behaviour (full workspace in one pass). When sharded, uses `cargo metadata` + `jq` to enumerate workspace crates and runs `cargo hack check --no-dev-deps -p <subset>`.
- `.github/workflows/continuous-integration-checks.yml`: matrix over `shard: [0, 1]` with `SHARDS=2`; job name includes shard index; `fail-fast: false` so both shards report independently.

## 📌 Submission Checklist

- [x] Changes are backward-compatible (default `SHARDS=1` is unchanged)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant) — Earthfile comment documents the new args
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Observe CI on this PR: two `Feature Unification Check (shard 0/2)` and `(shard 1/2)` jobs run in parallel.

## 🔱 Fork Strategy

- [x] N/A (CI-only)