### PR TITLE
fix(ci): tag release at inputs.ref, not the default branch HEAD

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -95,6 +95,7 @@ jobs:
       node-version: ${{ steps.release-env.outputs.node_version }}
       image-tag-content-hash: ${{ steps.release-env.outputs.image_tag_content_hash }}
       image-tag-release: ${{ steps.release-env.outputs.image_tag_release }}
+      release-sha: ${{ steps.release-env.outputs.release_sha }}
       git-tag-release: ${{ steps.release-config.outputs.git_tag_release }}
       git-tag-node: ${{ steps.release-config.outputs.git_tag_node }}
       git-tag-toolkit: ${{ steps.release-config.outputs.git_tag_toolkit }}
@@ -150,6 +151,10 @@ jobs:
           TOOLKIT_TAG_RELEASE="$TOOLKIT_VERSION$SUFFIX"
           RUNTIME_TAG_RELEASE="$RUNTIME_VERSION$SUFFIX"
 
+          # Resolve inputs.ref to a concrete commit SHA so every downstream
+          # tag/release points at the exact tree we just built from.
+          RELEASE_SHA="$(git rev-parse HEAD)"
+
           # Job outputs (for downstream jobs)
           echo "node_version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
           echo "toolkit_version=$TOOLKIT_VERSION" >> "$GITHUB_OUTPUT"
@@ -158,6 +163,7 @@ jobs:
           echo "image_tag_release=$IMAGE_TAG_RELEASE" >> "$GITHUB_OUTPUT"
           echo "toolkit_tag_release=$TOOLKIT_TAG_RELEASE" >> "$GITHUB_OUTPUT"
           echo "runtime_tag_release=$RUNTIME_TAG_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
           # Env vars (for subsequent steps in this job)
           echo "NODE_VERSION=$NODE_VERSION" >> "$GITHUB_ENV"
@@ -429,6 +435,7 @@ jobs:
           RUNTIME_VERSION: ${{ needs.prepare-release.outputs.runtime-version }}
           TOOLKIT_TAG_RELEASE: ${{ needs.prepare-release.outputs.toolkit-tag-release }}
           RUNTIME_TAG_RELEASE: ${{ needs.prepare-release.outputs.runtime-tag-release }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.release-sha }}
         run: |
           echo "IMAGE_TAG_CONTENT_HASH=$IMAGE_TAG_CONTENT_HASH" >> "$GITHUB_ENV"
           echo "IMAGE_TAG_RELEASE=$IMAGE_TAG_RELEASE" >> "$GITHUB_ENV"
@@ -438,6 +445,7 @@ jobs:
           echo "RUNTIME_VERSION=$RUNTIME_VERSION" >> "$GITHUB_ENV"
           echo "TOOLKIT_TAG_RELEASE=$TOOLKIT_TAG_RELEASE" >> "$GITHUB_ENV"
           echo "RUNTIME_TAG_RELEASE=$RUNTIME_TAG_RELEASE" >> "$GITHUB_ENV"
+          echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
       - name: Build Release Notes
         shell: bash
@@ -481,6 +489,23 @@ jobs:
           FORCE: ${{ github.event.inputs.force }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # If the tag already exists on the remote, refuse to publish unless it
+          # points at the commit we built from. Without this guard, a pre-existing
+          # tag at the wrong commit (e.g. created by a previous buggy run) would
+          # be silently reused by `gh release create/edit`.
+          if EXISTING_TAG_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${GIT_TAG_RELEASE}" 2>/dev/null); then
+            EXISTING_SHA=$(echo "$EXISTING_TAG_JSON" | jq -r '.object.sha')
+            EXISTING_TYPE=$(echo "$EXISTING_TAG_JSON" | jq -r '.object.type')
+            if [ "$EXISTING_TYPE" = "tag" ]; then
+              EXISTING_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${EXISTING_SHA}" --jq '.object.sha')
+            fi
+            if [ "$EXISTING_SHA" != "$RELEASE_SHA" ]; then
+              echo "::error::Tag ${GIT_TAG_RELEASE} already exists at ${EXISTING_SHA} but the release was built from ${RELEASE_SHA}."
+              echo "::error::Refusing to publish a release whose tag does not match the built tree."
+              exit 1
+            fi
+          fi
+
           if gh release view --repo "$GITHUB_REPOSITORY" "$GIT_TAG_RELEASE" --json isDraft 2>/dev/null; then
             if gh release view --repo "$GITHUB_REPOSITORY" "$GIT_TAG_RELEASE" --json isDraft -q '.isDraft' | grep -q false; then
               if [ "$FORCE" != "true" ]; then
@@ -502,6 +527,13 @@ jobs:
             latest)     FLAGS=("--latest" "--draft=false") ;;
           esac
 
+          # `--target` is only valid (and only meaningful) when gh creates the
+          # tag. Without it, gh creates the tag on the repository's default
+          # branch (main) — which is exactly the bug we're fixing.
+          if [ "$EDIT_OR_CREATE" = "create" ]; then
+            FLAGS+=("--target" "$RELEASE_SHA")
+          fi
+
           gh release --repo "$GITHUB_REPOSITORY" "$EDIT_OR_CREATE" "$GIT_TAG_RELEASE" \
             --title "$GIT_TAG_RELEASE" \
             "${FLAGS[@]}" \
@@ -516,8 +548,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create separate tags for toolkit and runtime (node tag is the primary release tag)
-          # This ensures each component has its own tag for independent versioning
-          RELEASE_SHA="$GITHUB_SHA"
+          # This ensures each component has its own tag for independent versioning.
+          # RELEASE_SHA is the resolved SHA of inputs.ref (set by Setup Env), not
+          # $GITHUB_SHA — which would be the workflow ref, possibly main.
 
           # Toolkit tag (only if toolkit is included and not skipped)
           if [ "$SKIP_TOOLKIT" != "true" ]; then


### PR DESCRIPTION
# Overview

Fixes #1514.

In run [25796464520](https://github.com/midnightntwrk/midnight-node/actions/runs/25796464520) — dispatched with `ref: release/node-1.0.0`, `suffix: -rc.7`, `release-type: prerelease` — the GitHub release `node-1.0.0-rc.7` was published with its tag on **main**, not on the release branch:

- `node-1.0.0-rc.7` → `a5a5d74f7` (a commit on `main`, never on `release/node-1.0.0`)
- `toolkit-1.0.0-rc.7` / `runtime-1.0.0-rc.7` → `b22e87f2a` (release branch HEAD — correct)
- Release API `targetCommitish: main`

## Root cause

`release-image.yml`'s `Create release` step called `gh release create` **without `--target`**. When the tag does not already exist, `gh release create` defaults `--target` to the repository's default branch (main), so the new tag was created on main HEAD rather than `inputs.ref`.

The component-tag step (`Create individual component tags`) used `RELEASE_SHA="$GITHUB_SHA"`, which happened to be correct in this specific run because the workflow itself was dispatched on `release/node-1.0.0`. But it's also fragile: if the workflow is dispatched on main with `inputs.ref: release/node-1.0.0`, `$GITHUB_SHA` would be main's HEAD and the component tags would also land on the wrong commit.

### Bug introduction

The buggy path was introduced in commit [`751e9ba6e7`](https://github.com/midnightntwrk/midnight-node/commit/751e9ba6e75b6cf89493d21380a62df2f71db312) ("ci: remove season-action from workflows", 2026-03-31), which replaced the legacy `season-create-tag` script with the bare `gh release create` call. The legacy script tagged from the checked-out `inputs.ref`, which was correct. The replacement omits `--target`.

Release branches forked from main **after** that commit (e.g. `release/node-1.0.0`) inherited the buggy workflow. Release branches forked **before** it (e.g. `release/node-0.22.5`) still use the legacy `season-create-tag` path and are unaffected.

## Affected releases

A full audit of every published release found 7 misplaced tags, all in the `node-1.0.0` / `toolkit-1.0.0` family (the only release line whose branch had diverged from main while the buggy workflow was active):

| Tag | Currently at (on main) | Should be (on `release/node-1.0.0`) |
|---|---|---|
| `node-1.0.0-rc.7` | `a5a5d74f7` | `b22e87f2a` |
| `toolkit-1.0.0-rc.6` | `8a630ba45` | `134de5fb6` |
| `node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.5` | `7113bf0a1` | `be5b1c4ab` |
| `node-1.0.0-toolkit-1.0.0-rc.4` | `05ed697a7` | `be5b1c4ab` |
| `node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.4` | `8d7d5ddd6` | `be5b1c4ab` |
| `node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.3` | `b362889b5` | `681e2105b` |
| `node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.2` | `55e55c609` | `482ddce29` |

All 7 have `target_commitish: main` in the GitHub API. The "should be" SHAs come from the dispatching workflow run's `headSha` (or for rc.2, which was dispatched from main, the release branch HEAD at workflow start time).

The build artifacts (docker images, binary release archives, runtime WASM, SBOMs, attestations) for these releases were all produced from the correct `inputs.ref` checkout — only the git tag is wrong. Source builds via `git checkout <tag>` get main's code instead.

## Script to move affected tags

This script moves the affected tags to the correct commits. The release assets are the source of truth - the script verifies that the new shas match the content hashes of the release assets before moving.

<details><summary>`move-misplaced-tags.sh`</summary>

```bash
#!/usr/bin/env bash
# Move the 7 git tags misplaced by the release-image.yml bug (issue #1514).
#
# For each tag in $MOVES:
#   1. Verifies the local repo can see both the current (wrong) SHA and the
#      target (correct) SHA, and that the target SHA is reachable from
#      origin/release/node-1.0.0.
#   2. Confirms the tag on the remote currently points at the expected wrong SHA.
#   3. NEW: Verifies the docker image attached to the release was actually
#      built from the target SHA — by checking that the release-tag image's
#      manifest digest equals the content-hash sibling tag's manifest digest,
#      where the content tag is `<NODE_VERSION>-<12-char tree-hash of target>`.
#      Without this match, moving the git tag would make the source code
#      diverge from the published image.
#   4. Force-updates the remote tag ref to the target SHA via the GitHub API.
#   5. Verifies the post-move SHA matches expectations.
#
# Usage:
#   ./move-misplaced-tags.sh                       # dry-run (default)
#   ./move-misplaced-tags.sh --apply               # actually move the tags
#   ./move-misplaced-tags.sh --skip-image-check    # bypass step 3 (use only if
#                                                  # the image is no longer in
#                                                  # GHCR; verify manually first)
#
# Requires:
#   - gh CLI authenticated with `repo` scope
#   - docker CLI logged in to ghcr.io (`docker login ghcr.io`)
#   - local clone with `origin/release/node-1.0.0` and all tags fetched

set -euo pipefail

REPO="midnightntwrk/midnight-node"
RELEASE_BRANCH="origin/release/node-1.0.0"

# tag → "current_wrong_sha:target_correct_sha:image_uri_for_verification"
# Target SHAs come from the dispatching workflow run's headSha. For rc.2
# (dispatched from main with inputs.ref=release/node-1.0.0), the target is the
# release branch HEAD at workflow start time.
# The image URI is the release-tag image whose tree should match the target.
declare -A MOVES=(
  ["node-1.0.0-rc.7"]="a5a5d74f7b88e67ac8ac577ffd89405504dbc806:b22e87f2ad19f8228cbb52f82d8bbf10c959d227:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.7"
  ["toolkit-1.0.0-rc.6"]="8a630ba45951cea8b8ea3890bee7f84acf506c87:134de5fb6d43a4a9358ecdde8f48f0eecbc40ab6:ghcr.io/midnight-ntwrk/midnight-node-toolkit:1.0.0-rc.6"
  ["node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.5"]="7113bf0a12f2dc5aec94ca344cb71dcf9e9d7411:be5b1c4abae084c532720da1e93d960a68dba6e6:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.5"
  ["node-1.0.0-toolkit-1.0.0-rc.4"]="05ed697a7f517084d26cb975f2e57494b883efe8:be5b1c4abae084c532720da1e93d960a68dba6e6:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.4"
  ["node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.4"]="8d7d5ddd61950b5f3642e8138da8b13634df9983:be5b1c4abae084c532720da1e93d960a68dba6e6:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.4"
  ["node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.3"]="b362889b5eaef8e2270444cafef50fca7223b993:681e2105b50b89df758a0300eb3c60080ce88553:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.3"
  ["node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.2"]="55e55c609e516f19593da0c1306bb455e9763c63:482ddce295b2190d8d67ad228df6c361042dfb0b:ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.2"
)

APPLY=false
SKIP_IMAGE_CHECK=false
for arg in "$@"; do
  case "$arg" in
    --apply)             APPLY=true ;;
    --skip-image-check)  SKIP_IMAGE_CHECK=true ;;
    *)                   echo "Unknown arg: $arg" >&2; exit 2 ;;
  esac
done

if $APPLY; then
  echo "MODE: APPLY — will mutate remote tags on $REPO"
else
  echo "MODE: DRY-RUN — no changes will be made (pass --apply to execute)"
fi
$SKIP_IMAGE_CHECK && echo "(image content-hash verification DISABLED — --skip-image-check)"
echo "----------------------------------------------------------------------"

if ! git rev-parse --verify --quiet "$RELEASE_BRANCH" >/dev/null; then
  echo "ERROR: $RELEASE_BRANCH not found locally. Run: git fetch origin release/node-1.0.0" >&2
  exit 1
fi

if ! $SKIP_IMAGE_CHECK && ! command -v docker >/dev/null; then
  echo "ERROR: docker not found. Install docker + 'docker login ghcr.io', or pass --skip-image-check." >&2
  exit 1
fi

# Verify the release-tag docker image's manifest matches the content-hash tag
# computed from the target SHA's tree. If they differ, the target SHA does not
# correspond to the published artifact and we must not move the tag.
verify_image() {
  local target="$1"
  local image_uri="$2"  # e.g. ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.7

  local image_repo="${image_uri%:*}"

  local node_version
  node_version=$(git show "$target:node/Cargo.toml" 2>/dev/null \
    | grep -m 1 '^version' | awk '{print $3}' | tr -d '"')
  if [ -z "$node_version" ]; then
    echo "  IMAGE VERIFY: ERROR — could not read NODE_VERSION at $target"
    return 1
  fi

  local tree_hash
  tree_hash=$(git rev-parse "${target}^{tree}" | cut -c1-12)

  local expected_content_tag="${node_version}-${tree_hash}"
  echo "  image: $image_uri"
  echo "  expected content tag: ${image_repo}:${expected_content_tag}"

  local release_digest
  release_digest=$(docker buildx imagetools inspect "$image_uri" --raw 2>/dev/null \
    | sha256sum | awk '{print $1}')
  if [ "$release_digest" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ] \
     || [ -z "$release_digest" ]; then
    echo "  IMAGE VERIFY: ERROR — release-tag image not found in registry"
    return 1
  fi

  local content_digest
  content_digest=$(docker buildx imagetools inspect "${image_repo}:${expected_content_tag}" --raw 2>/dev/null \
    | sha256sum | awk '{print $1}')
  if [ "$content_digest" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ] \
     || [ -z "$content_digest" ]; then
    echo "  IMAGE VERIFY: ERROR — content-hash tag ${expected_content_tag} not found"
    echo "    The published image was NOT built from $target. Refusing to move the git tag."
    return 1
  fi

  if [ "$release_digest" != "$content_digest" ]; then
    echo "  IMAGE VERIFY: ERROR — manifest mismatch"
    echo "    release-tag manifest:  $release_digest"
    echo "    content-hash manifest: $content_digest"
    return 1
  fi

  echo "  IMAGE VERIFY: OK — release image was built from tree of $target"
  return 0
}

FAIL_COUNT=0
APPLIED_COUNT=0
SKIPPED_COUNT=0

for tag in "${!MOVES[@]}"; do
  IFS=":" read -r expected_wrong target image_repo_part image_release_tag <<< "${MOVES[$tag]}"
  image_uri="${image_repo_part}:${image_release_tag}"

  echo
  echo "tag: $tag"
  echo "  expected wrong: $expected_wrong"
  echo "  target:         $target"

  # 1. Local target SHA exists?
  if ! git cat-file -e "$target" 2>/dev/null; then
    echo "  ERROR: target SHA $target not present locally" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi

  # 2. Target is on the release branch?
  if ! git merge-base --is-ancestor "$target" "$RELEASE_BRANCH"; then
    echo "  ERROR: target $target is NOT an ancestor of $RELEASE_BRANCH" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi

  # 3. Remote tag currently at expected wrong SHA?
  remote_sha=$(gh api "repos/$REPO/git/refs/tags/$tag" --jq '.object.sha' 2>/dev/null || echo "")
  if [ -z "$remote_sha" ]; then
    echo "  ERROR: tag $tag not found on remote" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi
  if [ "$remote_sha" = "$target" ]; then
    echo "  ALREADY AT TARGET — skipping"
    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
    continue
  fi
  if [ "$remote_sha" != "$expected_wrong" ]; then
    echo "  ERROR: remote tag at $remote_sha, expected wrong SHA $expected_wrong — refusing to move" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi

  # 4. Verify the published image was built from the target SHA's tree.
  if ! $SKIP_IMAGE_CHECK; then
    if ! verify_image "$target" "$image_uri"; then
      FAIL_COUNT=$((FAIL_COUNT + 1))
      continue
    fi
  fi

  # 5. Apply the move
  if ! $APPLY; then
    echo "  WOULD MOVE: $remote_sha → $target"
    continue
  fi

  echo "  moving $remote_sha → $target ..."
  result=$(gh api --method PATCH "repos/$REPO/git/refs/tags/$tag" \
    -f sha="$target" -F force=true --jq '.object.sha' 2>&1)
  if [ "$result" != "$target" ]; then
    echo "  ERROR: API returned $result, expected $target" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi

  new_sha=$(gh api "repos/$REPO/git/refs/tags/$tag" --jq '.object.sha')
  if [ "$new_sha" != "$target" ]; then
    echo "  ERROR: post-move verification failed (remote at $new_sha)" >&2
    FAIL_COUNT=$((FAIL_COUNT + 1))
    continue
  fi
  echo "  OK"
  APPLIED_COUNT=$((APPLIED_COUNT + 1))
done

echo
echo "----------------------------------------------------------------------"
if $APPLY; then
  echo "Summary: applied=$APPLIED_COUNT  skipped=$SKIPPED_COUNT  failed=$FAIL_COUNT"
else
  echo "Summary: $FAIL_COUNT pre-flight failure(s). Re-run with --apply to execute."
fi

if [ "$FAIL_COUNT" -gt 0 ]; then
  exit 1
fi
```
</details>

EDIT: Tags moved :heavy_check_mark: 

<details><summary>Command output</summary>
```
⬢ ❯ /tmp/move-misplaced-tags.sh --apply
MODE: APPLY — will mutate remote tags on midnightntwrk/midnight-node
----------------------------------------------------------------------

tag: node-1.0.0-toolkit-1.0.0-rc.4
  expected wrong: 05ed697a7f517084d26cb975f2e57494b883efe8
  target:         be5b1c4abae084c532720da1e93d960a68dba6e6
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.4
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-b04e112a84d9
  IMAGE VERIFY: OK — release image was built from tree of be5b1c4abae084c532720da1e93d960a68dba6e6
  moving 05ed697a7f517084d26cb975f2e57494b883efe8 → be5b1c4abae084c532720da1e93d960a68dba6e6 ...
  OK

tag: toolkit-1.0.0-rc.6
  expected wrong: 8a630ba45951cea8b8ea3890bee7f84acf506c87
  target:         134de5fb6d43a4a9358ecdde8f48f0eecbc40ab6
  image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:1.0.0-rc.6
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node-toolkit:1.0.0-3d59a49ab04a
  IMAGE VERIFY: OK — release image was built from tree of 134de5fb6d43a4a9358ecdde8f48f0eecbc40ab6
  moving 8a630ba45951cea8b8ea3890bee7f84acf506c87 → 134de5fb6d43a4a9358ecdde8f48f0eecbc40ab6 ...
  OK

tag: node-1.0.0-rc.7
  expected wrong: a5a5d74f7b88e67ac8ac577ffd89405504dbc806
  target:         b22e87f2ad19f8228cbb52f82d8bbf10c959d227
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.7
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-2cfea4a59b68
  IMAGE VERIFY: OK — release image was built from tree of b22e87f2ad19f8228cbb52f82d8bbf10c959d227
  moving a5a5d74f7b88e67ac8ac577ffd89405504dbc806 → b22e87f2ad19f8228cbb52f82d8bbf10c959d227 ...
  OK

tag: node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.3
  expected wrong: b362889b5eaef8e2270444cafef50fca7223b993
  target:         681e2105b50b89df758a0300eb3c60080ce88553
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.3
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-98e76abff153
  IMAGE VERIFY: OK — release image was built from tree of 681e2105b50b89df758a0300eb3c60080ce88553
  moving b362889b5eaef8e2270444cafef50fca7223b993 → 681e2105b50b89df758a0300eb3c60080ce88553 ...
  OK

tag: node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.2
  expected wrong: 55e55c609e516f19593da0c1306bb455e9763c63
  target:         482ddce295b2190d8d67ad228df6c361042dfb0b
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.2
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-01cc3feef2e3
  IMAGE VERIFY: OK — release image was built from tree of 482ddce295b2190d8d67ad228df6c361042dfb0b
  moving 55e55c609e516f19593da0c1306bb455e9763c63 → 482ddce295b2190d8d67ad228df6c361042dfb0b ...
  OK

tag: node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.5
  expected wrong: 7113bf0a12f2dc5aec94ca344cb71dcf9e9d7411
  target:         be5b1c4abae084c532720da1e93d960a68dba6e6
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.5
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-b04e112a84d9
  IMAGE VERIFY: OK — release image was built from tree of be5b1c4abae084c532720da1e93d960a68dba6e6
  moving 7113bf0a12f2dc5aec94ca344cb71dcf9e9d7411 → be5b1c4abae084c532720da1e93d960a68dba6e6 ...
  OK

tag: node-1.0.0-toolkit-1.0.0-runtime-1.0.0-rc.4
  expected wrong: 8d7d5ddd61950b5f3642e8138da8b13634df9983
  target:         be5b1c4abae084c532720da1e93d960a68dba6e6
  image: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-rc.4
  expected content tag: ghcr.io/midnight-ntwrk/midnight-node:1.0.0-b04e112a84d9
  IMAGE VERIFY: OK — release image was built from tree of be5b1c4abae084c532720da1e93d960a68dba6e6
  moving 8d7d5ddd61950b5f3642e8138da8b13634df9983 → be5b1c4abae084c532720da1e93d960a68dba6e6 ...
  OK

----------------------------------------------------------------------
Summary: applied=7  skipped=0  failed=0
```
</summary>

## Fix

- Resolve `inputs.ref` → a concrete SHA once in `prepare-release` (`git rev-parse HEAD` against the already-checked-out `./.tmp-package`) and expose it as `release-sha`.
- Pass `--target "$RELEASE_SHA"` to `gh release create` so the release tag is created at the built commit, not main.
- Use the resolved `$RELEASE_SHA` (instead of `$GITHUB_SHA`) when creating the toolkit/runtime tags via the git refs API. All three tags now share one source of truth.
- Before publishing, fail loudly if the tag already exists on a different commit — guards against silently reusing a tag misplaced by a previous buggy run.
- `--target` is only valid on `gh release create`, not `gh release edit`, so it's only added on the create path. The pre-publish guard means by the time we reach the edit path we've already verified the existing tag is at `$RELEASE_SHA`.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (\`git commit -s\`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change, no node/toolkit/runtime artifact impact
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

This is a workflow-only change to \`release-image.yml\`. \`actionlint\` passes clean.

End-to-end verification requires actually running the release workflow, which is high-cost. Suggested validation paths:

- Dry-run by dispatching the workflow against a throwaway pre-release tag (e.g. \`suffix: -test.N\`) on a non-default branch and confirm the resulting GitHub release has \`targetCommitish\` matching the dispatched ref's commit.
- Manually re-trigger the rc.7 release after deleting the misplaced tag, and confirm it now lands on \`release/node-1.0.0\`.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: CI / release tooling only
- [x] N/A

## Links

Issue: https://github.com/midnightntwrk/midnight-node/issues/1514
