### PR TITLE
ci(nightly-cnight-e2e-qanet): tunnel toolkit fetch cache via StrongDM

### DIFF
--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # required for AWS OIDC
 
 concurrency:
   group: nightly-e2e-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -36,17 +37,103 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install system dependencies (protoc)
+      - name: Install system dependencies (protoc, postgresql-client)
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler postgresql-client
           protoc --version
+
+      # --- Toolkit fetch cache: tunnel to the shared RDS via StrongDM -----
+      #
+      # See shieldedtech/shielded-gitops#2152 and the toolkit-cache-rds
+      # stack in shielded-iac for the data plane. Flow:
+      #
+      #   1. OIDC into shielded-dev (account 962595532105).
+      #   2. Pull SDM service-account token + RDS master credentials from
+      #      Secrets Manager.
+      #   3. `sdm login` then `sdm connect toolkit-cache-postgres` — SDM
+      #      assigns an ephemeral localhost port that the runner can talk
+      #      to over loopback.
+      #   4. Smoke `SELECT 1;` to fail fast if anything's wrong before the
+      #      4-hour e2e job starts.
+      #   5. Export TOOLKIT_CACHE_DB_URL for the test process; the qanet
+      #      branch of tests/e2e/tests/lib.rs::fetch_cache_config() reads
+      #      this env var (pending consumer change on the e2e branch).
+      - name: Configure AWS credentials (shielded-dev OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ vars.SHIELDED_DEV_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
+          role-duration-seconds: 14400 # nightly e2e runs up to ~4h
+
+      - name: Install StrongDM CLI
+        shell: bash
+        run: |
+          curl -fsSL https://app.strongdm.com/releases/cli/linux -o sdm.zip
+          unzip -q sdm.zip -d "$HOME/.sdm"
+          echo "$HOME/.sdm" >> "$GITHUB_PATH"
+
+      - name: Fetch toolkit-cache credentials from Secrets Manager
+        id: cache_creds
+        shell: bash
+        run: |
+          set -euo pipefail
+          # SDM service-account credentials for the nightly workflow.
+          sdm_secret=$(aws secretsmanager get-secret-value \
+            --secret-id toolkit-cache/sdm-ci-account \
+            --query SecretString --output text)
+          echo "::add-mask::$(jq -r .token <<<"$sdm_secret")"
+          echo "SDM_ADMIN_TOKEN=$(jq -r .token <<<"$sdm_secret")" >> "$GITHUB_ENV"
+
+          # RDS master credentials (toolkit_cache_admin user).
+          db_secret=$(aws secretsmanager get-secret-value \
+            --secret-id toolkit-cache/master \
+            --query SecretString --output text)
+          echo "::add-mask::$(jq -r .password <<<"$db_secret")"
+          echo "TOOLKIT_CACHE_DB_USER=$(jq -r .username <<<"$db_secret")" >> "$GITHUB_ENV"
+          echo "TOOLKIT_CACHE_DB_PASSWORD=$(jq -r .password <<<"$db_secret")" >> "$GITHUB_ENV"
+          echo "TOOLKIT_CACHE_DB_NAME=toolkit_cache_qanet" >> "$GITHUB_ENV"
+
+      - name: Open StrongDM tunnel to toolkit-cache-postgres
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdm login --admin-token "$SDM_ADMIN_TOKEN"
+          # Background `sdm connect`; capture the assigned localhost port.
+          sdm connect toolkit-cache-postgres &
+          # Poll until the resource shows a bound port. SDM exposes this
+          # via `sdm status --json`.
+          for _ in $(seq 1 30); do
+            port=$(sdm status --json 2>/dev/null \
+              | jq -r '.[] | select(.name=="toolkit-cache-postgres") | .listen_address' \
+              | awk -F: '{print $2}')
+            [ -n "$port" ] && [ "$port" != "null" ] && break
+            sleep 1
+          done
+          if [ -z "${port:-}" ] || [ "$port" = "null" ]; then
+            echo "::error::StrongDM tunnel never came up"
+            sdm status --json || true
+            exit 1
+          fi
+          echo "TOOLKIT_CACHE_DB_PORT=$port" >> "$GITHUB_ENV"
+          echo "TOOLKIT_CACHE_DB_URL=postgresql://${TOOLKIT_CACHE_DB_USER}:${TOOLKIT_CACHE_DB_PASSWORD}@127.0.0.1:${port}/${TOOLKIT_CACHE_DB_NAME}?sslmode=require" >> "$GITHUB_ENV"
+
+      - name: Smoke test the cache DB connection
+        shell: bash
+        env:
+          PGPASSWORD: ${{ env.TOOLKIT_CACHE_DB_PASSWORD }}
+        run: |
+          psql "host=127.0.0.1 port=${TOOLKIT_CACHE_DB_PORT} dbname=${TOOLKIT_CACHE_DB_NAME} user=${TOOLKIT_CACHE_DB_USER} sslmode=require" \
+            -c 'SELECT 1;'
 
       - name: Run e2e tests (all)
         working-directory: tests/e2e/tests
         env:
           RUST_BACKTRACE: "1"
+          # Consumed by tests/e2e/tests/lib.rs::fetch_cache_config() on
+          # the qanet branch — pending the e2e-branch lib.rs change.
+          TOOLKIT_CACHE_DB_URL: ${{ env.TOOLKIT_CACHE_DB_URL }}
         run: |
           cargo test --test e2e_tests cnight --no-default-features --features "${{ steps.vars.outputs.env }}" -- --no-capture
 


### PR DESCRIPTION
# Overview

Wires the nightly qanet cNgD e2e workflow into the shared toolkit-cache RDS Postgres provisioned in [shieldedtech/shielded-iac#1437](https://github.com/shieldedtech/shielded-iac/pull/1437) — so the toolkit's fetch cache persists across runs instead of cold-syncing ~3h every night.

Closes the workflow side of [shieldedtech/shielded-gitops#2152](https://github.com/shieldedtech/shielded-gitops/issues/2152). Opened as draft because:
1. The shielded-iac PR has not merged yet (RDS / SDM resource / service account / secrets don't exist).
2. The consumer-side `fetch_cache_config()` change on the `e2e-cngd-for-cardano-preview` branch is pending — without that, the `TOOLKIT_CACHE_DB_URL` env var this workflow exports is set but unused (still safe to land first).

## What changes

`.github/workflows/nightly-run-cnight-e2e-qanet.yml` only:

- Adds `id-token: write` permission for AWS OIDC.
- New steps before the cargo test job:
  - `aws-actions/configure-aws-credentials` into `shielded-dev` (962595532105) using `vars.SHIELDED_DEV_OIDC_ROLE_ARN`.
  - Installs the StrongDM CLI (~3 MB, ~2s).
  - Pulls `toolkit-cache/sdm-ci-account` and `toolkit-cache/master` from Secrets Manager; both values masked.
  - `sdm login --admin-token …`, `sdm connect toolkit-cache-postgres` in the background, polls `sdm status --json` for the ephemeral localhost port (up to 30s).
  - `psql -c 'SELECT 1;'` smoke test through the tunnel — fails the job fast if anything's wrong before the ~4h e2e run starts (issue AC item).
- Exports `TOOLKIT_CACHE_DB_URL=postgresql://toolkit_cache_admin:<pw>@127.0.0.1:<port>/toolkit_cache_qanet?sslmode=require` to the cargo test step.

The original AC asked for `TOOLKIT_CACHE_DB_URL` as a static GitHub secret. With StrongDM tunneling, the host is `127.0.0.1:<ephemeral-port>` so the URL has to be built at runtime — this is flagged on the shielded-iac PR's README and on issue #2152.

## 🗹 TODO before merging

- [ ] [shieldedtech/shielded-iac#1437](https://github.com/shieldedtech/shielded-iac/pull/1437) merges and applies cleanly — RDS, SDM resource, service account, secrets all exist in `shielded-dev`.
- [ ] Repository variable `SHIELDED_DEV_OIDC_ROLE_ARN` set to a midnight-node-trusted OIDC role in shielded-dev with `secretsmanager:GetSecretValue` on `arn:aws:secretsmanager:eu-west-1:962595532105:secret:toolkit-cache/*` and `kms:Decrypt` on the `alias/toolkit-cache-secrets` CMK. May need a small follow-up shielded-iac PR if no existing midnight-node OIDC role covers this account.
- [ ] `gha-toolkit-cache` SDM service account added as a member of the `Toolkit Cache - Access` SDM role (assignment is out-of-band in the SDM admin UI per the shielded-iac stack README).
- [ ] Consumer-side `fetch_cache_config()` PR on the `e2e-cngd-for-cardano-preview` branch reads `TOOLKIT_CACHE_DB_URL` and falls back to the local `postgresql://postgres:postgres@localhost:5433/toolkit_cache` URL when unset.
- [ ] Verify behaviour with `workflow_dispatch` (or temporary push trigger) before the next scheduled nightly.

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (workflow no-ops the new steps if the OIDC role var is unset — fails the step, not the whole run; protocol/test logic untouched)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version — N/A
- [x] Update documentation (if relevant) — see shielded-iac stack README
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed — N/A (no developer-facing build commands changed)
- [x] No new todos introduced

## 🧪 Testing Evidence

Validation in this PR is structural only:

- `yamllint .github/workflows/nightly-run-cnight-e2e-qanet.yml` — clean.
- `actionlint` — clean (no `act` run; pinned action SHAs are existing repo conventions).

Functional validation depends on the three TODO-before-merging items above. Plan for end-to-end verification once those land:

- [ ] Trigger nightly via `workflow_dispatch`.
- [ ] Confirm the AWS OIDC step succeeds and assumes the role.
- [ ] Confirm `SDM_ADMIN_TOKEN` and `TOOLKIT_CACHE_DB_PASSWORD` are masked in the log (`::add-mask::`).
- [ ] Confirm `sdm connect` reports `Connected` and a port is captured.
- [ ] Confirm `SELECT 1;` returns one row through the tunnel.
- [ ] Once the consumer-side `fetch_cache_config()` change lands, confirm a re-run completes materially faster than the cold-cache baseline (~3h delta expected).