### PR TITLE
feat: added post_block_update prevalidation to extrinsics disptach

### DIFF
--- a/changes/node/changed/post-block-update-prevalidation.md
+++ b/changes/node/changed/post-block-update-prevalidation.md
@@ -1,0 +1,12 @@
+#node #runtime
+# Prevalidate post-block-update after each ledger 9 transaction
+
+Transaction application (`apply_verified_transaction`, `apply_system_tx`) now
+runs ledger 9's `prevalidate_post_block_update` before mutating state, so
+transactions that would fail end-of-block processing are rejected early.
+
+Ledger 7 and 8 keep the previous behaviour via version-specific
+`post_block_update` modules (no-op; validation still runs only at
+`post_block_update`).
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1448

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -56,6 +56,9 @@ pub mod ledger_7 {
 	#[path = "guaranteed_validation/ledger_7.rs"]
 	mod guaranteed_validation;
 
+	#[path = "post_block_update/ledger_7.rs"]
+	mod post_block_update;
+
 	pub const CRATE_NAME: &str = "mn-ledger";
 	#[cfg(feature = "std")]
 	pub(crate) type TransactionSignature = base_crypto_local::signatures::Signature;
@@ -88,6 +91,9 @@ pub mod ledger_8 {
 
 	#[path = "guaranteed_validation/ledger_8.rs"]
 	mod guaranteed_validation;
+
+	#[path = "post_block_update/ledger_8.rs"]
+	mod post_block_update;
 
 	pub const CRATE_NAME: &str = "mn-ledger-8";
 	#[cfg(feature = "std")]
@@ -122,6 +128,9 @@ pub mod ledger_9 {
 
 	#[path = "guaranteed_validation/ledger_9.rs"]
 	mod guaranteed_validation;
+
+	#[path = "post_block_update/ledger_9.rs"]
+	mod post_block_update;
 
 	pub const CRATE_NAME: &str = "mn-ledger-9";
 	#[cfg(feature = "std")]

--- a/ledger/src/versions/common/api/ledger.rs
+++ b/ledger/src/versions/common/api/ledger.rs
@@ -37,6 +37,7 @@ use zswap_local::ledger::State as ZswapLedgerState;
 
 use super::{
 	super::super::BlockContext,
+	super::super::post_block_update,
 	Api, ContractAddress, ContractState, DeserializableError, LOG_TARGET, SerializableError,
 	SystemTransaction, Transaction, TransactionInvalid, UserAddress, ZswapState,
 	types::{DeserializationError, LedgerApiError, SerializationError, TransactionError},
@@ -139,8 +140,15 @@ impl<D: DB> Ledger<D> {
 		let tx_cost =
 			tx.0.cost(&sp.state.parameters, true)
 				.map_err(|_| LedgerApiError::FeeCalculationError)?;
-		let (next_state, result) = sp.state.apply(verified_tx, ctx);
 		let next_block_fullness = tx_cost + sp.block_fullness.clone().into();
+		post_block_update::prevalidate_post_block_update(
+			&sp.state,
+			&next_block_fullness,
+			&sp.state.parameters.limits.block_limits,
+			"apply_verified_transaction",
+		)?;
+
+		let (next_state, result) = sp.state.apply(verified_tx, ctx);
 		let new_sp = default_storage::<D>()
 			.arena
 			.alloc(Ledger { state: next_state, block_fullness: next_block_fullness.into() });
@@ -192,11 +200,18 @@ impl<D: DB> Ledger<D> {
 		tblock: Timestamp,
 	) -> Result<Sp<Self, D>, LedgerApiError> {
 		let tx_cost = tx.cost(&sp.state.parameters);
+		let next_block_fullness = tx_cost + sp.block_fullness.clone().into();
+		post_block_update::prevalidate_post_block_update(
+			&sp.state,
+			&next_block_fullness,
+			&sp.state.parameters.limits.block_limits,
+			"apply_system_tx",
+		)?;
+
 		let (next_state, _) = sp.state.apply_system_tx(tx, tblock).map_err(|e| {
 			log::error!(target: LOG_TARGET, "Error applying System Transaction: {e:?}");
 			LedgerApiError::Transaction(TransactionError::SystemTransaction(e.into()))
 		})?;
-		let next_block_fullness = tx_cost + sp.block_fullness.clone().into();
 		Ok(default_storage::<D>()
 			.arena
 			.alloc(Ledger { state: next_state, block_fullness: next_block_fullness.into() }))

--- a/ledger/src/versions/post_block_update/ledger_7.rs
+++ b/ledger/src/versions/post_block_update/ledger_7.rs
@@ -1,0 +1,29 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ledger-7 post-block-update prevalidation.
+//!
+//! Not supported on ledger 7; validation runs only at end-of-block `post_block_update`.
+
+#![cfg(feature = "std")]
+
+use super::{common::types::LedgerApiError, ledger_storage_local::db::DB};
+
+pub fn prevalidate_post_block_update<D: DB>(
+	_state: &super::mn_ledger_local::structure::LedgerState<D>,
+	_block_fullness: &super::base_crypto_local::cost_model::SyntheticCost,
+	_block_limits: &super::base_crypto_local::cost_model::SyntheticCost,
+	_context: &str,
+) -> Result<(), LedgerApiError> {
+	Ok(())
+}

--- a/ledger/src/versions/post_block_update/ledger_8.rs
+++ b/ledger/src/versions/post_block_update/ledger_8.rs
@@ -1,0 +1,29 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ledger-8 post-block-update prevalidation.
+//!
+//! Not supported on ledger 8; validation runs only at end-of-block `post_block_update`.
+
+#![cfg(feature = "std")]
+
+use super::{common::types::LedgerApiError, ledger_storage_local::db::DB};
+
+pub fn prevalidate_post_block_update<D: DB>(
+	_state: &super::mn_ledger_local::structure::LedgerState<D>,
+	_block_fullness: &super::base_crypto_local::cost_model::SyntheticCost,
+	_block_limits: &super::base_crypto_local::cost_model::SyntheticCost,
+	_context: &str,
+) -> Result<(), LedgerApiError> {
+	Ok(())
+}

--- a/ledger/src/versions/post_block_update/ledger_9.rs
+++ b/ledger/src/versions/post_block_update/ledger_9.rs
@@ -1,0 +1,46 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ledger-9 post-block-update prevalidation after each transaction.
+//!
+//! Uses ledger 9's `LedgerState::prevalidate_post_block_update` to reject
+//! transactions that would fail end-of-block processing before they are applied.
+
+#![cfg(feature = "std")]
+
+use super::{
+	base_crypto_local::cost_model::SyntheticCost,
+	common::{LOG_TARGET, types::LedgerApiError},
+	helpers_local::compute_overall_fullness,
+	ledger_storage_local::db::DB,
+	mn_ledger_local::{error::BlockLimitExceeded, structure::LedgerState},
+};
+
+pub fn prevalidate_post_block_update<D: DB>(
+	state: &LedgerState<D>,
+	block_fullness: &SyntheticCost,
+	block_limits: &SyntheticCost,
+	context: &str,
+) -> Result<(), LedgerApiError> {
+	let normalized_fullness = (*block_fullness).normalize(*block_limits).ok_or_else(|| {
+		log::warn!(
+			target: LOG_TARGET,
+			"Ledger block limit exceeded in {context}: fullness={block_fullness:?}, limits={block_limits:?}"
+		);
+		LedgerApiError::BlockLimitExceededError
+	})?;
+	let overall_fullness = compute_overall_fullness(&normalized_fullness);
+	state
+		.prevalidate_post_block_update(normalized_fullness, overall_fullness)
+		.map_err(|_err: BlockLimitExceeded| LedgerApiError::BlockLimitExceededError)
+}


### PR DESCRIPTION
# Overview

Prevalidate ledger 9 `post_block_update` before each transaction apply so block-limit violations are rejected early; ledgers 7/8 unchanged via version-specific no-op modules.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
