### PR TITLE
fix: don't use errornousely committed docker image for midnight-setup

### DIFF
--- a/local-environment/src/networks/local-env/docker-compose.yml
+++ b/local-environment/src/networks/local-env/docker-compose.yml
@@ -451,7 +451,7 @@ services:
 
   midnight-setup:
     container_name: midnight-setup
-    image: ghcr.io/midnightntwrk/midnight-node:1.0.0-e99482ac81b6-amd64
+    image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
       ogmios:


### PR DESCRIPTION
# Overview

Reverts accidental change.

Because on my linux I can't build locally that works as `midnight-setup`, I used CI built one for `midnight-setup` and accidently committed. This fixes that mistake.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
