### PR TITLE
chore: set default issue types on issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,6 +4,7 @@ about: Submit a bug report
 title: ""
 labels: midnight-template-repo, public
 assignees: ""
+type: Bug
 ---
 
 ### Context & versions:

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -4,6 +4,7 @@ about: Report a problem with the documentation
 title: ""
 labels: midnight-template-repo, public, documentation
 assignees: ""
+type: Task
 ---
 
 Documentation Improvement: Clearly describe the improvement requested for existing content and/or raise missing areas of documentation and provide details for what should be included.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,6 +4,7 @@ about: Submit a proposal for a new feature
 title: ""
 labels: midnight-template-repo, public
 assignees: ""
+type: Feature
 ---
 
 Feature Request: Clearly describe your feature, its benefits, and most important the expected outcome. This helps us analyze the proposed solution and develop alternatives

--- a/.github/ISSUE_TEMPLATE/node-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/node-release-checklist.md
@@ -4,7 +4,7 @@ about: Things to check when releasing node
 title: Node release x.y.z
 labels: ''
 assignees: ''
-
+type: Task
 ---
 ---
 **Release captain**: (tag a team member)


### PR DESCRIPTION
Sets the `type` field on all issue templates so new issues get a proper issue type by default.

- Bug report → Bug
- Feature request → Feature
- Documentation improvement → Task
- Node release checklist → Task