### PR TITLE
chore: bump ledger patches to storage-core-1.2.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "anyhow",
  "atomic-write-file",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "midnight-coin-structure"
 version = "2.0.1"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "fake",
  "lazy_static",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "midnight-ledger"
 version = "8.1.0-rc.1"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "midnight-ledger-static"
 version = "9.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-runtime"
 version = "3.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "derive-where",
  "enum_index",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-state"
 version = "3.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "derive-where",
  "fake",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-vm"
 version = "3.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "derive-where",
  "fake",
@@ -8185,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize"
 version = "1.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "crypto",
  "konst",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize-macros"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage"
 version = "2.0.1"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "crypto",
  "derive-where",
@@ -8244,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-core"
 version = "1.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "archery",
  "crypto",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-macros"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "midnight-serialize-macros",
  "proc-macro2",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "midnight-transient-crypto"
 version = "2.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -8338,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "midnight-zkir"
 version = "2.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "anyhow",
  "const-hex",
@@ -8386,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "midnight-zswap"
 version = "8.1.0-rc.1"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-8.1.0-rc.1#a553d042c818566cf70be1b571105341cec864e9"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "derive-where",
  "fake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,22 +409,22 @@ zeroize = { opt-level = 3 }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/midnightntwrk/rust-yamux", branch = "yamux-v0.12.2" }
-midnight-ledger = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-zswap = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-transient-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-onchain-vm = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-onchain-state = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-onchain-runtime = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-serialize = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-storage-core = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-coin-structure = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-base-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-base-crypto-derive = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-zkir = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-storage = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-serialize-macros = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-ledger-static = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
-midnight-storage-macros = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-8.1.0-rc.1" }
+midnight-ledger = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-zswap = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-transient-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-onchain-vm = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-onchain-state = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-onchain-runtime = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-serialize = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-storage-core = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-coin-structure = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-base-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-base-crypto-derive = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-zkir = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-storage = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-serialize-macros = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-ledger-static = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-storage-macros = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
 
 [workspace.metadata.cargo-shear]
 ignored = []


### PR DESCRIPTION
# Overview

Bumps all 16 ledger-crate patches in `[patch.crates-io]` from `ledger-8.1.0-rc.1` to `storage-core-1.2.0-rc.2` to pick up the storage-core `cache_insert_new_key` fix (ledger PR #433) and the ParityDb Deref feature.

`storage-core-1.2.0-rc.2` is a linear descendant of `ledger-8.1.0-rc.1` on `ledger-8`. The 4 commits between them only touch `storage-core/*`, so the other 15 crates are source-identical at both tags.

All 16 lines move to the same tag because inner ledger crates reference siblings via `path = "../..."`, which bypasses `[patch.crates-io]`; patching only `midnight-storage-core` produces a version skew that fails to compile.

Targets `release/node-1.0.0` so `main` can pick up a proper unified tag (e.g. `ledger-8.1.0-rc.2`) when the ledger team cuts one.

Closes #1358.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: _skipped — dependency tag bump, no user-visible behaviour change_
- [x] If the changes introduce a new feature, I have bumped the node minor version _(N/A)_
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed _(N/A)_
- [x] No new todos introduced

## 🧪 Testing Evidence

`cargo check` clean on `midnight-node-ledger`, `midnight-node-runtime`, `midnight-node`.

Downstream: same bump was integrated in midnight-indexer via PR #1052 and deployed to qanet-blue; indexer has processed 560K+ blocks cleanly with no `cache_insert_new_key` panics.

- [ ] Additional tests are provided (if possible) _(N/A — dependency tag bump)_

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other:
- [ ] N/A

## Links

Closes #1358.
Related: midnight-ledger #433 (upstream fix), midnight-indexer #1052 (same bump on indexer side).