### PR TITLE
local-env: pin contracts as submodule, retry-safe compile script

### DIFF
--- a/.github/actions/local-environment-tests/action.yml
+++ b/.github/actions/local-environment-tests/action.yml
@@ -57,15 +57,9 @@ runs:
       with:
         tool: just
 
-    - name: Checkout midnight-reserve-contracts
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      with:
-        repository: midnightntwrk/midnight-reserve-contracts
-        ref: c38439f6bae88252917bbf4f9797b7701ee78ee9
-        token: ${{ inputs.ghcr-password }}
-        path: midnight-reserve-contracts
-
     - name: Set contracts path
+      # midnight-reserve-contracts is a submodule of this repo, checked out by the caller's
+      # actions/checkout (with submodules: true). Pinning lives in .gitmodules, not here.
       run: echo "MIDNIGHT_RESERVE_CONTRACTS_PATH=${GITHUB_WORKSPACE}/midnight-reserve-contracts" >> "$GITHUB_ENV"
       shell: bash
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "indexer"]
 	path = indexer
 	url = https://github.com/midnightntwrk/midnight-indexer
+[submodule "midnight-reserve-contracts"]
+	path = midnight-reserve-contracts
+	url = https://github.com/midnightntwrk/midnight-reserve-contracts

--- a/local-environment/.envrc
+++ b/local-environment/.envrc
@@ -17,7 +17,7 @@ esac
 export ARCHITECTURE=${ARCHITECTURE:-linux/${ARCH}}
 
 GIT_ROOT="$(git rev-parse --show-toplevel)"
-export MIDNIGHT_RESERVE_CONTRACTS_PATH="${GIT_ROOT}/../midnight-reserve-contracts"
+export MIDNIGHT_RESERVE_CONTRACTS_PATH="${GIT_ROOT}/midnight-reserve-contracts"
 NODE_VERSION="$(cat ${GIT_ROOT}/node/Cargo.toml | grep -m 1 version | sed 's/version *= *"\([^\"]*\)".*/\1/')"
 GIT_SHORT_TAG="$(git rev-parse HEAD^{tree} | cut -c1-12)"
 

--- a/local-environment/README.md
+++ b/local-environment/README.md
@@ -60,8 +60,11 @@ See [fork-testing.md](../docs/fork-testing.md)
 In addition to well-known networks, you can launch a dynamic local environment that connects multiple components together.
 
 ### Local env – step by step
-> **Warning:** Public use of Local env is currently disabled, until we publish Governance Smart Contracts. For anyone who already has acccess,
-you need to clone [midnight-reserve-contracts](https://github.com/midnightntwrk/midnight-reserve-contracts) to the same location where midnight-node repo sits.
+> **Note:** The governance contracts are tracked as a git submodule at `midnight-reserve-contracts/`. If you cloned without `--recurse-submodules`, run:
+> ```
+> git submodule update --init midnight-reserve-contracts
+> ```
+> The submodule pin is the version used in CI; do not edit it on the local-env path.
 
 > **Note:** Local development environments use a self-signed TLS certificate for PostgreSQL connections. Production deployments should set `ssl_root_cert` for full certificate validation (`PgSslMode::VerifyFull`).
 

--- a/local-environment/src/networks/local-env/configurations/contract-compiler/.env
+++ b/local-environment/src/networks/local-env/configurations/contract-compiler/.env
@@ -104,8 +104,10 @@ TERMS_AND_CONDITIONS_INITIAL_LINK=
 # SIMPLE TX DEFAULTS
 # =============================================
 
-# Number of outputs for simple-tx command (default: 15)
-SIMPLE_TX_COUNT=15
+# Number of outputs for simple-tx command.
+# Must be at least max(*_one_shot_index) + 1 from aiken.toml's [config.local].
+# The pinned contracts repo uses collateral_utxo_index = 15, so we need 16 outputs (0..15).
+SIMPLE_TX_COUNT=16
 
 # Amount per output for simple-tx command (default: 20000000 = 20 ADA)
 SIMPLE_TX_AMOUNT=20000000

--- a/local-environment/src/networks/local-env/configurations/contract-compiler/compile-contracts.sh
+++ b/local-environment/src/networks/local-env/configurations/contract-compiler/compile-contracts.sh
@@ -32,8 +32,11 @@ OUTPUT_DIR="/runtime-values"
 AIKEN_TOML="${CONTRACTS_DIR}/aiken.toml"
 PLUTUS_JSON="${CONTRACTS_DIR}/plutus-local.json"
 
-# Copy contracts to writable location
+# Copy contracts to writable location.
+# Wipe any leftover state from a previous failed run on this container layer —
+# `cp -r` can't overwrite read-only files (e.g. .git pack files) created last time.
 echo "Copying contracts to writable location..."
+rm -rf "${CONTRACTS_DIR}"
 cp -r $CONTRACTS_SRC /tmp
 cp /.env $CONTRACTS_DIR
 echo "✓ Contracts copied to ${CONTRACTS_DIR}"


### PR DESCRIPTION
# Overview

Two fixes hit while running `npm run run:local-env`, plus pinning the contracts repo as a submodule:

1. **Stale container layer**: contract-compiler is reused across compose restarts, so read-only `.git/objects/*` from a previous run linger in `/tmp/contracts` and break the next `cp -r` with "Permission denied". Wipe the destination first so the script is idempotent.

2. **One-shot index off-by-one**: the pinned `aiken.toml`'s `[config.local]` references `collateral_utxo_index = 15`, which with 0-based indexing needs 16 simple-tx outputs. `SIMPLE_TX_COUNT` was 15, so deploy failed with `Inconsistent transaction inputs` at `resolveUnspentOutputs`. Bumped to 16.

3. **Submodule pin**: replace the manual sibling-clone instruction (`../midnight-reserve-contracts`) with a real submodule at `midnight-reserve-contracts/`, alongside `indexer/`. Pinned to `c38439f6` — the SHA CI was already using. CI's separate checkout step is dropped since the caller already passes `submodules: true` to `actions/checkout`.

## 🗹 TODO before merging
- [x] Ready

## 📌 Submission Checklist
- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: local-env only — no node/runtime/toolkit changes
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

End-to-end: `npm run run:local-env` completes through contract-compiler, including the `register-gov-auth` step. Without the retry-safety fix it died on the second invocation of the script; without the count bump it died at deploy.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy
- [x] N/A