### PR TITLE
fix: duplicated 'permissions' key in yaml

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,14 +14,11 @@ on:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
 
-# no top level default permissions for security reasons
-permissions:
-  contents: read
-
 jobs:
   actionlint:
     name: Lint workflows
     runs-on: ubuntu-latest
+    # no top level default permissions for security reasons
     permissions:
       contents: read
     steps:

--- a/.github/workflows/rebuild-chainspec-bot.yml
+++ b/.github/workflows/rebuild-chainspec-bot.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to rebuild chainspec for'
+        description: "PR number to rebuild chainspec for"
         required: true
       networks:
         description: 'Space-separated network names (e.g., "qanet preview")'
@@ -121,7 +121,7 @@ jobs:
         env:
           NETWORKS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.networks || steps.parse_comment.outputs.networks }}
         run: |
-          ALLOWED=$(ls res/cfg/*.toml | xargs -n1 basename | sed 's/\.toml$//' | grep -v '^default$' | sort)
+          ALLOWED="$(find res -iname '*.toml' -printf '%f\n' | sed 's/\.toml$//' | grep -v -e '^default$' -e '^Cargo$' | sort)"
           for network in $NETWORKS; do
             if ! echo "$ALLOWED" | grep -qx "$network"; then
               echo "::error::Unknown network: $network. Allowed: $(echo $ALLOWED | tr '\n' ' ')"

--- a/.github/workflows/rebuild-chainspec-bot.yml
+++ b/.github/workflows/rebuild-chainspec-bot.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           NETWORKS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.networks || steps.parse_comment.outputs.networks }}
         run: |
-          ALLOWED="$(find res -iname '*.toml' -printf '%f\n' | sed 's/\.toml$//' | grep -v -e '^default$' -e '^Cargo$' | sort)"
+          ALLOWED="$(find res -iname '*.toml' -exec basename {} .toml \; | grep -v -e '^default$' -e '^Cargo$' | sort)"
           for network in $NETWORKS; do
             if ! echo "$ALLOWED" | grep -qx "$network"; then
               echo "::error::Unknown network: $network. Allowed: $(echo $ALLOWED | tr '\n' ' ')"


### PR DESCRIPTION
# Overview

Fixing duplicated key 'permissions' in actionlint.yaml 

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
