### PR TITLE
chore(ci): add DCO config to allow individual remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,5 @@
+require:
+  members: true
+allowRemediationCommits:
+  individual: true
+  thirdParty: false


### PR DESCRIPTION
Adds .github/dco.yml to enable allowRemediationCommits.individual, so authors can fix missing sign-offs (e.g. from GitHub's "Apply suggestion" UI) by adding a remediation commit instead of needing to amend + force-push.

Context: PR #1365 hit this exact problem today — Giles applied my suggestion via the GitHub web UI, which doesn't include Signed-off-by, and the only fix without this config is force-push.