### PR TITLE
fix: deadlock squished

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "ariadne-simulator"
 version = "1.8.1"
 dependencies = [
@@ -6334,7 +6340,18 @@ checksum = "4381b9b00c55f251f2ebe9473aef7c117e96828def1a7cb3bd3f0f903c6894e9"
 dependencies = [
  "const_panic",
  "konst_kernel",
- "konst_proc_macros",
+ "konst_proc_macros 0.3.10",
+ "typewit",
+]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros 0.4.1",
  "typewit",
 ]
 
@@ -6352,6 +6369,12 @@ name = "konst_proc_macros"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00af7901ba50898c9e545c24d5c580c96a982298134e8037d8978b6594782c07"
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "kvdb"
@@ -7921,7 +7944,7 @@ dependencies = [
  "enum_index_derive",
  "fake",
  "hex",
- "konst",
+ "konst 0.3.16",
  "lazy_static",
  "midnight-base-crypto",
  "midnight-coin-structure",
@@ -7946,7 +7969,7 @@ dependencies = [
  "enum_index_derive",
  "fake",
  "hex",
- "konst",
+ "konst 0.3.16",
  "lazy_static",
  "midnight-base-crypto",
  "midnight-coin-structure",
@@ -8007,7 +8030,7 @@ dependencies = [
  "derive-where",
  "fake",
  "hex",
- "konst",
+ "konst 0.3.16",
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-onchain-state 2.0.1",
@@ -8028,7 +8051,7 @@ dependencies = [
  "derive-where",
  "fake",
  "hex",
- "konst",
+ "konst 0.3.16",
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-onchain-state 3.0.0",
@@ -8193,7 +8216,7 @@ version = "1.1.0"
 source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=serialize-1.1.0-rc.1#fdea5bbdd2759c293843cfc52543436b94673e95"
 dependencies = [
  "crypto",
- "konst",
+ "konst 0.3.16",
  "lazy_static",
  "midnight-serialize-macros",
  "serde",
@@ -8251,15 +8274,15 @@ dependencies = [
 [[package]]
 name = "midnight-storage-core"
 version = "1.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.3#493a8c2a0ae8f3d543388627a81a76ac28e4502b"
 dependencies = [
- "archery",
+ "archery 1.2.2",
  "crypto",
  "derive-where",
  "fake",
  "hex",
  "itertools 0.14.0",
- "konst",
+ "konst 0.4.3",
  "lru 0.16.3",
  "midnight-base-crypto",
  "midnight-serialize",
@@ -12934,7 +12957,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd6ce569b15c331b1e5fd8cf6adb0bf240678b5f0cdc4d0f41e11683f6feba9"
 dependencies = [
- "archery",
+ "archery 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,7 +441,7 @@ midnight-onchain-vm       = { git = "https://github.com/midnightntwrk/midnight-l
 midnight-onchain-state    = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-state-3.1.0-rc.1" }
 midnight-onchain-runtime  = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-runtime-3.1.0-rc.1" }
 midnight-serialize        = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "serialize-1.1.0-rc.1" }
-midnight-storage-core     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }
+midnight-storage-core     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.3" }
 
 [workspace.metadata.cargo-shear]
 ignored = []


### PR DESCRIPTION
## Summary

Bumps `midnight-storage-core` from `1.2.0-rc.2` to `1.2.0-rc.3` to pick up a deadlock fix in the storage layer.

Under load — e.g. registering several dust seeds in close succession — nodes could stall block production indefinitely. The runtime would fail to finish executing a block's extrinsics within the slot deadline, leaving the node stuck at its current best block with no recovery without a restart.

Fixes https://github.com/midnightntwrk/midnight-node/issues/1352

## Test plan

- [ ] Deploy on perfnet and register >3 dust seeds in quick succession; confirm block production continues
- [ ] Confirm no stalls or "Preparing 0.0 bps" stuck states under registration load