### PR TITLE
fix(ci): add --locked to subxt-cli install to pin transitive deps

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -119,7 +119,7 @@ subxt:
     # RUN cargo install cargo-binstall --version 1.6.9
     COPY Cargo.toml deps.toml
     LET SUBXT_VERSION = "$(cat deps.toml | grep -m 1 subxt | sed 's/subxt *= *"\([^\"]*\)".*/\1/')"
-    RUN cargo install subxt-cli@${SUBXT_VERSION}
+    RUN cargo install subxt-cli@${SUBXT_VERSION} --locked
     ENTRYPOINT ["subxt"]
     SAVE IMAGE localhost/subxt
 


### PR DESCRIPTION
## Summary

`+check-metadata` CI fails on `rustc 1.92.0 is not supported by constant_time_eq@0.4.3 (requires rustc 1.95.0)`. Without `--locked`, `cargo install subxt-cli@0.50.0` resolves transitive deps to the latest semver-compatible versions, and `constant_time_eq 0.4.3` recently bumped its MSRV to 1.95, breaking against the CI's `rust:1.92-trixie` image. `--locked` tells cargo to use subxt-cli's published `Cargo.lock`, pinning a compatible `constant_time_eq`.

Same one-line fix has been filed against `release/node-1.0.0` in #1361. This PR applies it to main so future work doesn't hit the same failure.

## Testing

Rely on this PR's own CI re-run to confirm `+subxt` and `+check-metadata` succeed.

## Links

Companion to #1361 (same fix, release/node-1.0.0 target).

## Checklist

- [x] GPG-signed, DCO signed-off.