### PR TITLE
fix(node): tune autovacuum on db-sync hot tables for stable query plans

### DIFF
--- a/changes/node/changed/tune-autovacuum-db-sync-hot-tables.md
+++ b/changes/node/changed/tune-autovacuum-db-sync-hot-tables.md
@@ -1,0 +1,13 @@
+#node
+# Tune autovacuum on db-sync hot tables for stable query plans
+
+Lower `autovacuum_analyze_scale_factor` from the postgres default of 0.1 to 0.01 on the
+cardano-db-sync tables midnight-node queries (`block`, `tx`, `tx_out`, `tx_in`, `ma_tx_out`,
+`datum`). The default 10% growth threshold means autoanalyze never fires for big append-heavy
+tables, leaving the planner on stale statistics and producing extreme worst-case plans
+(observed >400s queries on otherwise idle preview/preprod DBs) for the cnight-observation
+lookups. Applied alongside the existing index creation in `create_cnight_observation_indexes`,
+idempotent.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1434
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1298

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -341,6 +341,8 @@ pub async fn create_cnight_observation_data_source(
 	.await?;
 
 	midnight_primitives_mainchain_follower::db::create_cnight_observation_indexes(&pool).await?;
+	midnight_primitives_mainchain_follower::db::apply_cnight_observation_autovacuum_tuning(&pool)
+		.await?;
 
 	Ok(Arc::new(MidnightCNightObservationDataSourceImpl::new(pool, metrics_opt, 1000)))
 }

--- a/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/db/queries/cnight_observation.rs
@@ -341,6 +341,28 @@ pub async fn create_cnight_observation_indexes(pool: &Pool<Postgres>) -> Result<
 	Ok(())
 }
 
+/// Lower autovacuum_analyze_scale_factor on the cardano-db-sync hot tables that
+/// midnight-node queries. Postgres's default of 0.1 means autoanalyze only fires after
+/// 10% row growth — for append-heavy multi-million-row tables (tx_out, ma_tx_out, etc.)
+/// that threshold takes weeks to hit, so the planner runs on weeks-stale statistics and
+/// picks bad join orders for high-cardinality lookups (observed ~430s queries on a
+/// preview/preprod cnight observation lookup against an otherwise idle DB).
+///
+/// Lowering to 0.01 keeps stats fresh as db-sync ingests blocks. Idempotent.
+pub async fn apply_cnight_observation_autovacuum_tuning(
+	pool: &Pool<Postgres>,
+) -> Result<(), sqlx::Error> {
+	const TABLES: &[&str] = &["block", "tx", "tx_out", "tx_in", "ma_tx_out", "datum"];
+	for table in TABLES {
+		info!("Applying autovacuum tuning to '{table}'");
+		let sql = format!(
+			"ALTER TABLE {table} SET (autovacuum_analyze_scale_factor = 0.01, autovacuum_vacuum_scale_factor = 0.05)"
+		);
+		sqlx::query(&sql).execute(pool).await?;
+	}
+	Ok(())
+}
+
 /// Query to get the block by its hash
 pub(crate) async fn get_block_by_hash(
 	pool: &Pool<Postgres>,


### PR DESCRIPTION
Lower autovacuum_analyze_scale_factor from the postgres default of 0.1 to 0.01 on the cardano-db-sync tables midnight-node queries (block, tx, tx_out, tx_in, ma_tx_out, datum). The default 10% growth threshold means autoanalyze never fires for big append-heavy tables, leaving the planner on stale statistics and producing extreme worst-case plans (observed >400s queries on otherwise idle preview/preprod DBs) for the cnight-observation lookups.

Applied alongside the existing index creation in
create_cnight_observation_indexes, idempotent.

Refs: midnightntwrk/midnight-node#1298

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

### Mainnet sync — before vs after autovacuum tuning

**Before** (default `autovacuum_analyze_scale_factor = 0.1` on `cexplorer_mainnet`, schema otherwise identical, all indexes from `create_cnight_observation_indexes` present):

```
2026-04-27 15:54:56  INFO substrate: ⚙️  Syncing  0.0 bps, target=#569462 (9 peers), best: #27
2026-04-27 15:55:01  INFO substrate: ⚙️  Syncing  0.0 bps, target=#569463 (9 peers), best: #27
2026-04-27 15:55:05  WARN sqlx::query: slow statement ... elapsed=432.22s slow_threshold=1s
2026-04-27 15:55:11  INFO substrate: ⚙️  Syncing  0.0 bps, target=#569464 (9 peers), best: #27
```

`best` stuck at #27 for many intervals; one query took **432 s**. `pg_stat_user_tables` showed `tx_out` and `ma_tx_out` had never been autoanalyzed — last_autoanalyze NULL, analyze_count=1 from initial schema load.

**After** (this PR's tuning applied via `ALTER TABLE` + one-shot `vacuumdb --analyze-only` to backfill stats):

```
2026-04-27 16:32:27  INFO substrate: ⚙️  Syncing 38.5 bps, target=#569837 (8 peers), best: #67126
2026-04-27 16:32:32  INFO substrate: ⚙️  Syncing 48.9 bps, target=#569838 (8 peers), best: #67371
2026-04-27 16:34:22  INFO substrate: ⚙️  Syncing 43.9 bps, target=#569856 (9 peers), best: #72402
```

`best` advanced from #66933 → #72402 in 2 minutes — **~5500 blocks / 120 s ≈ 46 bps sustained** vs 0.0 before. **One** `slow statement` warning across the entire run, and that one was 2.6 s rather than 400+ s.

### Tracking
- Upstream issue: midnightntwrk/midnight-node#1298
- SRE side ticket (mitigation already applied to scotty): shieldedtech/shielded-sre#181

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

