### PR TITLE
feat(toolkit): add --input-utxo pin flag to generate-txs single-tx

### DIFF
--- a/changes/toolkit/added/single-tx-pin-input-utxos.md
+++ b/changes/toolkit/added/single-tx-pin-input-utxos.md
@@ -14,4 +14,4 @@ Useful for deterministic UTXO consolidation when the default
 "first-fit-that-overshoots, else tail" selector picks an unwanted
 subset of a skewed wallet.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1404

--- a/changes/toolkit/added/single-tx-pin-input-utxos.md
+++ b/changes/toolkit/added/single-tx-pin-input-utxos.md
@@ -1,0 +1,17 @@
+#toolkit #generate-txs
+# Pin specific UTXOs as inputs to generate-txs single-tx
+
+Adds a repeatable `--input-utxo <intent_hash_hex>#<output_no>` flag to
+`generate-txs single-tx`. When provided, the toolkit skips its built-in
+greedy coin selection for the unshielded transfer and uses exactly the
+listed UTXOs as inputs. The summed value must cover
+`--unshielded-amount * <destinations>`; any excess becomes change back
+to the source wallet. Missing UTXOs (wrong owner, wrong token, or not
+in the wallet's current state) produce an error instead of silently
+falling back to the default selector.
+
+Useful for deterministic UTXO consolidation when the default
+"first-fit-that-overshoots, else tail" selector picks an unwanted
+subset of a skewed wallet.
+
+PR:

--- a/ledger/helpers/src/versions/common/utxo_spend.rs
+++ b/ledger/helpers/src/versions/common/utxo_spend.rs
@@ -153,13 +153,7 @@ impl UtxoSpendInfo<WalletSeed> {
 								seed,
 							}))
 						})?;
-					total = total.checked_add(utxo.0.value).ok_or(
-						UtxoSelectionError::InsufficientBalance {
-							required: required_value,
-							token_type,
-							seed,
-						},
-					)?;
+					total = total.saturating_add(utxo.0.value);
 					selected.push(UtxoSpendInfo {
 						value: utxo.0.value,
 						owner: seed,

--- a/ledger/helpers/src/versions/common/utxo_spend.rs
+++ b/ledger/helpers/src/versions/common/utxo_spend.rs
@@ -12,11 +12,19 @@
 // limitations under the License.
 
 use super::{
-	DB, IntentHash, LedgerContext, SigningKey, Sp, UnshieldedTokenType, Utxo, UtxoSpend, Wallet,
-	WalletSeed,
+	DB, IntentHash, LedgerContext, SigningKey, Sp, UnshieldedTokenType, Utxo, UtxoId, UtxoSpend,
+	Wallet, WalletSeed,
 };
 use itertools::Itertools;
 use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct PinnedUtxoNotFound {
+	pub intent_hash: IntentHash,
+	pub output_no: u32,
+	pub token_type: UnshieldedTokenType,
+	pub seed: WalletSeed,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum UtxoSelectionError {
@@ -24,6 +32,8 @@ pub enum UtxoSelectionError {
 	InsufficientBalance { required: u128, token_type: UnshieldedTokenType, seed: WalletSeed },
 	#[error("no UTXO of token {token_type:?} with value >= {min_value} for seed {seed:?}")]
 	NoMatchingUtxo { min_value: u128, token_type: UnshieldedTokenType, seed: WalletSeed },
+	#[error("pinned UTXO not found: {0:?}")]
+	PinnedUtxoNotFound(Box<PinnedUtxoNotFound>),
 }
 
 pub struct UtxoSpendInfo<O> {
@@ -103,6 +113,69 @@ impl UtxoSpendInfo<WalletSeed> {
 						seed,
 					},
 				)
+			})
+		})
+	}
+
+	/// Look up a specific set of UTXOs (by intent_hash + output_no) belonging to `seed`
+	/// and `token_type`, and return them as `UtxoSpendInfo` together with the change
+	/// (sum - required). Errors if any requested UTXO is missing from the wallet or
+	/// if the pinned sum is below `required_value`.
+	pub fn utxos_by_ids<D: DB + Clone>(
+		context: Arc<LedgerContext<D>>,
+		seed: WalletSeed,
+		required_value: u128,
+		token_type: UnshieldedTokenType,
+		utxo_ids: &[UtxoId],
+	) -> Result<(Vec<UtxoSpendInfo<WalletSeed>>, u128), UtxoSelectionError> {
+		context.with_ledger_state(|ledger_state| {
+			context.with_wallet_from_seed(seed, |wallet| {
+				let owner = wallet.unshielded.signing_key().verifying_key();
+				let mut selected: Vec<UtxoSpendInfo<WalletSeed>> =
+					Vec::with_capacity(utxo_ids.len());
+				let mut total: u128 = 0;
+				for &UtxoId { intent_hash, output_number } in utxo_ids {
+					let utxo = ledger_state
+						.utxo
+						.utxos
+						.iter()
+						.find(|utxo| {
+							utxo.0.intent_hash == intent_hash
+								&& utxo.0.output_no == output_number
+								&& utxo.0.type_ == token_type
+								&& utxo.0.owner == owner.clone().into()
+						})
+						.ok_or_else(|| {
+							UtxoSelectionError::PinnedUtxoNotFound(Box::new(PinnedUtxoNotFound {
+								intent_hash,
+								output_no: output_number,
+								token_type,
+								seed,
+							}))
+						})?;
+					total = total.checked_add(utxo.0.value).ok_or(
+						UtxoSelectionError::InsufficientBalance {
+							required: required_value,
+							token_type,
+							seed,
+						},
+					)?;
+					selected.push(UtxoSpendInfo {
+						value: utxo.0.value,
+						owner: seed,
+						token_type: utxo.0.type_,
+						intent_hash: Some(utxo.0.intent_hash),
+						output_number: Some(utxo.0.output_no),
+					});
+				}
+				let change = total.checked_sub(required_value).ok_or(
+					UtxoSelectionError::InsufficientBalance {
+						required: required_value,
+						token_type,
+						seed,
+					},
+				)?;
+				Ok((selected, change))
 			})
 		})
 	}

--- a/util/toolkit/src/commands/generate_txs.rs
+++ b/util/toolkit/src/commands/generate_txs.rs
@@ -146,6 +146,7 @@ mod tests {
 			)
 			.unwrap(),
 		],
+		input_utxos: vec![],
 		rng_seed: None,
 	}), ["genesis/genesis_block_undeployed.mn"]) =>
 	   matches Ok(..);

--- a/util/toolkit/src/tx_generator/builder/builders/common/batch_single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/batch_single_tx.rs
@@ -108,6 +108,7 @@ impl BatchSingleTxBuilder {
 				vec![dest_wallet],
 				amount,
 				token_type,
+				&[],
 			)?;
 			tx_info.set_intents(intents);
 		}

--- a/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
@@ -11,7 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, convert::Infallible, sync::Arc};
+use std::{
+	collections::{HashMap, HashSet},
+	convert::Infallible,
+	sync::Arc,
+};
 
 use super::ledger_helpers_local::{
 	BuildInput, BuildIntent, BuildOutput, BuildUtxoOutput, BuildUtxoSpend, DefaultDB,
@@ -67,7 +71,14 @@ impl SingleTxBuilder {
 				.iter()
 				.map(convert_wallet_address)
 				.collect(),
-			input_utxos: args.input_utxos.iter().map(convert_utxo_id).collect(),
+			input_utxos: {
+				let mut seen: HashSet<([u8; 32], u32)> = HashSet::new();
+				args.input_utxos
+					.iter()
+					.filter(|id| seen.insert((id.intent_hash.0.0, id.output_number)))
+					.map(convert_utxo_id)
+					.collect()
+			},
 			rng_seed: args.rng_seed,
 		}
 	}

--- a/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
@@ -153,7 +153,9 @@ impl BuildTxs for SingleTxBuilder {
 				self.unshielded_token_type,
 				&self.input_utxos,
 			)
-			.expect("insufficient UTXOs for transfer");
+			.unwrap_or_else(|error| {
+				panic!("failed to select unshielded UTXOs for transfer: {error}")
+			});
 			tx_info.set_intents(intents);
 		}
 

--- a/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
@@ -17,7 +17,7 @@ use super::ledger_helpers_local::{
 	BuildInput, BuildIntent, BuildOutput, BuildUtxoOutput, BuildUtxoSpend, DefaultDB,
 	FromContext as _, InputInfo, IntentInfo, LedgerContext, OfferInfo, OutputInfo, ProofProvider,
 	Segment, ShieldedCoinSelectionError, ShieldedTokenType, ShieldedWallet, StandardTrasactionInfo,
-	TransactionWithContext, UnshieldedOfferInfo, UnshieldedTokenType, UnshieldedWallet,
+	TransactionWithContext, UnshieldedOfferInfo, UnshieldedTokenType, UnshieldedWallet, UtxoId,
 	UtxoOutputInfo, UtxoSelectionError, UtxoSpendInfo, WalletAddress, WalletSeed,
 };
 use async_trait::async_trait;
@@ -42,6 +42,7 @@ pub struct SingleTxBuilder {
 	source_seed: WalletSeed,
 	funding_seed: Option<WalletSeed>,
 	destination_address: Vec<WalletAddress>,
+	input_utxos: Vec<UtxoId>,
 	rng_seed: Option<[u8; 32]>,
 }
 
@@ -66,6 +67,7 @@ impl SingleTxBuilder {
 				.iter()
 				.map(convert_wallet_address)
 				.collect(),
+			input_utxos: args.input_utxos.iter().map(convert_utxo_id).collect(),
 			rng_seed: args.rng_seed,
 		}
 	}
@@ -138,6 +140,7 @@ impl BuildTxs for SingleTxBuilder {
 				unshielded_wallets,
 				self.unshielded_amount.unwrap(),
 				self.unshielded_token_type,
+				&self.input_utxos,
 			)
 			.expect("insufficient UTXOs for transfer");
 			tx_info.set_intents(intents);
@@ -208,13 +211,17 @@ pub(crate) fn build_unshielded_intents(
 	output_wallets: Vec<UnshieldedWallet>,
 	amount_to_send_per_output: u128,
 	token_type: UnshieldedTokenType,
+	input_utxos: &[UtxoId],
 ) -> Result<HashMap<u16, Box<dyn BuildIntent<DefaultDB>>>, UtxoSelectionError> {
 	let total_required = amount_to_send_per_output
 		.checked_mul(output_wallets.len() as u128)
 		.expect("unshielded amount overflow");
 
-	let (inputs_info, remaining_nights) =
-		UtxoSpendInfo::utxos_to_cover_value(context, source_seed, total_required, token_type)?;
+	let (inputs_info, remaining_nights) = if input_utxos.is_empty() {
+		UtxoSpendInfo::utxos_to_cover_value(context, source_seed, total_required, token_type)?
+	} else {
+		UtxoSpendInfo::utxos_by_ids(context, source_seed, total_required, token_type, input_utxos)?
+	};
 
 	let inputs_info: Vec<Box<dyn BuildUtxoSpend<DefaultDB>>> = inputs_info
 		.into_iter()

--- a/util/toolkit/src/tx_generator/builder/builders/common/type_convert.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/type_convert.rs
@@ -17,7 +17,8 @@
 //! When compiled through `ledger_7.rs`, these convert through raw bytes/strings.
 
 use super::ledger_helpers_local::{
-	CoinPublicKey, ContractAddress, HashOutput, ShieldedTokenType, UnshieldedTokenType, WalletSeed,
+	CoinPublicKey, ContractAddress, HashOutput, IntentHash, ShieldedTokenType, UnshieldedTokenType,
+	UtxoId, WalletSeed,
 };
 use std::str::FromStr;
 
@@ -52,4 +53,11 @@ pub fn convert_wallet_address(
 ) -> super::ledger_helpers_local::WalletAddress {
 	super::ledger_helpers_local::WalletAddress::from_str(&wa.to_bech32())
 		.expect("wallet address conversion between versions")
+}
+
+pub fn convert_utxo_id(id: &midnight_node_ledger_helpers::UtxoId) -> UtxoId {
+	UtxoId {
+		intent_hash: IntentHash(HashOutput(id.intent_hash.0.0)),
+		output_number: id.output_number,
+	}
 }

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -250,6 +250,12 @@ pub struct SingleTxArgs {
 	/// Destination address, both shielded and unshielded
 	#[arg(long, required = true)]
 	pub destination_address: Vec<WalletAddress>,
+	/// Pin specific wallet UTXOs as inputs to the unshielded transfer. Format:
+	/// <intent_hash_hex>#<output_no>, e.g. abc123…#0. Repeatable. When set, the
+	/// toolkit skips its built-in coin selection and uses exactly these UTXOs;
+	/// their summed value must be >= --unshielded-amount * destinations.
+	#[arg(long = "input-utxo", value_parser = cli::utxo_id_decode)]
+	pub input_utxos: Vec<UtxoId>,
 	#[arg(
         long,
         value_parser = cli::hex_str_decode::<[u8; 32]>,


### PR DESCRIPTION
# Overview

Adds a repeatable `--input-utxo <intent_hash_hex>#<output_no>` flag to
`generate-txs single-tx`. When set, the toolkit skips its built-in coin
selection and uses exactly the listed UTXOs as inputs for the
unshielded transfer; the summed value must cover
`unshielded-amount * destinations`, with the overage returned as change
to the source wallet.

## Motivation

The current unshielded coin selector is a greedy
"first-fit-that-overshoots, else pick the current tail" pass (see
[`UtxoSpendInfo::select_inputs`](../blob/main/ledger/helpers/src/versions/common/utxo_spend.rs)).
On skewed wallets — e.g. one UTXO holding most of the balance with
many dust outputs — this produces surprising selections depending on
the target amount:

- Tiny amount → picks one whale and produces change (UTXO count +1).
- Amount ≈ total-whale → picks many tail elements without ever
  pulling the whale, ending far below the nominal target.
- Amount hitting an exact subset sum → coincidentally picks ~2 UTXOs.

For deterministic UTXO consolidation this is painful. `UtxoSpendInfo`
already carried `intent_hash` and `output_number` fields and the
`BuildUtxoSpend` impl at `utxo_spend.rs:138-140` honours them when set,
so the plumbing existed internally — this PR just surfaces it through
the CLI.

## What changed

- `SingleTxArgs` gains `--input-utxo <UtxoId>` (repeatable). Parser
  and type reuse existing `utxo_id_decode` / `UtxoId` (`hex#n`).
- `UtxoSpendInfo::utxos_by_ids` — new sibling of `utxos_to_cover_value`
  that looks up pinned UTXOs in ledger state, validates owner +
  token-type match, sums values and returns `(Vec<UtxoSpendInfo>, change)`.
- New `UtxoSelectionError::PinnedUtxoNotFound(Box<_>)` for missing
  pins; boxed to keep the enum under clippy's `result_large_err`
  threshold.
- `build_unshielded_intents` branches on whether the pinned list is
  empty: empty → existing behaviour unchanged; non-empty → the new
  pinned path.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `cargo fmt -p midnight-node-toolkit -p midnight-node-ledger-helpers`
- `cargo check -p midnight-node-toolkit`
- `cargo clippy -p midnight-node-toolkit -p midnight-node-ledger-helpers --no-deps -- -D warnings`

Manual repro of the motivating bug is in the PR description above. I
have not yet run end-to-end against a live network — reviewers: please
flag if you want an e2e test added before merging.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: toolkit binary only; no runtime or node-client impact.
- [ ] N/A

## Links

No JIRA ticket — user-requested toolkit ergonomics change.