### PR TITLE
ci: use docker auth if available to prevent rate limits

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -43,15 +43,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Authenticate to Docker Hub on internal PRs / pushes to avoid the unauthenticated
+      # pull rate limit when WITH DOCKER pulls images like postgres for testcontainers.
+      # Skipped on fork PRs where these secrets are not available.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+
       - name: Run build
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
         run: |
           PUSH_FLAG=""
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             PUSH_FLAG="--push"
           fi
-          . ./.envrc && earthly -P --secret GITHUB_TOKEN="$GITHUB_TOKEN" --strict $PUSH_FLAG --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test +test
+          . ./.envrc && earthly -P \
+            --secret GITHUB_TOKEN="$GITHUB_TOKEN" \
+            --secret DOCKERHUB_USER="$DOCKERHUB_USER" \
+            --secret DOCKERHUB_TOKEN="$DOCKERHUB_TOKEN" \
+            --strict $PUSH_FLAG \
+            --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test +test
 
       - name: Upload test report artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/Earthfile
+++ b/Earthfile
@@ -858,8 +858,14 @@ test:
     # - Midnight Node Toolkit (depends on Node Toolkit (JS) npm packages from midnight-js)
     # - pallet-midnight fixture tests (depend on .mn files that need regenerating with Midnight Node Toolkit)
     # - partner-chains-cardano-offchain are: 1) flaky, 2) long running, 3) test in partner-chains repo, 4) cover functionality used to e2e test partner-chains (non-production)
+    # DOCKERHUB_USER/TOKEN default to empty so local builds and fork PRs (where secrets
+    # aren't exposed) still work — at the cost of unauthenticated pull rate limits.
     WITH DOCKER
-        RUN MIDNIGHT_LEDGER_EXPERIMENTAL=1 cargo nextest r --profile ci --release --workspace --locked \
+        RUN --secret DOCKERHUB_USER= --secret DOCKERHUB_TOKEN= \
+            if [ -n "$DOCKERHUB_TOKEN" ]; then \
+              echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USER" --password-stdin; \
+            fi && \
+            MIDNIGHT_LEDGER_EXPERIMENTAL=1 cargo nextest r --profile ci --release --workspace --locked \
             --exclude midnight-node-toolkit \
             --exclude partner-chains-cardano-offchain \
             -E 'not (test(/^tests::test_get_contract_state$/) | test(/^tests::test_send_mn_transaction$/) | test(/^tests::test_validation_works$/))'


### PR DESCRIPTION
ci: use docker auth if available to prevent rate limits