### PR TITLE
feat: parity-db with ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10534,9 +10534,9 @@ dependencies = [
 [[package]]
 name = "parity-db"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6985a45b0597d68448dac9db2907f9f72bbaf63fe3383d4ba15f99096c87212f"
+source = "git+https://github.com/midnightntwrk/parity-db.git?branch=master#d44ef4fafd15ed8326e74b88f2558afaf458f7f6"
 dependencies = [
+ "ahash 0.8.12",
  "blake2 0.10.6",
  "crc32fast",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -436,6 +436,7 @@ zeroize = { opt-level = 3 }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/midnightntwrk/rust-yamux", branch = "yamux-v0.12.2" }
+parity-db = { git = "https://github.com/midnightntwrk/parity-db.git", branch = "master" }
 midnight-ledger           = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "crate-ledger-8.1.0-rc.1" }
 midnight-zswap            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "zswap-8.1.0-rc.1" }
 midnight-transient-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "transient-crypto-2.1.0-rc.1" }

--- a/changes/node/changed/parity-db-fork-flush-ahash.md
+++ b/changes/node/changed/parity-db-fork-flush-ahash.md
@@ -1,0 +1,13 @@
+#node
+# parity-db: Midnight fork, lower flush threshold, ahash
+
+The workspace `parity-db` dependency is updated to the Midnight fork
+(`github.com/midnightntwrk/parity-db`) instead of the crates.io release. The
+fork sets a smaller background flush threshold (64 → 16) and uses `ahash` for
+hashing:
+
+https://github.com/midnightntwrk/parity-db/pull/1
+https://github.com/midnightntwrk/parity-db/pull/2
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1478
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1485


### PR DESCRIPTION
# Overview

Updates the workspace `parity-db` dependency to the Midnight fork ([midnightntwrk/parity-db](https://github.com/midnightntwrk/parity-db)) instead of the crates.io crate. That fork lowers the database background flush threshold from **64 → 16** and switches hashing to **ahash**, with the goal of more predictable WAL flushing and better hash throughput under load.

Fork PRs:

- <https://github.com/midnightntwrk/parity-db/pull/1>
- <https://github.com/midnightntwrk/parity-db/pull/2>

Upstream PR: https://github.com/paritytech/parity-db/pull/250

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
