### PR TITLE
Fix local-environment p2p connectivity

### DIFF
--- a/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-1/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-1/entrypoint.sh
@@ -23,6 +23,7 @@ set -euxo pipefail
   --alice \
   --chain=/shared/chain-spec.json \
   --node-key=0000000000000000000000000000000000000000000000000000000000000001 \
+  --public-addr=/dns/midnight-node-1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
   --base-path=/data \
   --unsafe-rpc-external \
   --rpc-methods=Unsafe \

--- a/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-2/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-2/entrypoint.sh
@@ -23,6 +23,8 @@ set -euxo pipefail
   --bob \
   --chain=/shared/chain-spec.json \
   --node-key=0000000000000000000000000000000000000000000000000000000000000002 \
+  --port=30334 \
+  --public-addr=/dns/midnight-node-2/tcp/30334/p2p/12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD \
   --bootnodes="/dns/midnight-node-1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp" \
   --base-path=/data \
   --unsafe-rpc-external \

--- a/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-3/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-3/entrypoint.sh
@@ -23,6 +23,8 @@ set -euxo pipefail
   --charlie \
   --chain=/shared/chain-spec.json \
   --node-key=0000000000000000000000000000000000000000000000000000000000000003 \
+  --port=30335 \
+  --public-addr=/dns/midnight-node-3/tcp/30335/p2p/12D3KooWSCufgHzV4fCwRijfH2k3abrpAJxTKxEvN1FDuRXA2U9x \
   --bootnodes="/dns/midnight-node-1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp" \
   --base-path=/data \
   --unsafe-rpc-external \

--- a/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-4/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-4/entrypoint.sh
@@ -23,6 +23,8 @@ set -euxo pipefail
   --chain=/shared/chain-spec.json \
   --validator \
   --node-key=0000000000000000000000000000000000000000000000000000000000000004 \
+  --port=30336 \
+  --public-addr=/dns/midnight-node-4/tcp/30336/p2p/12D3KooWSsChzF81YDUKpe9Uk5AHV5oqAaXAcWNSPYgoLauUk4st \
   --bootnodes="/dns/midnight-node-1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp" \
   --base-path=/data \
   --keystore-path=/keystore \

--- a/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-5/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-nodes/midnight-node-5/entrypoint.sh
@@ -23,6 +23,8 @@ set -euxo pipefail
   --chain=/shared/chain-spec.json \
   --validator \
   --node-key=0000000000000000000000000000000000000000000000000000000000000005 \
+  --port=30337 \
+  --public-addr=/dns/midnight-node-5/tcp/30337/p2p/12D3KooWSuTq6MG9gPt7qZqLFKkYrfxMewTZhj9nmRHJkPwzWDG2 \
   --bootnodes="/dns/midnight-node-1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp" \
   --base-path=/data \
   --keystore-path=/keystore \


### PR DESCRIPTION

# Overview

Before `midnight-node-1` had 4 peers but other nodes had only 1 peer.
It was because they used private IP as public address and Kademlia was filtering out private IPs

Additional fix is to match p2p ports to ports that exposed in docker-compose.yml.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
