### PR TITLE
chore: bump srtool to rust 1.93.0 (port of #1497 to main)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1068,14 +1068,14 @@ subwasm:
 # This ensures reproducible builds across different environments
 # See: https://github.com/paritytech/srtool
 #
-# Note: srtool uses its own pinned Rust version (currently 1.88.0) for deterministic builds.
+# Note: srtool uses its own pinned Rust version (currently 1.93.0) for deterministic builds.
 # The project's rust-toolchain.toml (1.90) is intentionally NOT used here to maintain
 # reproducibility - srtool's environment is fixed and verified.
 srtool-build:
     # renovate: datasource=docker packageName=paritytech/srtool
-    ARG SRTOOL_VERSION=0.18.3
-    # srtool 1.88.0 uses Rust 1.88.0 - this is intentional for determinism
-    FROM paritytech/srtool:1.88.0-${SRTOOL_VERSION}
+    ARG SRTOOL_VERSION=0.18.4
+    # srtool 1.93.0 uses Rust 1.93.0 - this is intentional for determinism
+    FROM paritytech/srtool:1.93.0-${SRTOOL_VERSION}
 
     # srtool expects source code in /build
     WORKDIR /build
@@ -1104,8 +1104,8 @@ srtool-build:
 
 # srtool-info displays information about the srtool build without building
 srtool-info:
-    ARG SRTOOL_VERSION=0.18.3
-    FROM paritytech/srtool:1.88.0-${SRTOOL_VERSION}
+    ARG SRTOOL_VERSION=0.18.4
+    FROM paritytech/srtool:1.93.0-${SRTOOL_VERSION}
     WORKDIR /build
     USER root
     COPY Cargo.lock Cargo.toml ./

--- a/changes/node/changed/bump-srtool-rust-1.93.md
+++ b/changes/node/changed/bump-srtool-rust-1.93.md
@@ -1,0 +1,12 @@
+#ci
+# Bump srtool image to Rust 1.93.0 for konst 0.4.3 MSRV compatibility
+
+`midnight-storage-core` 1.2.0-rc.3 pulled in `konst` 0.4.3, which raised its MSRV
+to Rust 1.89. The srtool image was pinned to `paritytech/srtool:1.88.0-0.18.3`,
+so deterministic runtime WASM builds failed at the cargo dependency check before
+producing any artifact. Bumping both `srtool-build` and `srtool-info` targets to
+`paritytech/srtool:1.93.0-0.18.4` restores the build. The toolchain change also
+shifts the deterministic build baseline — downstream consumers verifying srtool
+digests should re-anchor against the new image.
+
+PR:

--- a/changes/node/changed/bump-srtool-rust-1.93.md
+++ b/changes/node/changed/bump-srtool-rust-1.93.md
@@ -9,4 +9,4 @@ producing any artifact. Bumping both `srtool-build` and `srtool-info` targets to
 shifts the deterministic build baseline — downstream consumers verifying srtool
 digests should re-anchor against the new image.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1508


### PR DESCRIPTION
# Overview

Ports #1497 (merged into `release/node-1.0.0`) onto `main`.

`midnight-storage-core` 1.2.0-rc.3 pulled in `konst` 0.4.3, which raised its MSRV
to Rust 1.89. The srtool image was pinned to `paritytech/srtool:1.88.0-0.18.3`,
so deterministic runtime WASM builds failed at the cargo dependency check before
producing any artifact. Bumping both `srtool-build` and `srtool-info` targets to
`paritytech/srtool:1.93.0-0.18.4` restores the build.

The toolchain change shifts the deterministic build baseline — downstream
consumers verifying srtool digests should re-anchor against the new image.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [ ] All commits are signed off (\`git commit -s\`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Same diff as #1497, which has already passed CI on \`release/node-1.0.0\`.
Local sanity:

\`\`\`
$ git diff main..HEAD -- Earthfile | diffstat
 Earthfile | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
\`\`\`

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A — CI/build-only change (deterministic runtime WASM image bump).

## Links

Cherry-pick of #1497.