### PR TITLE
fix: use proper global unix interpreter

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Require a DCO (Signed-off-by) in the commit message
 if ! grep -q "Signed-off-by:" "$1"; then


### PR DESCRIPTION
# Overview

`#!/usr/bin/env bash` is a the proper shebang line if we want universal portability in unix systems. `#!/bin/bash` specifies an absolute path to the Bash interpreter, which can vary across unix systems

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
