### PR TITLE
fix(cnight-observation): enforce MaxRegistrationsPerCardanoAddress in handle_registration (audit AE / #314)

### DIFF
--- a/changes/runtime/changed/audit-cnight-observation-cap-enforcement.md
+++ b/changes/runtime/changed/audit-cnight-observation-cap-enforcement.md
@@ -1,0 +1,20 @@
+#runtime
+# Enforce per-address registration cap in cnight-observation
+
+`pallet-cnight-observation::handle_registration` previously appended to the
+`Mappings` storage map without checking the per-address cap declared by the
+mock-runtime constants and referenced (but never enforced) by the dead
+`Error::MaxRegistrationsExceeded` variant. A single Cardano reward address
+could therefore grow `Mappings::<T>::get(addr)` without bound through repeated
+registration UTXOs. The cap is now an associated type
+`Config::MaxRegistrationsPerCardanoAddress: Get<u32>` (bound to `100` in the
+runtime and both mocks) and is enforced as a writer invariant inside
+`handle_registration`: over-cap registrations are dropped with a new
+`Event::MappingCapped(MappingEntry)` event and a `log::warn!` diagnostic, and
+the surrounding `process_tokens` inherent batch continues processing
+sibling UTXOs. `Mappings` storage type is unchanged (still `Vec<MappingEntry>`)
+so no `OnRuntimeUpgrade` migration is required; the now-dead
+`Error::MaxRegistrationsExceeded` variant is removed.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1488
+Ticket: https://midnight-ntwrk.atlassian.net/browse/PM-19974

--- a/pallets/cnight-observation/mock/src/mock.rs
+++ b/pallets/cnight-observation/mock/src/mock.rs
@@ -143,12 +143,13 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxRegistrationsPerCardanoAddress: u8 = 100;
+	pub const MaxRegistrationsPerCardanoAddress: u32 = 100;
 }
 
 impl pallet_cnight_observation::Config for Test {
 	type MidnightSystemTransactionExecutor = MidnightSystem;
 	type WeightInfo = ();
+	type MaxRegistrationsPerCardanoAddress = MaxRegistrationsPerCardanoAddress;
 }
 
 impl mock_pallet::Config for Test {}

--- a/pallets/cnight-observation/mock/src/mock_with_capture.rs
+++ b/pallets/cnight-observation/mock/src/mock_with_capture.rs
@@ -131,7 +131,7 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-	pub const MaxRegistrationsPerCardanoAddress: u8 = 100;
+	pub const MaxRegistrationsPerCardanoAddress: u32 = 100;
 }
 
 pub struct MidnightSystemTx {}
@@ -156,6 +156,7 @@ impl MidnightSystemTransactionExecutor for MidnightSystemTx {
 impl pallet_cnight_observation::Config for Test {
 	type MidnightSystemTransactionExecutor = MidnightSystemTx;
 	type WeightInfo = ();
+	type MaxRegistrationsPerCardanoAddress = MaxRegistrationsPerCardanoAddress;
 }
 
 impl mock_pallet::Config for Test {}

--- a/pallets/cnight-observation/src/lib.rs
+++ b/pallets/cnight-observation/src/lib.rs
@@ -159,6 +159,14 @@ pub mod pallet {
 		type MidnightSystemTransactionExecutor: MidnightSystemTransactionExecutor;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: crate::weights::WeightInfo;
+		/// Maximum number of [`MappingEntry`] rows the pallet will retain in
+		/// `Mappings` for a single Cardano reward address. Enforced as a writer
+		/// invariant inside `handle_registration`; over-cap registrations are
+		/// dropped with a `MappingCapped` event and a `log::warn!`. The cap is
+		/// per-address and applies to the raw `Vec<MappingEntry>` length —
+		/// duplicates (which are observable but invalid per `is_registered`)
+		/// count toward the cap.
+		type MaxRegistrationsPerCardanoAddress: Get<u32>;
 	}
 
 	#[pallet::event]
@@ -169,13 +177,18 @@ pub mod pallet {
 		MappingAdded(MappingEntry),
 		MappingRemoved(MappingEntry),
 		SystemTransactionApplied(SystemTransactionApplied),
+		/// A Registration UTXO was rejected because the per-address mapping
+		/// cap (`Config::MaxRegistrationsPerCardanoAddress`) was already
+		/// reached. The payload describes the rejected entry; no `Mappings`
+		/// mutation occurred and the surrounding inherent batch continues
+		/// processing.
+		MappingCapped(MappingEntry),
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
 		/// A Cardano Wallet address was sent, but was longer than expected
 		MaxCardanoAddrLengthExceeded,
-		MaxRegistrationsExceeded,
 		/// Only one inherent is allowed per block
 		InherentAlreadyExecuted,
 		/// Next Cardano position does not advance beyond current position
@@ -420,6 +433,22 @@ pub mod pallet {
 				utxo_tx_hash: header.utxo_tx_hash,
 				utxo_index: header.utxo_index.0,
 			};
+
+			// Writer-invariant cap enforcement. `Mappings` is stored as a
+			// plain `Vec<MappingEntry>` (Path A), so the cap is not enforced
+			// by the storage type and any future writer to `Mappings` MUST
+			// reproduce this check. The cap is checked before any read of
+			// `previous_registration` or mutation of `Mappings` so an
+			// over-cap registration is a pure no-op against state, observable
+			// only via the `MappingCapped` event and the `log::warn!` below.
+			let existing_len = Mappings::<T>::decode_len(cardano_reward_address).unwrap_or(0);
+			if existing_len >= T::MaxRegistrationsPerCardanoAddress::get() as usize {
+				log::warn!(
+					"Registration cap reached for {cardano_reward_address:?}, rejecting {new_reg:?}"
+				);
+				Self::deposit_event(Event::<T>::MappingCapped(new_reg));
+				return None;
+			}
 
 			let previous_registration = Self::get_registration(&cardano_reward_address);
 

--- a/pallets/cnight-observation/tests/tests.rs
+++ b/pallets/cnight-observation/tests/tests.rs
@@ -1617,3 +1617,239 @@ fn is_inherent_required_with_malformed_data_returns_error() {
 		assert_eq!(result, Err(InherentError::DecodeFailed));
 	});
 }
+
+// ---- Per-address Registration cap enforcement ----------------------------
+//
+// Audit Issue AE (Least Authority Node Final Report, 10 Mar 2026) requires
+// `handle_registration` to enforce `Config::MaxRegistrationsPerCardanoAddress`
+// as a writer invariant on the `Mappings` storage map. The cap is `100` under
+// both mocks. The tests below cover:
+//   1. cap-exact accumulation  — the cap-th registration is accepted
+//   2. cap-over rejection      — the cap+1-th registration is rejected with
+//                                a `MappingCapped` event and no `Mappings`
+//                                mutation, while the inherent itself succeeds
+//   3. batch continuity        — a cap-rejected UTXO mid-batch does not
+//                                poison sibling UTXOs in the same inherent
+//
+// `init_ledger_state()` is intentionally NOT called: these tests exercise
+// the registration writer path only, which has no LedgerApi dependency.
+
+/// Deterministic `DustPublicKeyBytes` derived from a `u16` salt.
+///
+/// The cap-batch tests need ~`cap + 2` distinct dust public keys per test;
+/// the production helper `dust_public_key()` samples from system entropy
+/// and is not addressable by index. The bytes used here are not cryptographic
+/// inputs — they only have to satisfy `BoundedVec<u8, ConstU32<33>>` and be
+/// distinct across the batch so each constructed `MappingEntry` is unique.
+fn deterministic_dust_public_key(salt: u16) -> DustPublicKeyBytes {
+	let mut bytes = vec![0u8; 32];
+	bytes[0..2].copy_from_slice(&salt.to_be_bytes());
+	DustPublicKeyBytes(BoundedVec::try_from(bytes).unwrap())
+}
+
+/// Build a Registration `ObservedUtxo` from a `(cardano_addr, dust_key, idx)`
+/// triple. `idx` is the per-UTXO index inside a single test inherent; it is
+/// used both as the `utxo_index` field and to seed the `utxo_tx_hash` so
+/// every entry in the batch has a distinct `MappingEntry` shape.
+fn registration_utxo(
+	cardano_addr: CardanoRewardAddressBytes,
+	dust_key: DustPublicKeyBytes,
+	idx: u16,
+) -> ObservedUtxo {
+	ObservedUtxo {
+		header: test_header(1, idx.into(), idx, None),
+		data: ObservedUtxoData::Registration(RegistrationData {
+			cardano_reward_address: cardano_addr,
+			dust_public_key: dust_key,
+		}),
+	}
+}
+
+fn cap() -> usize {
+	<Test as pallet_cnight_observation::Config>::MaxRegistrationsPerCardanoAddress::get() as usize
+}
+
+#[test]
+fn cap_exact_accumulation_accepts_cap_th_registration() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let cardano_addr = cardano_reward_address(b"cardano-cap-exact");
+		let cap = cap();
+
+		let utxos: Vec<ObservedUtxo> = (0..cap)
+			.map(|i| {
+				registration_utxo(cardano_addr, deterministic_dust_public_key(i as u16), i as u16)
+			})
+			.collect();
+
+		let inherent_data = create_inherent(utxos, test_position(2, 0));
+		let call = CNightObservation::create_inherent(&inherent_data)
+			.expect("Expected to create inherent call");
+		let call = RuntimeCall::CNightObservation(call);
+		assert_ok!(call.dispatch(RawOrigin::None.into()));
+
+		// All `cap` registrations stored.
+		assert_eq!(
+			Mappings::<Test>::get(cardano_addr).len(),
+			cap,
+			"the cap-th registration must be accepted (cap is inclusive on the at-cap side)"
+		);
+
+		// Event-log accounting.
+		let mut mapping_added_count = 0usize;
+		let mut mapping_capped_count = 0usize;
+		for record in frame_system::Pallet::<Test>::events() {
+			match record.event {
+				RuntimeEvent::CNightObservation(crate::Event::MappingAdded(_)) => {
+					mapping_added_count += 1
+				},
+				RuntimeEvent::CNightObservation(crate::Event::MappingCapped(_)) => {
+					mapping_capped_count += 1
+				},
+				_ => {},
+			}
+		}
+		assert_eq!(
+			mapping_added_count, cap,
+			"expected exactly cap MappingAdded events for cap accepted registrations"
+		);
+		assert_eq!(
+			mapping_capped_count, 0,
+			"no MappingCapped event should fire when storage stays at or below the cap"
+		);
+	});
+}
+
+#[test]
+fn cap_rejection_emits_mapping_capped_event() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let cardano_addr = cardano_reward_address(b"cardano-cap-over");
+		let cap = cap();
+
+		// `cap + 1` UTXOs from a single Cardano address. The last one must be
+		// rejected; the first `cap` must accumulate cleanly.
+		let utxos: Vec<ObservedUtxo> = (0..=cap)
+			.map(|i| {
+				registration_utxo(cardano_addr, deterministic_dust_public_key(i as u16), i as u16)
+			})
+			.collect();
+
+		// The rejected entry is the `cap`-th (zero-indexed) UTXO.
+		let rejected_dust = deterministic_dust_public_key(cap as u16);
+		let rejected_header = test_header(1, cap as u32, cap as u16, None);
+		let expected_rejected_entry = MappingEntry {
+			cardano_reward_address: cardano_addr,
+			dust_public_key: rejected_dust,
+			utxo_tx_hash: rejected_header.utxo_tx_hash,
+			utxo_index: rejected_header.utxo_index.0,
+		};
+
+		let inherent_data = create_inherent(utxos, test_position(2, 0));
+		let call = CNightObservation::create_inherent(&inherent_data)
+			.expect("Expected to create inherent call");
+		let call = RuntimeCall::CNightObservation(call);
+		assert_ok!(call.dispatch(RawOrigin::None.into()));
+
+		// Storage stops at `cap`, not `cap + 1`.
+		assert_eq!(
+			Mappings::<Test>::get(cardano_addr).len(),
+			cap,
+			"cap+1-th registration must NOT mutate Mappings"
+		);
+
+		// Event-log accounting: exactly `cap` `MappingAdded`, exactly one
+		// `MappingCapped` matching the rejected entry.
+		let mut mapping_added_count = 0usize;
+		let mut mapping_capped_count = 0usize;
+		let mut captured_capped: Option<MappingEntry> = None;
+		for record in frame_system::Pallet::<Test>::events() {
+			match record.event {
+				RuntimeEvent::CNightObservation(crate::Event::MappingAdded(_)) => {
+					mapping_added_count += 1
+				},
+				RuntimeEvent::CNightObservation(crate::Event::MappingCapped(ref entry)) => {
+					mapping_capped_count += 1;
+					captured_capped = Some(entry.clone());
+				},
+				_ => {},
+			}
+		}
+		assert_eq!(mapping_added_count, cap, "expected cap MappingAdded events");
+		assert_eq!(
+			mapping_capped_count, 1,
+			"expected exactly one MappingCapped event for the rejected UTXO"
+		);
+		assert_eq!(
+			captured_capped.expect("MappingCapped event payload missing"),
+			expected_rejected_entry,
+			"MappingCapped payload must describe the rejected UTXO's MappingEntry"
+		);
+	});
+}
+
+#[test]
+fn cap_rejection_does_not_mutate_mappings_or_poison_batch() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let addr_a = cardano_reward_address(b"cardano-batch-A");
+		let addr_b = cardano_reward_address(b"cardano-batch-B");
+		let cap = cap();
+
+		// UTXOs 0..cap   : `addr_a` registrations that fill the cap.
+		// UTXO  cap      : `addr_a` registration that must be cap-rejected.
+		// UTXO  cap + 1  : `addr_b` registration that must still succeed —
+		//                  proves the cap-rejection in `handle_registration`
+		//                  does not abort the surrounding `process_tokens`
+		//                  per-UTXO loop.
+		let mut utxos: Vec<ObservedUtxo> = (0..cap)
+			.map(|i| registration_utxo(addr_a, deterministic_dust_public_key(i as u16), i as u16))
+			.collect();
+		utxos.push(registration_utxo(
+			addr_a,
+			deterministic_dust_public_key(cap as u16),
+			cap as u16,
+		));
+		utxos.push(registration_utxo(
+			addr_b,
+			deterministic_dust_public_key((cap + 1) as u16),
+			(cap + 1) as u16,
+		));
+
+		let inherent_data = create_inherent(utxos, test_position(2, 0));
+		let call = CNightObservation::create_inherent(&inherent_data)
+			.expect("Expected to create inherent call");
+		let call = RuntimeCall::CNightObservation(call);
+		assert_ok!(call.dispatch(RawOrigin::None.into()));
+
+		// Per-address storage state.
+		assert_eq!(
+			Mappings::<Test>::get(addr_a).len(),
+			cap,
+			"addr_a should be at cap, with the cap+1-th UTXO rejected"
+		);
+		assert_eq!(
+			Mappings::<Test>::get(addr_b).len(),
+			1,
+			"addr_b must not be poisoned by addr_a's rejection — batch continuity"
+		);
+
+		// Event-log accounting: `cap` MappingAdded for addr_a, one for addr_b,
+		// one MappingCapped (for addr_a's rejected UTXO).
+		let mut mapping_added_count = 0usize;
+		let mut mapping_capped_count = 0usize;
+		for record in frame_system::Pallet::<Test>::events() {
+			match record.event {
+				RuntimeEvent::CNightObservation(crate::Event::MappingAdded(_)) => {
+					mapping_added_count += 1
+				},
+				RuntimeEvent::CNightObservation(crate::Event::MappingCapped(_)) => {
+					mapping_capped_count += 1
+				},
+				_ => {},
+			}
+		}
+		assert_eq!(mapping_added_count, cap + 1, "cap MappingAdded for addr_a + 1 for addr_b");
+		assert_eq!(mapping_capped_count, 1, "exactly one MappingCapped event");
+	});
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -828,11 +828,13 @@ impl pallet_throttle::Config for Runtime {
 
 parameter_types! {
 	pub const BridgeMaxTransfersPerBlock: u32 = 256;
+	pub const MaxRegistrationsPerCardanoAddress: u32 = 100;
 }
 
 impl pallet_cnight_observation::Config for Runtime {
 	type MidnightSystemTransactionExecutor = MidnightSystem;
 	type WeightInfo = pallet_cnight_observation::weights::SubstrateWeight<Runtime>;
+	type MaxRegistrationsPerCardanoAddress = MaxRegistrationsPerCardanoAddress;
 }
 
 impl pallet_partner_chains_bridge::Config for Runtime {


### PR DESCRIPTION
## Summary

Enforce `MaxRegistrationsPerCardanoAddress` in `pallet-cnight-observation::handle_registration` so a single Cardano address cannot accumulate more `MappingEntry` records than the declared cap, closing the writer-side gap flagged by audit Issue AE.


🐛 [Issue](https://github.com/shieldedtech/shielded-security-engineering/issues/314)  📐 [Engineering](https://github.com/shieldedtech/midnight-agent-eng/blob/mike/.engineering/artifacts/planning/2026-05-11-node-issue-314-enforce-cap-handle-registration/README.md)

_Audit reference: Least Authority Node Final Audit Report (10 March 2026) — Issue AE._
_Jira: [PM-19974](https://midnight-ntwrk.atlassian.net/browse/PM-19974)._

---

## Motivation

`pallet-cnight-observation`'s `handle_registration` (`pallets/cnight-observation/src/lib.rs:411-452`) appends new `MappingEntry` records to `Mappings::<T>::get(cardano_reward_address)` without checking the per-address cap. The cap concept is already declared in three places — `Error::<T>::MaxRegistrationsExceeded` (`src/lib.rs:178`, currently unused), `MaxRegistrationsPerCardanoAddress = 100` in both mock runtimes (`mock/src/mock.rs:146`, `mock_with_capture.rs:134`), and a block of commented-out cap-enforcement tests in `tests/tests.rs:730+` — but no path reads the cap at write time. A Cardano address that submits N valid registration UTXOs without intervening deregistrations accumulates N entries unchecked. The audit categorises both severity and feasibility as Low (the spam path is rate-limited by Cardano fees), but the gap is a straightforward declaration/enforcement mismatch and a latent panic site for any future reader that converts `Mappings` to `BoundedVec`.

This PR closes the gap with a writer-invariant cap inside `handle_registration`, parameterised on the pallet `Config` trait so the runtime can bind the value. The cap-rejection is observable via a new `Event::MappingCapped` variant (indexer-facing) and a `log::warn!` line (operator-facing). The dead `Error::MaxRegistrationsExceeded` variant is removed in the same PR.

---

## Changes

**Implementation (coming next):**
- **Config** — Add `type MaxRegistrationsPerCardanoAddress: Get<u32>` to `pallet_cnight_observation::Config` (third associated type, alongside `MidnightSystemTransactionExecutor` and `WeightInfo`).
- **Writer invariant** — Insert a cap-check at the head of `handle_registration` (before any read of `Mappings` for write purposes). On `mappings.len() as u32 >= T::MaxRegistrationsPerCardanoAddress::get()`, emit `Event::MappingCapped(new_reg)`, `log::warn!`, and `return None`. No mutation occurs on rejection.
- **Event** — Add `MappingCapped(MappingEntry)` variant to `Event<T>`. Shape-parallel to `MappingAdded` / `MappingRemoved`.
- **Error** — Remove the unused `Error::MaxRegistrationsExceeded` variant.
- **Mock bindings** — Widen `MaxRegistrationsPerCardanoAddress` literal from `u8 = 100` to `u32 = 100` in both mocks; bind `type MaxRegistrationsPerCardanoAddress = MaxRegistrationsPerCardanoAddress;` in each `impl Config for Test`.
- **Runtime binding** — Add `parameter_types! { pub const MaxRegistrationsPerCardanoAddress: u32 = 100; }` and bind `type MaxRegistrationsPerCardanoAddress` in `runtime/src/lib.rs`.
- **Tests** — Three new unit tests: cap-exact accumulation (cap-th accepted), cap-over rejection (cap+1-th rejected with `MappingCapped` event), and `process_tokens` batch continuity (cap-rejected UTXO does not poison sibling UTXOs).
- **Change file** — `changes/runtime/changed/audit-cnight-observation-cap-enforcement.md` mirroring the `audit-motion-close-weight-bound.md` precedent.
- **Storage type** — **Unchanged**. `Mappings` remains `Vec<MappingEntry>`. No `BoundedVec` migration in this PR. (Path B — typed `BoundedVec<_, T::MaxRegistrationsPerCardanoAddress>` with `OnRuntimeUpgrade` — is enumerated as a follow-up in the engineering plan.)

---

## 📌 Submission Checklist

- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: [reason]
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

---

## 🔱 Fork Strategy

- [x] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [ ] N/A

---

## 🗹 TODO before merging

- [ ] Ready for review


[PM-19974]: https://shielded.atlassian.net/browse/PM-19974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ