### PR TITLE
Revert "chore(deps): bump secp256k1 from 0.30.0 to 0.31.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
  "plutus",
  "plutus-datum-derive",
  "pretty_assertions",
- "secp256k1 0.31.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sidechain-domain",
@@ -10730,7 +10730,7 @@ dependencies = [
  "plutus-datum-derive",
  "pretty_assertions",
  "scale-info",
- "secp256k1 0.31.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sidechain-domain",
@@ -14938,17 +14938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.9.2",
- "secp256k1-sys 0.11.0",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14971,15 +14960,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -15451,7 +15431,7 @@ dependencies = [
  "plutus",
  "plutus-datum-derive",
  "scale-info",
- "secp256k1 0.31.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,7 @@ quickcheck_macros = { version = "1" }
 quote = "1.0"
 rand_chacha = { version = "0.10.0", default-features = false }
 raw-scripts = { git = "https://github.com/input-output-hk/partner-chains-smart-contracts.git", tag = "v8.1.0" }
-secp256k1 = { version = "0.31.1", default-features = false }
+secp256k1 = { version = "0.30.0", default-features = false }
 selection = { path = "partner-chains/toolkit/committee-selection/selection", default-features = false }
 testcontainers = { version = "0.27" }
 time = { version = "0.3.47", default-features = false }

--- a/partner-chains/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains/toolkit/partner-chains-cli/src/register/register1.rs
@@ -118,7 +118,7 @@ fn sign_registration_message_with_sidechain_key(
 	ecdsa_pair: ecdsa::Pair,
 ) -> Result<String, anyhow::Error> {
 	let seed = ecdsa_pair.seed();
-	let secret_key = secp256k1::SecretKey::from_byte_array(seed).map_err(|e| anyhow!(e))?;
+	let secret_key = secp256k1::SecretKey::from_slice(&seed).map_err(|e| anyhow!(e))?;
 	let (_, sig) = sc_public_key_and_signature_for_datum(secret_key, message.clone());
 	Ok(hex::encode(sig.serialize_compact()))
 }

--- a/partner-chains/toolkit/sidechain/domain/src/crypto.rs
+++ b/partner-chains/toolkit/sidechain/domain/src/crypto.rs
@@ -28,7 +28,7 @@ mod full_crypto {
 	/// Calculates the public key and signature for given private key and hashed data.
 	pub fn sc_public_key_and_signature(key: SecretKey, hashed: [u8; 32]) -> (PublicKey, Signature) {
 		let public_key = PublicKey::from_secret_key_global(&key);
-		let signature = key.sign_ecdsa(Message::from_digest(hashed));
+		let signature = key.sign_ecdsa(Message::from_digest_slice(hashed.as_slice()).unwrap());
 		(public_key, signature)
 	}
 


### PR DESCRIPTION
Reverts midnightntwrk/midnight-node#1502

ATM there is issue with local builds, at least two devs are affected.

```
    cargo:warning=In file included from depend/secp256k1/src/secp256k1.c:39:
    cargo:warning=depend/secp256k1/src/hsort_impl.h:30:5: error: call to undeclared library function 'memmove' with type 'void *(void *, const void *, __size_t)' (aka 'void *(void *, const void *, unsigned long)'); ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    cargo:warning=   30 |     memmove(a, b, len);
    cargo:warning=      |     ^
    cargo:warning=depend/secp256k1/src/hsort_impl.h:30:5: note: include the header <string.h> or explicitly provide a declaration for 'memmove'
```