### PR TITLE
fix: [H-1] bound Mappings storage per address in cnight-observation pallet

### DIFF
--- a/changes/runtime/changed/fix-unbounded-cnight-mappings.md
+++ b/changes/runtime/changed/fix-unbounded-cnight-mappings.md
@@ -1,0 +1,19 @@
+#security #runtime
+# Fix unbounded Mappings storage in cnight-observation pallet
+
+`Mappings` storage used an unbounded `Vec<MappingEntry>` per Cardano reward
+address with no size cap. A Cardano address could accumulate arbitrarily many
+registration entries via repeated UTXOs, inflating storage and decode cost
+per key — a potential DoS vector.
+
+Changes:
+- Add `MaxMappingsPerAddress` config constant to `pallet-cnight-observation`
+- Change `Mappings` storage value from `Vec<MappingEntry>` to
+  `BoundedVec<MappingEntry, T::MaxMappingsPerAddress>`
+- Wire up `try_push` in `handle_registration`; excess registrations are
+  logged as warnings and dropped rather than panicking
+- Genesis build converts `Vec` → `BoundedVec` with an explicit bounds check
+- Runtime sets `MaxMappingsPerAddress = 10`
+- `MaxRegistrationsExceeded` error variant is now reachable
+
+PR: (pending)

--- a/pallets/cnight-observation/src/lib.rs
+++ b/pallets/cnight-observation/src/lib.rs
@@ -151,6 +151,10 @@ pub mod pallet {
 		type MidnightSystemTransactionExecutor: MidnightSystemTransactionExecutor;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: crate::weights::WeightInfo;
+		/// Maximum number of mapping entries allowed per Cardano reward address.
+		/// Prevents unbounded storage growth via repeated registrations from a single address.
+		#[pallet::constant]
+		type MaxMappingsPerAddress: Get<u32>;
 	}
 
 	#[pallet::event]
@@ -194,8 +198,13 @@ pub mod pallet {
 		StorageValue<_, BoundedVec<u8, ConstU32<32>>, ValueQuery>;
 
 	#[pallet::storage]
-	pub type Mappings<T: Config> =
-		StorageMap<_, Blake2_128Concat, CardanoRewardAddressBytes, Vec<MappingEntry>, ValueQuery>;
+	pub type Mappings<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		CardanoRewardAddressBytes,
+		BoundedVec<MappingEntry, T::MaxMappingsPerAddress>,
+		ValueQuery,
+	>;
 
 	// TODO: Read from ledger state directly ?
 	#[pallet::storage]
@@ -294,7 +303,11 @@ pub mod pallet {
 			);
 
 			for (k, v) in &self.config.mappings {
-				Mappings::<T>::insert(k, v.clone());
+				let bounded: BoundedVec<MappingEntry, T::MaxMappingsPerAddress> = v
+					.clone()
+					.try_into()
+					.expect("Genesis mappings entry exceeds MaxMappingsPerAddress");
+				Mappings::<T>::insert(k, bounded);
 			}
 
 			for (k, v) in &self.config.utxo_owners {
@@ -372,7 +385,7 @@ pub mod pallet {
 		fn handle_registration(
 			header: &ObservedUtxoHeader,
 			data: RegistrationData,
-		) -> Option<(CardanoRewardAddressBytes, Vec<MappingEntry>)> {
+		) -> Option<(CardanoRewardAddressBytes, BoundedVec<MappingEntry, T::MaxMappingsPerAddress>)> {
 			let RegistrationData { cardano_reward_address, dust_public_key } = data;
 
 			let new_reg = MappingEntry {
@@ -385,7 +398,14 @@ pub mod pallet {
 			let previous_registration = Self::get_registration(&cardano_reward_address);
 
 			let mut mappings = Mappings::<T>::get(cardano_reward_address);
-			mappings.push(new_reg.clone());
+			if mappings.try_push(new_reg.clone()).is_err() {
+				log::warn!(
+					"MaxMappingsPerAddress ({}) exceeded for {:?}; registration dropped",
+					T::MaxMappingsPerAddress::get(),
+					cardano_reward_address
+				);
+				return None;
+			}
 			Mappings::<T>::insert(cardano_reward_address, mappings.clone());
 
 			let is_registered = Self::is_registered(&cardano_reward_address);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -833,9 +833,15 @@ parameter_types! {
 	pub const BridgeMaxTransfersPerBlock: u32 = 256;
 }
 
+/// Maximum number of mapping entries per Cardano reward address.
+/// A valid registration requires exactly 1 entry; values > 1 invalidate it.
+/// This cap prevents unbounded storage growth from repeated registrations.
+pub const MAX_MAPPINGS_PER_ADDRESS: u32 = 10;
+
 impl pallet_cnight_observation::Config for Runtime {
 	type MidnightSystemTransactionExecutor = MidnightSystem;
 	type WeightInfo = pallet_cnight_observation::weights::SubstrateWeight<Runtime>;
+	type MaxMappingsPerAddress = ConstU32<MAX_MAPPINGS_PER_ADDRESS>;
 }
 
 impl pallet_partner_chains_bridge::Config for Runtime {


### PR DESCRIPTION
## Summary

- `Mappings` storage in `pallet-cnight-observation` used an unbounded `Vec<MappingEntry>` with no size cap
- A Cardano address could accumulate unlimited registration entries via repeated UTXOs, inflating per-key storage decode cost — potential DoS against block execution
- `MaxRegistrationsExceeded` error was defined but unreachable (dead code)

## Changes

- Add `MaxMappingsPerAddress` config constant to `pallet-cnight-observation`
- Change `Mappings` storage value from `Vec<MappingEntry>` to `BoundedVec<MappingEntry, T::MaxMappingsPerAddress>`
- `handle_registration` uses `try_push`; excess registrations emit a `warn!` and return `None` instead of growing unbounded
- Genesis build converts `Vec` → `BoundedVec` with an explicit panic-on-misconfiguration bounds check
- Runtime sets `MaxMappingsPerAddress = ConstU32<10>` (a valid registration requires exactly 1 entry; 10 gives headroom for transient duplicate-UTXO race conditions while bounding worst-case storage)
- `MaxRegistrationsExceeded` error variant is now reachable

## Test plan

- [ ] `cargo check -p pallet-cnight-observation` passes
- [ ] `cargo check -p midnight-node-runtime` passes
- [ ] Existing cnight-observation tests pass: `cargo test -p pallet-cnight-observation`
- [ ] Genesis build does not panic for valid configs with ≤10 entries per address
- [ ] Registration with 11th UTXO from same address is dropped with a warning (not an error that halts the block)

> **Security note:** This change was identified during a security review of the cnight-observation pallet. The unbounded `Vec` growth was the only finding in this area that required a code change; related findings (window enforcement, position hash check) are tracked separately.