### PR TITLE
fix(cnight-observation): bound IDP queries by CardanoBlockWindowSize (0.22.5 backport)

### DIFF
--- a/changes/changed/bound-cnight-observation-window.md
+++ b/changes/changed/bound-cnight-observation-window.md
@@ -1,0 +1,10 @@
+#node #cnight-observation #performance
+# Bound cNight observation queries by `CardanoBlockWindowSize`
+
+The cNight observation IDP previously queried cardano-db-sync from `NextCardanoPosition` all the way to the current Cardano tip on every Midnight block. For sparse assets like cNight, this resulted in multi-minute db-sync queries scanning effectively the full Cardano history, blocking block import to ~0.1 bps.
+
+The `CardanoBlockWindowSize` storage value already existed and was already exposed via `CNightObservationApi::get_cardano_block_window_size`, but was unused by the IDP. This change reads the window size in the IDP, threads it through `MidnightCNightObservationDataSource::get_utxos_up_to_capacity`, and clamps the query upper bound to `start + window` in the data source. Each query now scans a bounded window (default 1000 Cardano blocks) instead of the full chain. The genesis-creation tool passes `u32::MAX` to preserve its existing full-history scan.
+
+Backport of #1432 to release/node-0.22.5.
+
+PR:

--- a/changes/changed/bound-cnight-observation-window.md
+++ b/changes/changed/bound-cnight-observation-window.md
@@ -7,4 +7,4 @@ The `CardanoBlockWindowSize` storage value already existed and was already expos
 
 Backport of #1432 to release/node-0.22.5.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1433

--- a/node/src/genesis/creation/cnight_genesis.rs
+++ b/node/src/genesis/creation/cnight_genesis.rs
@@ -97,6 +97,7 @@ pub async fn generate_cnight_genesis(
 				&current_position,
 				cardano_tip.clone(),
 				UTXO_CAPACITY,
+				u32::MAX,
 			)
 			.await
 			.map_err(CNightGenesisError::UtxoQueryError)?;

--- a/primitives/mainchain-follower/src/data_source/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation.rs
@@ -59,6 +59,8 @@ pub struct TxPosition {
 pub enum MidnightCNightObservationDataSourceError {
 	#[error("missing reference for block hash `{0}` in db-sync")]
 	MissingBlockReference(McBlockHash),
+	#[error("missing reference for block number `{0}` in db-sync")]
+	MissingBlockNumber(u32),
 	#[error("Error querying database: {0}")]
 	DBQueryError(#[from] sqlx::error::Error),
 	#[error("Error extracting network id from Cardano address")]
@@ -106,6 +108,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 		start_position: &CardanoPosition,
 		current_tip: McBlockHash,
 		tx_capacity: usize,
+		block_window_size: u32,
 	) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>> {
 		let cnight_asset_name = config.cnight_asset_name.as_bytes();
 
@@ -148,10 +151,26 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 			.await?;
 
 		// Get end position from cardano block hash
-		let end: CardanoPosition = crate::db::get_block_by_hash(&self.pool, current_tip.clone())
+		let tip: CardanoPosition = crate::db::get_block_by_hash(&self.pool, current_tip.clone())
 			.await?
 			.ok_or(MidnightCNightObservationDataSourceError::MissingBlockReference(current_tip))?
 			.into();
+
+		// Clamp the upper query bound to `start + block_window_size`. Without this, every
+		// per-block invocation scans from `start_position` to the current Cardano tip, which
+		// for sparse assets (e.g. cNight) means scanning the whole chain on every Midnight
+		// block. The runtime API exposes the window so it can be tuned without a node release.
+		let max_block_no = start_position.block_number.saturating_add(block_window_size);
+		let end: CardanoPosition = if tip.block_number > max_block_no {
+			crate::db::get_block_by_block_no(&self.pool, max_block_no)
+				.await?
+				.ok_or(MidnightCNightObservationDataSourceError::MissingBlockNumber(
+					max_block_no,
+				))?
+				.into()
+		} else {
+			tip
+		};
 
 		let (low_bounds, high_bounds) = tokio::try_join!(
 			async {

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_mock.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_mock.rs
@@ -84,6 +84,7 @@ impl MidnightCNightObservationDataSource for CNightObservationDataSourceMock {
 		start: &CardanoPosition,
 		_current_tip: McBlockHash,
 		_capacity: usize,
+		_block_window_size: u32,
 	) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>> {
 		let mut end = start.clone();
 		end.block_number += 1;

--- a/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
@@ -365,6 +365,31 @@ WHERE hash = $1
 	.await
 }
 
+/// Query to get the block by its block number.
+// Uses the runtime-checked sqlx::query_as form so that adding this helper does
+// not require regenerating the offline sqlx cache (no live db-sync at build time).
+pub(crate) async fn get_block_by_block_no(
+	pool: &Pool<Postgres>,
+	block_no: u32,
+) -> Result<Option<Block>, SqlxError> {
+	sqlx::query_as::<_, Block>(
+		r#"
+SELECT
+    block_no AS block_number,
+    hash AS hash,
+    epoch_no AS epoch_number,
+    slot_no AS slot_number,
+    time,
+    tx_count
+FROM block
+WHERE block_no = $1
+"#,
+	)
+	.bind(block_no as i32)
+	.fetch_optional(pool)
+	.await
+}
+
 /// Gets coarse bounds of table ids.
 /// Guarantees:
 /// * tx_id belongs to a transaction made before given block

--- a/primitives/mainchain-follower/src/idp/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/idp/cnight_observation.rs
@@ -25,8 +25,6 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 use std::{error::Error, string::FromUtf8Error, sync::Arc};
 
-pub const DEFAULT_CARDANO_BLOCK_WINDOW_SIZE: u32 = 10000;
-
 pub struct MidnightCNightObservationInherentDataProvider {
 	pub utxos: Vec<ObservedUtxo>,
 	pub next_cardano_position: CardanoPosition,
@@ -105,6 +103,7 @@ impl MidnightCNightObservationInherentDataProvider {
 			.try_into()
 			.map_err(|_| IDPCreationError::AuthTokenAssetNameNotString)?;
 		let cardano_position_start = api.get_next_cardano_position(parent_hash)?;
+		let block_window_size = api.get_cardano_block_window_size(parent_hash)?;
 
 		let config = CNightAddresses {
 			mapping_validator_address,
@@ -123,6 +122,7 @@ impl MidnightCNightObservationInherentDataProvider {
 				&cardano_position_start,
 				mc_hash,
 				utxo_capacity as usize,
+				block_window_size,
 			)
 			.await
 			.map_err(IDPCreationError::DataSourceError)?;

--- a/primitives/mainchain-follower/src/idp/mod.rs
+++ b/primitives/mainchain-follower/src/idp/mod.rs
@@ -22,9 +22,6 @@ pub mod cnight_observation;
 pub mod federated_authority_observation;
 
 #[cfg(feature = "std")]
-pub use cnight_observation::{
-	DEFAULT_CARDANO_BLOCK_WINDOW_SIZE, IDPCreationError,
-	MidnightCNightObservationInherentDataProvider,
-};
+pub use cnight_observation::{IDPCreationError, MidnightCNightObservationInherentDataProvider};
 #[cfg(feature = "std")]
 pub use federated_authority_observation::FederatedAuthorityInherentDataProvider;

--- a/primitives/mainchain-follower/src/lib.rs
+++ b/primitives/mainchain-follower/src/lib.rs
@@ -55,6 +55,7 @@ pub mod inherent_provider {
 			start_position: &CardanoPosition,
 			current_tip: McBlockHash,
 			capacity: usize,
+			block_window_size: u32,
 		) -> Result<ObservedUtxos, Box<dyn std::error::Error + Send + Sync>>;
 	}
 


### PR DESCRIPTION
# Overview

Backport of #1432 to `release/node-0.22.5`.

The cNight observation Inherent Data Provider was querying cardano-db-sync from `NextCardanoPosition` all the way to the current Cardano tip on every Midnight block. For sparse assets like cNight — which appear in only a tiny fraction of Cardano outputs — this caused db-sync queries that effectively scanned the entire Cardano history on every 6-second Midnight block, blocking block import to ~0.1 bps whenever the IDP's start position fell behind tip.

`CardanoBlockWindowSize` already exists as runtime storage on `pallet-cnight-observation` (default 1000) and is already exposed via `CNightObservationApi::get_cardano_block_window_size`, but the IDP never actually read it. The "window" was effectively `[start, ∞)`. This PR finishes that wiring on the 0.22.5 release branch.

## Change

1. `MidnightCNightObservationInherentDataProvider::new` reads `block_window_size` from the runtime API.
2. `MidnightCNightObservationDataSource::get_utxos_up_to_capacity` takes a new `block_window_size: u32` parameter.
3. The data source clamps the query upper bound to `start + block_window_size`. When tip is closer than `start + window`, behavior is unchanged.
4. A new `db::get_block_by_block_no` helper is added (uses runtime-checked `sqlx::query_as` so it doesn't require regenerating the offline sqlx cache).
5. The genesis-creation tool passes `u32::MAX` to preserve its existing full-history scan.
6. The previously-unused `DEFAULT_CARDANO_BLOCK_WINDOW_SIZE` constant in the IDP module is removed.

The cap on `end` also tightens the `get_high_bounds` integer-id ranges that constrain `tx`/`tx_out`/`ma_tx_out`/`tx_in` joins, so each query benefits twice from the smaller window.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `SQLX_OFFLINE=true cargo check -p midnight-primitives-mainchain-follower` — clean
- `SKIP_WASM_BUILD=1 SQLX_OFFLINE=true cargo check -p midnight-node` — clean
- `cargo fmt -p midnight-primitives-mainchain-follower -p midnight-node` — no diff

Functional verification: replace the running node binary with this build on a node that's currently stuck at 0.0–0.1 bps with ~118s db-sync queries. Expect query latency to drop to sub-second and `bps` to recover to normal AURA cadence.

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

Node-client behavior change only — the runtime API surface is unchanged (the `get_cardano_block_window_size` API already exists in 0.22.5 and is implemented; only its consumer changed). Old nodes continue to function with the existing slow behavior; new nodes use the bounded window.

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

- main PR: #1432