### PR TITLE
Check reference hardware on node startup

### DIFF
--- a/changes/node/added/midnight-reference-hardware.md
+++ b/changes/node/added/midnight-reference-hardware.md
@@ -1,0 +1,20 @@
+#node
+# Add Midnight-specific reference hardware profile for benchmark machine checks
+
+Replaces the upstream `SUBSTRATE_REFERENCE_HARDWARE` defaults with a
+Midnight-specific profile (`node/src/midnight_reference_hardware.json`)
+embedded in the binary. The profile is used in two places:
+
+- `midnight-node benchmark machine` validates the host against it and
+  reports per-metric pass/fail.
+- Node startup warns authorities whose hardware does not meet the
+  profile (existing check, now against Midnight's minimums rather than
+  Substrate's).
+
+A new helper script `scripts/benchmark/generate-reference-hardware.sh`
+runs `benchmark machine` on the current host and rewrites the JSON,
+treating that host as the new reference. Run it on dedicated reference
+hardware whenever the supported floor changes.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1511
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1509

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -35,10 +35,10 @@ use crate::{
 			verify_reserve_auth_script,
 		},
 	},
+	reference_hardware::MIDNIGHT_REFERENCE_HARDWARE,
 	service::{self, StorageInit},
 };
 use clap::Parser;
-use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
 use midnight_node_runtime::Block;
 use midnight_primitives_cnight_observation::CNightAddresses;
 use midnight_primitives_federated_authority_observation::FederatedAuthorityAddresses;
@@ -277,7 +277,7 @@ fn run_node(cfg: Cfg) -> sc_cli::Result<()> {
 			.then(|| {
 				config.database.path().map(|database_path| {
 					let _ = std::fs::create_dir_all(database_path);
-					sc_sysinfo::gather_hwbench(Some(database_path), &SUBSTRATE_REFERENCE_HARDWARE)
+					sc_sysinfo::gather_hwbench(Some(database_path), &MIDNIGHT_REFERENCE_HARDWARE)
 				})
 			})
 			.flatten();
@@ -604,7 +604,7 @@ fn run_subcommand(subcommand: Subcommand, cfg: Cfg) -> sc_cli::Result<()> {
 						)
 					},
 					BenchmarkCmd::Machine(cmd) => {
-						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())
+						cmd.run(&config, MIDNIGHT_REFERENCE_HARDWARE.clone())
 					},
 				}
 			})

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -31,6 +31,7 @@ pub mod openrpc;
 pub mod partner_chains;
 pub mod payload;
 pub mod peer_info_rpc;
+pub mod reference_hardware;
 pub mod rpc;
 pub mod service;
 pub mod sidechain_params_cmd;

--- a/node/src/midnight_reference_hardware.json
+++ b/node/src/midnight_reference_hardware.json
@@ -1,0 +1,27 @@
+[
+	{
+		"metric": "Blake2256",
+		"minimum": 1024.0
+	},
+	{
+		"metric": {"Blake2256Parallel":{"num_cores":8}},
+		"minimum": 374.59,
+		"validator_only": true
+	},
+	{
+		"metric": "Sr25519Verify",
+		"minimum": 0.633916015625
+	},
+	{
+		"metric": "MemCopy",
+		"minimum": 16220.16
+	},
+	{
+		"metric": "DiskSeqWrite",
+		"minimum": 5519.36
+	},
+	{
+		"metric": "DiskRndWrite",
+		"minimum": 1945.6
+	}
+]

--- a/node/src/reference_hardware.rs
+++ b/node/src/reference_hardware.rs
@@ -1,0 +1,34 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sc_sysinfo::Requirements;
+use std::sync::LazyLock;
+
+// Regenerate via scripts/benchmark/generate-reference-hardware.sh.
+pub static MIDNIGHT_REFERENCE_HARDWARE: LazyLock<Requirements> = LazyLock::new(|| {
+	let raw = include_bytes!("midnight_reference_hardware.json").as_ref();
+	serde_json::from_reader(raw).expect("Bundled reference hardware JSON is valid; qed")
+});
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn reference_hardware_json_parses() {
+		let reqs = &*MIDNIGHT_REFERENCE_HARDWARE;
+		assert!(!reqs.0.is_empty(), "reference hardware requirements must not be empty");
+	}
+}

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -50,7 +50,7 @@ use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 
 use crate::filtering_pool::{FilteringMetrics, FilteringTransactionPool, TxFilterConfig};
-use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
+use crate::reference_hardware::MIDNIGHT_REFERENCE_HARDWARE;
 use mmr_gadget::MmrGadget;
 use sc_rpc::SubscriptionTaskExecutor;
 use sp_core::storage::Storage;
@@ -672,7 +672,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 
 	if let Some(hwbench) = hwbench {
 		sc_sysinfo::print_hwbench(&hwbench);
-		match SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench, false) {
+		match MIDNIGHT_REFERENCE_HARDWARE.check_hardware(&hwbench, false) {
 			Err(err) if role.is_authority() => {
 				log::warn!(
 					"⚠️  The hardware does not meet the minimal requirements {} for role 'Authority'.",

--- a/scripts/benchmark/generate-reference-hardware.sh
+++ b/scripts/benchmark/generate-reference-hardware.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# This file is part of midnight-node.
+# Copyright (C) Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regenerates node/src/midnight_reference_hardware.json from a fresh
+# `midnight-node benchmark machine` run on the current host. Treat the host
+# as the reference machine: measured scores become the minimums other
+# operators are checked against at startup.
+#
+# Usage:
+#   scripts/benchmark/generate-reference-hardware.sh [BINARY]
+#
+# BINARY defaults to ./target/release/midnight-node. Run on dedicated
+# reference hardware with no competing workload — measurements are
+# sensitive to noise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${1:-$REPO_ROOT/target/release/midnight-node}"
+OUTPUT="$REPO_ROOT/node/src/midnight_reference_hardware.json"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "error: midnight-node binary not found or not executable: $BINARY" >&2
+    echo "       build with: cargo build --release" >&2
+    exit 1
+fi
+
+TMP_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMP_BASE"' EXIT
+
+echo "Running benchmark machine (this takes ~1 minute)..."
+RAW_OUTPUT="$("$BINARY" benchmark machine --base-path "$TMP_BASE" --allow-benchmark-overhead 2>&1 || true)"
+echo "$RAW_OUTPUT"
+
+# Parse the table. Each metric row looks like:
+#   | CPU    | BLAKE2-256 | 1.00 GiBs | 1000.00 MiBs | ... |
+# Score column (3rd) is what we want as the new minimum.
+parse_score() {
+    local function_name="$1"
+    echo "$RAW_OUTPUT" | awk -F '|' -v fn="$function_name" '
+        $0 ~ fn {
+            score = $4
+            gsub(/^[ \t]+|[ \t]+$/, "", score)
+            print score
+            exit
+        }
+    '
+}
+
+# Convert "1.00 GiBs" / "374.59 MiBs" / "649.13 KiBs" to MiB/s (the unit
+# sc_sysinfo::Throughput expects in JSON).
+to_mibs() {
+    local raw="$1"
+    if [[ -z "$raw" ]]; then
+        echo "error: missing score for required metric" >&2
+        exit 1
+    fi
+    awk -v s="$raw" 'BEGIN {
+        n = s + 0
+        if (s ~ /GiBs/)      printf "%.6f\n", n * 1024
+        else if (s ~ /MiBs/) printf "%.6f\n", n
+        else if (s ~ /KiBs/) printf "%.9f\n", n / 1024
+        else { print "error: unknown unit in \"" s "\"" > "/dev/stderr"; exit 1 }
+    }'
+}
+
+BLAKE=$(to_mibs "$(parse_score 'BLAKE2-256 ')")
+BLAKE_PARALLEL=$(to_mibs "$(parse_score 'BLAKE2-256-Parallel-8')")
+SR25519=$(to_mibs "$(parse_score 'SR25519-Verify')")
+MEMCOPY=$(to_mibs "$(parse_score ' Copy ')")
+SEQ_WRITE=$(to_mibs "$(parse_score 'Seq Write')")
+RND_WRITE=$(to_mibs "$(parse_score 'Rnd Write')")
+
+cat >"$OUTPUT" <<EOF
+[
+	{
+		"metric": "Blake2256",
+		"minimum": $BLAKE
+	},
+	{
+		"metric": {"Blake2256Parallel":{"num_cores":8}},
+		"minimum": $BLAKE_PARALLEL,
+		"validator_only": true
+	},
+	{
+		"metric": "Sr25519Verify",
+		"minimum": $SR25519
+	},
+	{
+		"metric": "MemCopy",
+		"minimum": $MEMCOPY
+	},
+	{
+		"metric": "DiskSeqWrite",
+		"minimum": $SEQ_WRITE
+	},
+	{
+		"metric": "DiskRndWrite",
+		"minimum": $RND_WRITE
+	}
+]
+EOF
+
+echo
+echo "Wrote reference hardware profile to: $OUTPUT"


### PR DESCRIPTION
# Overview

Informs the node operator if their machine is underspecced relative to the midnight validator reference hardware, on startup.

Fixes https://github.com/midnightntwrk/midnight-node/issues/1509

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
