### PR TITLE
fix: restrict privileged CI from PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,10 +8,6 @@ env:
 
 on:
   merge_group:
-  pull_request:
-    branches: [ "**" ]
-    paths-ignore:
-      - "changes/**"
   workflow_dispatch:
     inputs:
       force_rebuild:


### PR DESCRIPTION
### Motivation
- Prevent unreviewed PR-controlled code from running privileged CI that receives repository secrets by removing the pre-merge `pull_request` trigger from the CI + E2E workflow.

### Description
- Removed the `pull_request` trigger block from `.github/workflows/continuous-integration.yml` and preserved `merge_group` and `workflow_dispatch` so the workflow only runs via the merge queue or manual dispatch.

### Testing
- Ran `git diff --check`, parsed the modified workflow with `ruby -e 'YAML.load_file(...)'`, and asserted with a short `python3` script that the pre-`permissions` section no longer contains `pull_request:`, all of which passed (note: `actionlint` was not available in the environment so GH Actions linting was not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b968f073c8333bff35c713824c802)