### PR TITLE
fix(cnight-observation): bound IDP queries by CardanoBlockWindowSize

### DIFF
--- a/changes/node/changed/bound-cnight-observation-window.md
+++ b/changes/node/changed/bound-cnight-observation-window.md
@@ -1,0 +1,8 @@
+#node #cnight-observation #performance
+# Bound cNight observation queries by `CardanoBlockWindowSize`
+
+The cNight observation IDP previously queried cardano-db-sync from `NextCardanoPosition` all the way to the current Cardano tip on every Midnight block. For sparse assets like cNight, this resulted in multi-minute db-sync queries scanning effectively the full Cardano history, blocking block import to ~0.1 bps.
+
+The `CardanoBlockWindowSize` storage value already existed and was already exposed via `CNightObservationApi::get_cardano_block_window_size`, but was unused by the IDP. This change reads the window size in the IDP, threads it through `MidnightCNightObservationDataSource::get_utxos_up_to_capacity`, and clamps the query upper bound to `start + window` in the data source. Each query now scans a bounded window (default 1000 Cardano blocks) instead of the full chain. The genesis-creation tool passes `u32::MAX` to preserve its existing full-history scan.
+
+PR:

--- a/changes/node/changed/bound-cnight-observation-window.md
+++ b/changes/node/changed/bound-cnight-observation-window.md
@@ -5,4 +5,4 @@ The cNight observation IDP previously queried cardano-db-sync from `NextCardanoP
 
 The `CardanoBlockWindowSize` storage value already existed and was already exposed via `CNightObservationApi::get_cardano_block_window_size`, but was unused by the IDP. This change reads the window size in the IDP, threads it through `MidnightCNightObservationDataSource::get_utxos_up_to_capacity`, and clamps the query upper bound to `start + window` in the data source. Each query now scans a bounded window (default 1000 Cardano blocks) instead of the full chain. The genesis-creation tool passes `u32::MAX` to preserve its existing full-history scan.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1432

--- a/node/src/genesis/creation/cnight_genesis.rs
+++ b/node/src/genesis/creation/cnight_genesis.rs
@@ -97,6 +97,7 @@ pub async fn generate_cnight_genesis(
 				&current_position,
 				cardano_tip.clone(),
 				UTXO_CAPACITY,
+				u32::MAX,
 			)
 			.await
 			.map_err(CNightGenesisError::UtxoQueryError)?;

--- a/primitives/mainchain-follower/src/data_source/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation.rs
@@ -59,6 +59,8 @@ pub struct TxPosition {
 pub enum MidnightCNightObservationDataSourceError {
 	#[error("missing reference for block hash `{0}` in db-sync")]
 	MissingBlockReference(McBlockHash),
+	#[error("missing reference for block number `{0}` in db-sync")]
+	MissingBlockNumber(u32),
 	#[error("Error querying database: {0}")]
 	DBQueryError(#[from] sqlx::error::Error),
 	#[error("Error extracting network id from Cardano address")]
@@ -110,6 +112,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 		start_position: &CardanoPosition,
 		current_tip: McBlockHash,
 		tx_capacity: usize,
+		block_window_size: u32,
 	) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>> {
 		let cnight_asset_name = config.cnight_asset_name.as_bytes();
 
@@ -153,11 +156,29 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 
 		// Get end position from cardano block hash
 		let _block_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_block_by_hash");
-		let end: CardanoPosition = crate::db::get_block_by_hash(&self.pool, current_tip.clone())
+		let tip: CardanoPosition = crate::db::get_block_by_hash(&self.pool, current_tip.clone())
 			.await?
 			.ok_or(MidnightCNightObservationDataSourceError::MissingBlockReference(current_tip))?
 			.into();
 		drop(_block_timer);
+
+		// Clamp the upper query bound to `start + block_window_size`. Without this, every
+		// per-block invocation scans from `start_position` to the current Cardano tip, which
+		// for sparse assets (e.g. cNight) means scanning the whole chain on every Midnight
+		// block. The runtime API exposes the window so it can be tuned without a node release.
+		let max_block_no = start_position.block_number.saturating_add(block_window_size);
+		let end: CardanoPosition = if tip.block_number > max_block_no {
+			let _bounded_timer =
+				start_sub_query_timer(&self.metrics_opt, "cnight_get_block_by_block_no");
+			crate::db::get_block_by_block_no(&self.pool, max_block_no)
+				.await?
+				.ok_or(MidnightCNightObservationDataSourceError::MissingBlockNumber(
+					max_block_no,
+				))?
+				.into()
+		} else {
+			tip
+		};
 
 		let (low_bounds, high_bounds) = tokio::try_join!(
 			async {

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_mock.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_mock.rs
@@ -84,6 +84,7 @@ impl MidnightCNightObservationDataSource for CNightObservationDataSourceMock {
 		start: &CardanoPosition,
 		_current_tip: McBlockHash,
 		_capacity: usize,
+		_block_window_size: u32,
 	) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>> {
 		let mut end = start.clone();
 		end.block_number += 1;

--- a/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
@@ -364,6 +364,29 @@ WHERE hash = $1
 	.await
 }
 
+/// Query to get the block by its block number
+pub(crate) async fn get_block_by_block_no(
+	pool: &Pool<Postgres>,
+	block_no: u32,
+) -> Result<Option<Block>, SqlxError> {
+	sqlx::query_as::<_, Block>(
+		r#"
+SELECT
+    block_no AS block_number,
+    hash AS hash,
+    epoch_no AS epoch_number,
+    slot_no AS slot_number,
+    time,
+    tx_count
+FROM block
+WHERE block_no = $1
+"#,
+	)
+	.bind(block_no as i32)
+	.fetch_optional(pool)
+	.await
+}
+
 /// Gets coarse bounds of table ids.
 /// Guarantees:
 /// * tx_id belongs to a transaction made before given block

--- a/primitives/mainchain-follower/src/idp/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/idp/cnight_observation.rs
@@ -25,8 +25,6 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 use std::{error::Error, string::FromUtf8Error, sync::Arc};
 
-pub const DEFAULT_CARDANO_BLOCK_WINDOW_SIZE: u32 = 10000;
-
 pub struct MidnightCNightObservationInherentDataProvider {
 	pub utxos: Vec<ObservedUtxo>,
 	pub next_cardano_position: CardanoPosition,
@@ -105,6 +103,7 @@ impl MidnightCNightObservationInherentDataProvider {
 			.try_into()
 			.map_err(|_| IDPCreationError::AuthTokenAssetNameNotString)?;
 		let cardano_position_start = api.get_next_cardano_position(parent_hash)?;
+		let block_window_size = api.get_cardano_block_window_size(parent_hash)?;
 
 		let config = CNightAddresses {
 			mapping_validator_address,
@@ -123,6 +122,7 @@ impl MidnightCNightObservationInherentDataProvider {
 				&cardano_position_start,
 				mc_hash,
 				utxo_capacity as usize,
+				block_window_size,
 			)
 			.await
 			.map_err(IDPCreationError::DataSourceError)?;

--- a/primitives/mainchain-follower/src/idp/mod.rs
+++ b/primitives/mainchain-follower/src/idp/mod.rs
@@ -22,9 +22,6 @@ pub mod cnight_observation;
 pub mod federated_authority_observation;
 
 #[cfg(feature = "std")]
-pub use cnight_observation::{
-	DEFAULT_CARDANO_BLOCK_WINDOW_SIZE, IDPCreationError,
-	MidnightCNightObservationInherentDataProvider,
-};
+pub use cnight_observation::{IDPCreationError, MidnightCNightObservationInherentDataProvider};
 #[cfg(feature = "std")]
 pub use federated_authority_observation::FederatedAuthorityInherentDataProvider;

--- a/primitives/mainchain-follower/src/lib.rs
+++ b/primitives/mainchain-follower/src/lib.rs
@@ -56,6 +56,7 @@ pub mod inherent_provider {
 			start_position: &CardanoPosition,
 			current_tip: McBlockHash,
 			capacity: usize,
+			block_window_size: u32,
 		) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>>;
 	}
 


### PR DESCRIPTION
# Overview

The cNight observation Inherent Data Provider was querying cardano-db-sync from `NextCardanoPosition` all the way to the current Cardano tip on every Midnight block. For sparse assets like cNight — which appear in only a tiny fraction of Cardano outputs — this caused db-sync queries that effectively scanned the entire Cardano history on every 6-second Midnight block, blocking block import to ~0.1 bps whenever the IDP's start position fell behind tip.

`CardanoBlockWindowSize` already exists as runtime storage on `pallet-cnight-observation` (default 1000) and is already exposed via `CNightObservationApi::get_cardano_block_window_size`, but the IDP never actually read it. The "window" was effectively `[start, ∞)`. This PR finishes that wiring.

## Change

1. `MidnightCNightObservationInherentDataProvider::new` reads `block_window_size` from the runtime API.
2. `MidnightCNightObservationDataSource::get_utxos_up_to_capacity` takes a new `block_window_size: u32` parameter.
3. The data source clamps the query upper bound to `start + block_window_size`. When tip is closer than `start + window`, behavior is unchanged.
4. A new `db::get_block_by_block_no` helper is added to fetch the bounded block for the upper bound.
5. The genesis-creation tool passes `u32::MAX` to preserve its existing full-history scan (it's a one-time, off-the-hot-path job).
6. The previously-unused `DEFAULT_CARDANO_BLOCK_WINDOW_SIZE` constant in the IDP module is removed (the value now comes from the runtime API).

The cap on `end` also tightens the `get_high_bounds` integer-id ranges that constrain `tx`/`tx_out`/`ma_tx_out`/`tx_in` joins, so each query benefits twice from the smaller window.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `SQLX_OFFLINE=true cargo check -p midnight-primitives-mainchain-follower` — clean
- `SKIP_WASM_BUILD=1 SQLX_OFFLINE=true cargo check -p midnight-node` — clean
- `SKIP_WASM_BUILD=1 SQLX_OFFLINE=true cargo clippy -p midnight-primitives-mainchain-follower -p midnight-node` — clean
- `cargo fmt -p midnight-primitives-mainchain-follower -p midnight-node` — no diff

Functional verification on a node that's currently stuck at 0.0–0.1 bps with ~118s db-sync queries: expect query latency to drop to sub-second and `bps` to recover to normal AURA cadence once a node running this build replaces the existing one. The window-size pallet storage is already populated at default 1000 across networks; no chain-spec or genesis change required.

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

This is a node-client behavior change only — the runtime API surface is unchanged (the `get_cardano_block_window_size` runtime API already exists and was already being implemented; only its consumer changed). Old nodes will continue to function (with the existing slow behavior); new nodes will use the bounded window.

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links