### PR TITLE
Toolkit multiseed cache bug

### DIFF
--- a/changes/toolkit/changed/dust-balance-cache-save-with-dust-warp.md
+++ b/changes/toolkit/changed/dust-balance-cache-save-with-dust-warp.md
@@ -1,0 +1,28 @@
+#toolkit
+# Fix dust-balance wallet/ledger snapshot saved at `block_height = 0` when `dust_warp` is enabled
+
+`build_fork_aware_context_cached` was using `blocks.last()` to determine
+the height to tag the wallet/ledger snapshot at when saving to
+`ledger_state_db`. With `dust_warp = true`,
+`SourceTransactions::from_blocks` appends a synthetic timestamp-only
+block with `number = 0` to the end of the block list — so the save
+was tagged with `block_height = 0` even though the inner state had
+been replayed up to the chain head. On subsequent runs the snapshot
+was reloaded, the replay started at block 0, and dust events were
+re-inserted into an already-full dust generation tree, panicking at
+`ledger/helpers/src/versions/common/context.rs` with "values inserted
+non-linearly".
+
+Switches the save-height computation to
+`blocks.iter().max_by_key(|b| b.number)`, which picks the highest real
+block regardless of where the synthetic timestamp block lands.
+Behaviour is unchanged for `dust_warp = false` (the only call path
+the toolkit's existing CLI exercises). Adds a regression unit test in
+`serde_def/transactions.rs` pinning the `from_blocks(_, dust_warp=true,
+_)` synthetic-block-at-number-zero invariant that the fix relies on,
+and a `check_balance_caches_at_real_head_with_dust_warp` integration
+test in `dust_balance` that runs `execute` twice against the same
+`ledger_state_db` tempdir.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1574
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1573

--- a/changes/toolkit/changed/dust-balance-cache-save-with-dust-warp.md
+++ b/changes/toolkit/changed/dust-balance-cache-save-with-dust-warp.md
@@ -13,16 +13,37 @@ re-inserted into an already-full dust generation tree, panicking at
 `ledger/helpers/src/versions/common/context.rs` with "values inserted
 non-linearly".
 
-Switches the save-height computation to
-`blocks.iter().max_by_key(|b| b.number)`, which picks the highest real
-block regardless of where the synthetic timestamp block lands.
+Reworks `build_fork_aware_context_cached` to separate the synthetic
+dust-warp block from the replay set:
+
+- The synthetic block (detected as the last block with `number = 0`
+  alongside at least one block with `number > 0`) is excluded from
+  the replay on both the cold and warm paths.
+- The save step now persists the post-replay context, which carries
+  the real-head block's `latest_block_context` — not the wall-clock
+  warp time. Save-height computation also switches from
+  `blocks.last()` to `blocks.iter().max_by_key(|b| b.number)` as a
+  defence-in-depth guard.
+- The synthetic block is applied in-memory only as a post-save step,
+  so downstream callers in the warp-enabled run
+  (`register_dust_address`, batch builders) read wall-clock-now while
+  the persisted snapshot stays clean. This prevents a silent warp-leak
+  where a later `dust_warp = false` run against the same
+  `ledger_state_db` would restore wall-clock-warp context even though
+  warping is disabled.
+
 Behaviour is unchanged for `dust_warp = false` (the only call path
 the toolkit's existing CLI exercises). Adds a regression unit test in
 `serde_def/transactions.rs` pinning the `from_blocks(_, dust_warp=true,
 _)` synthetic-block-at-number-zero invariant that the fix relies on,
 and a `check_balance_caches_at_real_head_with_dust_warp` integration
-test in `dust_balance` that runs `execute` twice against the same
-`ledger_state_db` tempdir.
+test in `dust_balance` that drives `build_fork_aware_context_cached`
+directly (renumbering the fixture's blocks so `chain_id()` resolves
+and the cache path actually runs) and pins five invariants:
+snapshot tagged at real head, no snapshot at height 0, in-memory
+tblock warped after warm restore, persisted snapshot carries the
+real-head `tblock_secs` not the warp, and the warm-restore second
+call does not re-persist the warp.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1574
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1573

--- a/util/toolkit/src/commands/dust_balance.rs
+++ b/util/toolkit/src/commands/dust_balance.rs
@@ -234,19 +234,29 @@ mod tests {
 	/// makes `chain_id()` resolve and forces both calls through the cache
 	/// path that the fix is meant to protect.
 	///
-	/// Pins three invariants:
+	/// Pins five invariants:
 	///   1. After call 1, the wallet cache holds a snapshot tagged at the
 	///      real chain head (`max(block.number)`), not at the synthetic
 	///      dust-warp block's `number = 0`.
 	///   2. No snapshot is ever saved at `block_height = 0` — the negative
 	///      version of (1), since under the old bug that's where the
 	///      snapshot lived.
-	///   3. After call 2 (warm restore), `latest_block_context.tblock` is
-	///      "now", not the value persisted from call 1. This guards the
-	///      separate fix where the synthetic dust-warp block is re-applied
-	///      after warm restore so downstream callers
-	///      (`register_dust_address`, batch builders) don't read a stale
-	///      timestamp out of the restored snapshot.
+	///   3. After call 2 (warm restore), the in-memory
+	///      `latest_block_context.tblock` is wall-clock "now" — the
+	///      synthetic dust-warp block must be re-applied after warm restore
+	///      so downstream callers (`register_dust_address`, batch builders)
+	///      don't read a stale timestamp out of the restored snapshot.
+	///   4. The persisted snapshot's `latest_block_context.tblock_secs`
+	///      equals the *real-head block's* `tblock_secs`, NOT the synthetic
+	///      dust-warp block's wall-clock value. Persisting wall-clock-now
+	///      under the real-head height would surface as a silent warp-leak
+	///      on a later `dust_warp = false` run against the same
+	///      `ledger_state_db` (the restored snapshot would feed
+	///      wall-clock-now to downstream callers even though warping was
+	///      disabled).
+	///   5. The warm-restore second call must not re-persist the warp
+	///      either — re-checking the snapshot after the second call
+	///      confirms the post-save warp re-apply stays in-memory only.
 	#[tokio::test]
 	async fn check_balance_caches_at_real_head_with_dust_warp() {
 		// `WalletStateCaching` methods (`get_latest_ledger_height`,
@@ -331,19 +341,54 @@ mod tests {
 			"no snapshot must be stored at block_height = 0",
 		);
 
-		// Second call: warm restore, must not panic and must re-warp tblock.
+		// Invariant (4): the persisted snapshot must carry the real-head
+		// block's `tblock_secs`, NOT the synthetic dust-warp block's
+		// wall-clock tblock. Persisting the warp under the real-head
+		// height would surface as a silent warp-leak on a later
+		// `dust_warp = false` run against the same `ledger_state_db`:
+		// the restored snapshot would feed wall-clock-now to
+		// `register_dust_address` / batch builders even though warping
+		// was disabled.
+		let snapshot = storage
+			.get_ledger_snapshot(chain_id, real_head)
+			.await
+			.expect("snapshot must exist at real head");
+		let real_head_block = source_blocks
+			.blocks
+			.iter()
+			.find(|b| b.number == real_head)
+			.expect("real head block must be in source");
+		assert_eq!(
+			snapshot.latest_block_context.tblock_secs, real_head_block.tblock_secs,
+			"snapshot.latest_block_context.tblock_secs must equal the real-head \
+			 block's tblock_secs (the dust-warp synthetic must NOT be applied \
+			 before save); test_start={test_start_secs}",
+		);
+		assert!(
+			snapshot.latest_block_context.tblock_secs < test_start_secs,
+			"snapshot tblock_secs ({}) should pre-date the test start \
+			 ({test_start_secs}) — the fixture's chain timestamps are historic; \
+			 a value >= test_start would mean the dust-warp synthetic leaked \
+			 into the persisted snapshot",
+			snapshot.latest_block_context.tblock_secs,
+		);
+
+		// Second call: warm restore, must not panic and must apply the
+		// warp in-memory only.
 		let fork_ctx_2 =
 			build_fork_aware_context_cached(&seeds, &source_blocks, Some(storage)).await;
 
-		// Invariant (3): synthetic warp re-applied on warm restore. Before
-		// the fix, the warm-path filter dropped the synthetic and tblock
-		// kept whatever the call-1 snapshot persisted.
+		// Invariant (3): in-memory warp re-applied on warm restore. The
+		// warm-path filter drops the synthetic (number=0 ≤ start_height),
+		// so without the post-save re-apply step the in-memory tblock
+		// would be the real-head block's historic tblock instead of
+		// wall-clock-now.
 		match fork_ctx_2 {
 			ForkAwareLedgerContext::Ledger8(ctx) => {
 				let ctx_tblock = ctx.latest_block_context().tblock.to_secs();
 				assert!(
 					ctx_tblock >= test_start_secs,
-					"latest_block_context.tblock should be >= test start \
+					"in-memory latest_block_context.tblock should be >= test start \
 					 ({test_start_secs}) after warm restore with dust_warp=true; \
 					 got {ctx_tblock}",
 				);
@@ -352,6 +397,21 @@ mod tests {
 				panic!("post-fork context should be on Ledger8 after replay")
 			},
 		}
+
+		// Invariant (5): the second call must not have re-persisted the
+		// warp under the real-head height. Re-check the snapshot after
+		// the warm-restore path runs end-to-end.
+		let snapshot_after_warm = storage
+			.get_ledger_snapshot(chain_id, real_head)
+			.await
+			.expect("snapshot must still exist after warm restore");
+		assert_eq!(
+			snapshot_after_warm.latest_block_context.tblock_secs,
+			real_head_block.tblock_secs,
+			"snapshot tblock_secs must remain at real-head value after warm \
+			 restore — the post-save warp re-apply must not leak into the \
+			 persisted state",
+		);
 	}
 
 	#[tokio::test]

--- a/util/toolkit/src/commands/dust_balance.rs
+++ b/util/toolkit/src/commands/dust_balance.rs
@@ -212,6 +212,148 @@ mod tests {
 		assert!(res.is_empty(), "empty seeds should yield empty result without touching source");
 	}
 
+	/// Regression test for the multi-seed (and dust_warp) cache save bug.
+	///
+	/// Before the fix: `build_fork_aware_context_cached` used `blocks.last()`
+	/// to determine the height to save the wallet/ledger snapshot at, but
+	/// `SourceTransactions::from_blocks(_, dust_warp = true, _)` appends a
+	/// synthetic timestamp-only block with `number = 0` at the end. The
+	/// cache was therefore saved with `block_height = 0` even when the
+	/// inner state had been replayed all the way to the chain head. On the
+	/// next run the snapshot was loaded and replayed starting at block 0,
+	/// re-inserting dust events into an already-full generation tree and
+	/// panicking with a non-linear-insertion error.
+	///
+	/// The test drives `build_fork_aware_context_cached` directly (not via
+	/// `execute`) because file-loaded `SourceTransactions` go through
+	/// `from_batches` -> `new_from_timestamp`, which hardcodes
+	/// `RawBlockData::number = 0` for every block. With every block at
+	/// height 0, `SourceTransactions::chain_id()` returns `None` and the
+	/// builder short-circuits to the non-caching `_raw` path before any
+	/// snapshot save / load runs. Renumbering the real blocks 1..N here
+	/// makes `chain_id()` resolve and forces both calls through the cache
+	/// path that the fix is meant to protect.
+	///
+	/// Pins three invariants:
+	///   1. After call 1, the wallet cache holds a snapshot tagged at the
+	///      real chain head (`max(block.number)`), not at the synthetic
+	///      dust-warp block's `number = 0`.
+	///   2. No snapshot is ever saved at `block_height = 0` — the negative
+	///      version of (1), since under the old bug that's where the
+	///      snapshot lived.
+	///   3. After call 2 (warm restore), `latest_block_context.tblock` is
+	///      "now", not the value persisted from call 1. This guards the
+	///      separate fix where the synthetic dust-warp block is re-applied
+	///      after warm restore so downstream callers
+	///      (`register_dust_address`, batch builders) don't read a stale
+	///      timestamp out of the restored snapshot.
+	#[tokio::test]
+	async fn check_balance_caches_at_real_head_with_dust_warp() {
+		// `WalletStateCaching` methods (`get_latest_ledger_height`,
+		// `get_ledger_snapshot`) come into scope via the `&dyn
+		// WalletStateCaching` trait object type that `create_file_wallet_cache`
+		// returns — no explicit `use` import needed for method dispatch.
+		use midnight_node_ledger_helpers::fork::fork_aware_context::ForkAwareLedgerContext;
+		use std::time::{SystemTime, UNIX_EPOCH};
+
+		let tempdir = tempfile::tempdir().expect("create tempdir for cache");
+		let seed_hex = "0000000000000000000000000000000000000000000000000000000000000001";
+		let src_files = vec![td("genesis/genesis_block_undeployed.mn")];
+		let fetch_cache_path = tempdir.path().join("fetch_cache.db");
+		let ledger_state_db = tempdir.path().join("ledger_cache_db");
+		let fetch_cache_cfg = FetchCacheConfig::Redb {
+			filename: fetch_cache_path.to_string_lossy().into_owned(),
+		};
+		let ledger_state_db_str = ledger_state_db.to_string_lossy().into_owned();
+
+		let source = Source {
+			src_url: None,
+			fetch_concurrency: 1,
+			fetch_compute_concurrency: None,
+			src_files: Some(src_files.clone()),
+			dust_warp: true,
+			ignore_block_context: false,
+			fetch_only_cached: false,
+			fetch_cache: fetch_cache_cfg.clone(),
+			ledger_state_db: ledger_state_db_str.clone(),
+		};
+		let src = TxGenerator::source(source, false).await.expect("build source");
+		let mut source_blocks = src.get_txs().await.expect("get_txs");
+
+		// The fixture is loaded with dust_warp=true so the last block is the
+		// synthetic warp marker. Renumber the real blocks 1..N (leaving the
+		// synthetic at number=0) so chain_id() returns Some and both
+		// execute() calls go through the cache path.
+		assert!(!source_blocks.blocks.is_empty(), "fixture must produce >= 1 block");
+		let real_count = source_blocks.blocks.len() - 1;
+		assert!(
+			real_count >= 1,
+			"fixture must produce >= 1 real block alongside the dust-warp synthetic",
+		);
+		for (i, block) in source_blocks.blocks.iter_mut().take(real_count).enumerate() {
+			block.number = (i + 1) as u64;
+			// `chain_id()` keys on `blocks[0].hash`; give every real block a
+			// stable non-zero hash so the cache key is deterministic across
+			// the two calls.
+			block.hash = [(i + 1) as u8; 32];
+		}
+		let chain_id = source_blocks.chain_id().expect("chain_id should resolve after renumber");
+		let real_head = source_blocks
+			.blocks
+			.iter()
+			.map(|b| b.number)
+			.max()
+			.expect("blocks non-empty");
+		assert_eq!(real_head, real_count as u64, "real head must be N (the synthetic stays at 0)");
+
+		let seeds = vec![WalletSeed::try_from_hex_str(seed_hex).unwrap()];
+
+		let wallet_cache = create_file_wallet_cache(&ledger_state_db_str, &fetch_cache_cfg);
+		let storage = wallet_cache.as_deref().expect("file wallet cache must be Some");
+
+		// First call: cold cache, full replay, must persist a snapshot at
+		// the real chain head.
+		let test_start_secs =
+			SystemTime::now().duration_since(UNIX_EPOCH).expect("clock").as_secs();
+		let _ = build_fork_aware_context_cached(&seeds, &source_blocks, Some(storage)).await;
+
+		// Invariant (1) + (2): snapshot tagged at real head, never at 0.
+		let latest = storage.get_latest_ledger_height(chain_id).await;
+		assert_eq!(
+			latest,
+			Some(real_head),
+			"snapshot must be tagged at the real chain head ({}), not at the synthetic \
+			 dust-warp block's number=0",
+			real_head,
+		);
+		assert!(
+			storage.get_ledger_snapshot(chain_id, 0).await.is_none(),
+			"no snapshot must be stored at block_height = 0",
+		);
+
+		// Second call: warm restore, must not panic and must re-warp tblock.
+		let fork_ctx_2 =
+			build_fork_aware_context_cached(&seeds, &source_blocks, Some(storage)).await;
+
+		// Invariant (3): synthetic warp re-applied on warm restore. Before
+		// the fix, the warm-path filter dropped the synthetic and tblock
+		// kept whatever the call-1 snapshot persisted.
+		match fork_ctx_2 {
+			ForkAwareLedgerContext::Ledger8(ctx) => {
+				let ctx_tblock = ctx.latest_block_context().tblock.to_secs();
+				assert!(
+					ctx_tblock >= test_start_secs,
+					"latest_block_context.tblock should be >= test start \
+					 ({test_start_secs}) after warm restore with dust_warp=true; \
+					 got {ctx_tblock}",
+				);
+			},
+			ForkAwareLedgerContext::Ledger7(_) => {
+				panic!("post-fork context should be on Ledger8 after replay")
+			},
+		}
+	}
+
 	#[tokio::test]
 	async fn check_balance_many_dry_run_skips_fetch() {
 		let seeds = vec![

--- a/util/toolkit/src/commands/dust_balance.rs
+++ b/util/toolkit/src/commands/dust_balance.rs
@@ -271,9 +271,8 @@ mod tests {
 		let src_files = vec![td("genesis/genesis_block_undeployed.mn")];
 		let fetch_cache_path = tempdir.path().join("fetch_cache.db");
 		let ledger_state_db = tempdir.path().join("ledger_cache_db");
-		let fetch_cache_cfg = FetchCacheConfig::Redb {
-			filename: fetch_cache_path.to_string_lossy().into_owned(),
-		};
+		let fetch_cache_cfg =
+			FetchCacheConfig::Redb { filename: fetch_cache_path.to_string_lossy().into_owned() };
 		let ledger_state_db_str = ledger_state_db.to_string_lossy().into_owned();
 
 		let source = Source {
@@ -308,12 +307,8 @@ mod tests {
 			block.hash = [(i + 1) as u8; 32];
 		}
 		let chain_id = source_blocks.chain_id().expect("chain_id should resolve after renumber");
-		let real_head = source_blocks
-			.blocks
-			.iter()
-			.map(|b| b.number)
-			.max()
-			.expect("blocks non-empty");
+		let real_head =
+			source_blocks.blocks.iter().map(|b| b.number).max().expect("blocks non-empty");
 		assert_eq!(real_head, real_count as u64, "real head must be N (the synthetic stays at 0)");
 
 		let seeds = vec![WalletSeed::try_from_hex_str(seed_hex).unwrap()];
@@ -406,8 +401,7 @@ mod tests {
 			.await
 			.expect("snapshot must still exist after warm restore");
 		assert_eq!(
-			snapshot_after_warm.latest_block_context.tblock_secs,
-			real_head_block.tblock_secs,
+			snapshot_after_warm.latest_block_context.tblock_secs, real_head_block.tblock_secs,
 			"snapshot tblock_secs must remain at real-head value after warm \
 			 restore — the post-save warp re-apply must not leak into the \
 			 persisted state",

--- a/util/toolkit/src/fetcher/wallet_state_cache.rs
+++ b/util/toolkit/src/fetcher/wallet_state_cache.rs
@@ -586,8 +586,7 @@ mod tests {
 		// Replay remaining blocks
 		use crate::tx_generator::builder::replay_blocks;
 		let fork_ctx = ForkAwareLedgerContext::Ledger8(restored);
-		let blocks: Vec<_> = second_half.iter().collect();
-		let fork_ctx = replay_blocks(fork_ctx, &blocks, &[]);
+		let fork_ctx = replay_blocks(fork_ctx, second_half, &[]);
 		let incremental_context = fork_ctx.into_ledger8().expect("expected ledger 8 after replay");
 
 		// Compare ledger state

--- a/util/toolkit/src/serde_def/transactions.rs
+++ b/util/toolkit/src/serde_def/transactions.rs
@@ -173,3 +173,61 @@ impl SourceTransactions {
 			.unwrap_or(LedgerVersion::default())
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Construct a minimal `RawBlockData` at a given height for tests.
+	fn block_at(number: u64) -> RawBlockData {
+		RawBlockData {
+			hash: [0u8; 32],
+			parent_hash: [0u8; 32],
+			number,
+			ledger_version: LedgerVersion::default(),
+			transactions: Vec::new(),
+			tblock_secs: number, // deterministic, non-zero past block 0
+			tblock_err: 30,
+			parent_block_hash: [0u8; 32],
+			last_block_time_secs: number.saturating_sub(1),
+			state_root: None,
+			state: None,
+		}
+	}
+
+	/// `from_blocks(_, dust_warp = true, _)` appends a synthetic
+	/// timestamp-only block with `number = 0` to the end of `blocks`. This
+	/// is the invariant that the cache-save logic in
+	/// `tx_generator::builder::build_fork_aware_context_cached` relies on:
+	/// it must compute the save height via `max_by_key(|b| b.number)`
+	/// rather than `blocks.last()`, otherwise the cache is tagged with
+	/// `block_height = 0` and subsequent runs panic on non-linear dust-tree
+	/// insertion when they reload the snapshot.
+	#[test]
+	fn from_blocks_with_dust_warp_appends_synthetic_block_at_number_zero() {
+		let real_blocks = vec![block_at(1), block_at(2), block_at(3)];
+		let src = SourceTransactions::from_blocks(
+			real_blocks.clone(),
+			/* dust_warp = */ true,
+			Some("test".to_string()),
+		);
+
+		assert_eq!(src.blocks.len(), real_blocks.len() + 1, "synthetic block appended");
+		assert_eq!(src.blocks.last().unwrap().number, 0, "synthetic block is at number = 0");
+
+		let max_by_number = src.blocks.iter().max_by_key(|b| b.number).expect("non-empty");
+		assert_eq!(
+			max_by_number.number, 3,
+			"max_by_number must pick the highest real block, not the synthetic"
+		);
+
+		// And without dust_warp, last() and max_by_number agree.
+		let src_no_warp = SourceTransactions::from_blocks(
+			real_blocks,
+			/* dust_warp = */ false,
+			Some("test".to_string()),
+		);
+		assert_eq!(src_no_warp.blocks.last().unwrap().number, 3);
+		assert_eq!(src_no_warp.blocks.iter().max_by_key(|b| b.number).unwrap().number, 3,);
+	}
+}

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -1056,22 +1056,34 @@ pub async fn build_fork_aware_context_cached(
 	// this run (`register_dust_address`, batch builders) read the
 	// warped tblock as expected.
 	//
-	// Mirrors `replay_blocks_8`'s contract: `apply_block_8` only
+	// Mirrors `replay_blocks_{7,8}`'s contract: `apply_block_*` only
 	// updates the ledger context (and `latest_block_context`); the
 	// per-wallet dust TTL advance lives in `update_dust_from_block`,
-	// which `replay_blocks_8` always calls for the last replayed block
-	// (see `replay_blocks_8` final stanza). Without this second call
-	// the warp would advance the *ledger's* clock but leave wallets'
-	// dust nullifier windows pinned at the real-head block's tblock,
-	// so transaction builders would read a warped `latest_block_context`
-	// while the wallet's dust availability still reflects real-head
-	// time. The synthetic has no transactions, so we don't need a
-	// matching `update_dust_from_events` — `apply_block_8` returns an
-	// empty event vec on a tx-less block.
+	// which `replay_blocks_{7,8}` always calls for the last replayed
+	// block (see their final stanzas). Without this second call the
+	// warp would advance the *ledger's* clock but leave wallets' dust
+	// nullifier windows pinned at the real-head block's tblock, so
+	// transaction builders would read a warped `latest_block_context`
+	// while wallet dust availability still reflects real-head time.
+	// The synthetic has no transactions, so we don't need a matching
+	// `update_dust_from_events` — `apply_block_*` returns an empty
+	// event vec on a tx-less block.
+	//
+	// Handle both Ledger7 and Ledger8 variants: a pre-fork chain
+	// produces a `Ledger7` context out of step 5, and the raw/no-cache
+	// path replays the synthetic block inline in that case, so the
+	// cached path must do the same to preserve dust-warp semantics on
+	// pre-Ledger8 sources.
 	if let Some(synthetic) = synthetic_dust_warp {
-		if let ForkAwareLedgerContext::Ledger8(ctx8) = &fork_ctx {
-			let _events = apply_block_8(ctx8, synthetic);
-			ctx8.update_dust_from_block(&block_context_from_raw_8(synthetic));
+		match &fork_ctx {
+			ForkAwareLedgerContext::Ledger8(ctx8) => {
+				let _events = apply_block_8(ctx8, synthetic);
+				ctx8.update_dust_from_block(&block_context_from_raw_8(synthetic));
+			},
+			ForkAwareLedgerContext::Ledger7(ctx7) => {
+				let _events = apply_block_7(ctx7, synthetic);
+				ctx7.update_dust_from_block(&block_context_from_raw_7(synthetic));
+			},
 		}
 	}
 

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -817,7 +817,7 @@ const REPLAY_INFO_HEARTBEAT: std::time::Duration = std::time::Duration::from_sec
 
 fn replay_blocks_7(
 	ctx: &midnight_node_ledger_helpers::ledger_7::context::LedgerContext<Db7>,
-	blocks_sorted_by_height: &[&RawBlockData],
+	blocks_sorted_by_height: &[RawBlockData],
 ) {
 	let mut events: Vec<midnight_node_ledger_helpers::ledger_7::Event<Db7>> = Vec::new();
 	let total = blocks_sorted_by_height.len();
@@ -855,7 +855,7 @@ fn replay_blocks_7(
 
 fn replay_blocks_8(
 	ctx: &midnight_node_ledger_helpers::ledger_8::context::LedgerContext<Db8>,
-	blocks_sorted_by_height: &[&RawBlockData],
+	blocks_sorted_by_height: &[RawBlockData],
 	wallets_sorted_by_height: &[(WalletSeed, CachedWalletState)],
 ) {
 	let mut events: Vec<midnight_node_ledger_helpers::ledger_8::Event<Db8>> = Vec::new();
@@ -916,7 +916,7 @@ fn replay_blocks_8(
 /// injecting cached wallets at their saved height.
 pub(crate) fn replay_blocks(
 	fork_ctx: ForkAwareLedgerContext,
-	blocks: &[&RawBlockData],
+	blocks: &[RawBlockData],
 	cached: &[(WalletSeed, CachedWalletState)],
 ) -> ForkAwareLedgerContext {
 	if !blocks.is_empty() && !cached.is_empty() {
@@ -1022,26 +1022,25 @@ pub async fn build_fork_aware_context_cached(
 	} else {
 		&received_tx.blocks[..]
 	};
-	let blocks: Vec<_> = if start_height == 0 {
-		real_blocks.iter().collect()
+	// Warm path uses `partition_point` (O(log n) binary search) rather
+	// than a linear `.filter()` — `real_blocks` is sorted by `b.number`
+	// ascending (the rest of `replay_blocks_*` already relies on this).
+	// Cold path takes the whole slice.
+	let blocks: &[RawBlockData] = if start_height == 0 {
+		real_blocks
 	} else {
-		real_blocks.iter().filter(|b| b.number > start_height).collect()
+		let i = real_blocks.partition_point(|b| b.number <= start_height);
+		&real_blocks[i..]
 	};
 
 	// 5. Replay with mid-replay wallet injection.
-	let fork_ctx = replay_blocks(fork_ctx, &blocks, &cached);
+	let fork_ctx = replay_blocks(fork_ctx, blocks, &cached);
 
-	// 6. Save updated cache.
-	//
-	// `max_by_key(|b| b.number)` (rather than `blocks.last()`) is now
-	// redundant with step 4's pre-filter — the synthetic is no longer in
-	// `blocks` — but it remains as a defence in depth: any future change
-	// that puts a number=0 block into the replay set won't accidentally
-	// tag the cache at block_height=0. Tagging at 0 would cause the next
-	// run to restart replay at block 0 and re-insert dust events into an
-	// already-full generation tree (non-linear insert panic in
-	// `ledger/helpers/src/versions/common/context.rs`).
-	if let Some(final_block) = blocks.iter().max_by_key(|b| b.number) {
+	// 6. Save updated cache. `blocks.last()` is sound here because
+	// step 4 already excluded the dust-warp synthetic (`number = 0`)
+	// from `blocks`; the last entry is the real chain head, and
+	// pointer lookup beats an O(n) `max_by_key` on long replays.
+	if let Some(final_block) = blocks.last() {
 		try_save_cache_v2(&fork_ctx, wallet_seeds, chain_id, final_block.number, storage).await;
 	}
 
@@ -1187,8 +1186,7 @@ pub fn build_fork_aware_context_raw(
 		ForkAwareLedgerContext::new_from_wallet_seeds(initial_version, network_id, wallet_seeds);
 	log::debug!("[perf] new_from_wallet_seeds (raw) took {:?}", t.elapsed());
 
-	let blocks: Vec<_> = received_tx.blocks.iter().collect();
-	replay_blocks(ctx, &blocks, &[])
+	replay_blocks(ctx, &received_tx.blocks, &[])
 }
 
 /// Build a fork-aware context from source transactions, returning a ledger 8 context.

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -993,49 +993,71 @@ pub async fn build_fork_aware_context_cached(
 		initialize_context(received_tx, &uncached_seeds, start_height, storage, chain_id).await;
 
 	// 4. Determine blocks to replay.
-	let blocks: Vec<_> = if start_height == 0 {
-		received_tx.blocks.iter().collect()
+	//
+	// Exclude any dust-warp synthetic block from the replay set so the
+	// persisted snapshot (step 6) captures the real-head `BlockContext`
+	// rather than wall-clock-now. `from_blocks(_, dust_warp = true, _)`
+	// appends a synthetic timestamp-only block via
+	// `RawBlockData::new_from_timestamp(...)` which hard-codes
+	// `number = 0`. If that block is replayed before save, the snapshot's
+	// `latest_block_context.tblock` becomes the warp timestamp but the
+	// snapshot is keyed at the real chain height; a later run on the
+	// same `ledger_state_db` with `dust_warp = false` would then restore
+	// the warped context and downstream callers (`register_dust_address`,
+	// batch builders) would read warp time even though warping is off.
+	//
+	// The synthetic is always pushed last by `from_blocks`, so we
+	// detect it as last-block-number=0 alongside at least one block
+	// with number>0 (guards against legitimate fixture-loaded sources
+	// where every block has number=0 — those won't pass the chain_id
+	// check anyway, but we double-guard for clarity). We apply it
+	// explicitly *after* save as step 7 so the in-memory context for
+	// this run reflects the warp.
+	let synthetic_dust_warp = received_tx.blocks.last().filter(|last| {
+		last.number == 0 && received_tx.blocks.iter().any(|b| b.number > 0)
+	});
+	let real_blocks: &[RawBlockData] = if synthetic_dust_warp.is_some() {
+		&received_tx.blocks[..received_tx.blocks.len() - 1]
 	} else {
-		received_tx.blocks.iter().filter(|b| b.number > start_height).collect()
+		&received_tx.blocks[..]
+	};
+	let blocks: Vec<_> = if start_height == 0 {
+		real_blocks.iter().collect()
+	} else {
+		real_blocks.iter().filter(|b| b.number > start_height).collect()
 	};
 
 	// 5. Replay with mid-replay wallet injection.
 	let fork_ctx = replay_blocks(fork_ctx, &blocks, &cached);
 
-	// 5b. Re-apply the dust-warp synthetic block (if present) after replay so
-	// `latest_block_context.tblock` reflects wall-clock "now" even on warm
-	// restore. `from_blocks(_, dust_warp = true, _)` appends a synthetic
-	// timestamp-only block with `number = 0`; the warm-path filter at step 4
-	// (`b.number > start_height`) drops it whenever `start_height > 0`,
-	// leaving downstream callers (`register_dust_address`, batch builders) to
-	// read whatever `tblock` the cache snapshot captured on a previous run —
-	// possibly hours or days stale. On the cold path the synthetic was
-	// already in `blocks` and replayed, so the re-apply is a cheap no-op
-	// (zero transactions, idempotent latest_block_context overwrite); we
-	// run it unconditionally to keep both paths symmetric.
-	if let Some(synthetic) = received_tx.blocks.last().filter(|last| {
-		last.number == 0 && received_tx.blocks.iter().any(|b| b.number > 0)
-	}) {
-		if let ForkAwareLedgerContext::Ledger8(ctx8) = &fork_ctx {
-			apply_block_8(ctx8, synthetic);
-		}
-	}
-
 	// 6. Save updated cache.
 	//
-	// Use `max_by_key(|b| b.number)` rather than `blocks.last()`:
-	// `SourceTransactions::from_blocks(_, dust_warp = true, _)` appends a
-	// synthetic timestamp-only block at the end of `blocks` with
-	// `RawBlockData::new_from_timestamp(...)`, which sets `number = 0`
-	// (see `ledger/helpers/src/fork/raw_block_data.rs:139`). Using
-	// `.last()` here would tag the cache with `block_height = 0` even
-	// though the inner state has been replayed to the actual head — on
-	// the next run the saved snapshot would be picked up, the replay
-	// would start at block 0, and dust events would be re-inserted into
-	// an already-full dust generation tree (non-linear insert panic in
+	// `max_by_key(|b| b.number)` (rather than `blocks.last()`) is now
+	// redundant with step 4's pre-filter — the synthetic is no longer in
+	// `blocks` — but it remains as a defence in depth: any future change
+	// that puts a number=0 block into the replay set won't accidentally
+	// tag the cache at block_height=0. Tagging at 0 would cause the next
+	// run to restart replay at block 0 and re-insert dust events into an
+	// already-full generation tree (non-linear insert panic in
 	// `ledger/helpers/src/versions/common/context.rs`).
 	if let Some(final_block) = blocks.iter().max_by_key(|b| b.number) {
 		try_save_cache_v2(&fork_ctx, wallet_seeds, chain_id, final_block.number, storage).await;
+	}
+
+	// 7. Apply the dust-warp synthetic block (in-memory only, post-save).
+	//
+	// Intentionally runs *after* `try_save_cache_v2`: applying the
+	// synthetic overwrites `latest_block_context` with wall-clock-now,
+	// and persisting that under the real-head height would surface as a
+	// silent warp-leak on later `dust_warp = false` runs against the
+	// same `ledger_state_db`. Doing it here keeps the warp in-memory
+	// only — the saved snapshot stays clean. Downstream callers in
+	// this run (`register_dust_address`, batch builders) read the
+	// warped tblock as expected.
+	if let Some(synthetic) = synthetic_dust_warp {
+		if let ForkAwareLedgerContext::Ledger8(ctx8) = &fork_ctx {
+			apply_block_8(ctx8, synthetic);
+		}
 	}
 
 	fork_ctx

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -1013,9 +1013,10 @@ pub async fn build_fork_aware_context_cached(
 	// check anyway, but we double-guard for clarity). We apply it
 	// explicitly *after* save as step 7 so the in-memory context for
 	// this run reflects the warp.
-	let synthetic_dust_warp = received_tx.blocks.last().filter(|last| {
-		last.number == 0 && received_tx.blocks.iter().any(|b| b.number > 0)
-	});
+	let synthetic_dust_warp = received_tx
+		.blocks
+		.last()
+		.filter(|last| last.number == 0 && received_tx.blocks.iter().any(|b| b.number > 0));
 	let real_blocks: &[RawBlockData] = if synthetic_dust_warp.is_some() {
 		&received_tx.blocks[..received_tx.blocks.len() - 1]
 	} else {
@@ -1054,9 +1055,23 @@ pub async fn build_fork_aware_context_cached(
 	// only — the saved snapshot stays clean. Downstream callers in
 	// this run (`register_dust_address`, batch builders) read the
 	// warped tblock as expected.
+	//
+	// Mirrors `replay_blocks_8`'s contract: `apply_block_8` only
+	// updates the ledger context (and `latest_block_context`); the
+	// per-wallet dust TTL advance lives in `update_dust_from_block`,
+	// which `replay_blocks_8` always calls for the last replayed block
+	// (see `replay_blocks_8` final stanza). Without this second call
+	// the warp would advance the *ledger's* clock but leave wallets'
+	// dust nullifier windows pinned at the real-head block's tblock,
+	// so transaction builders would read a warped `latest_block_context`
+	// while the wallet's dust availability still reflects real-head
+	// time. The synthetic has no transactions, so we don't need a
+	// matching `update_dust_from_events` — `apply_block_8` returns an
+	// empty event vec on a tx-less block.
 	if let Some(synthetic) = synthetic_dust_warp {
 		if let ForkAwareLedgerContext::Ledger8(ctx8) = &fork_ctx {
-			apply_block_8(ctx8, synthetic);
+			let _events = apply_block_8(ctx8, synthetic);
+			ctx8.update_dust_from_block(&block_context_from_raw_8(synthetic));
 		}
 	}
 

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -1002,8 +1002,39 @@ pub async fn build_fork_aware_context_cached(
 	// 5. Replay with mid-replay wallet injection.
 	let fork_ctx = replay_blocks(fork_ctx, &blocks, &cached);
 
+	// 5b. Re-apply the dust-warp synthetic block (if present) after replay so
+	// `latest_block_context.tblock` reflects wall-clock "now" even on warm
+	// restore. `from_blocks(_, dust_warp = true, _)` appends a synthetic
+	// timestamp-only block with `number = 0`; the warm-path filter at step 4
+	// (`b.number > start_height`) drops it whenever `start_height > 0`,
+	// leaving downstream callers (`register_dust_address`, batch builders) to
+	// read whatever `tblock` the cache snapshot captured on a previous run —
+	// possibly hours or days stale. On the cold path the synthetic was
+	// already in `blocks` and replayed, so the re-apply is a cheap no-op
+	// (zero transactions, idempotent latest_block_context overwrite); we
+	// run it unconditionally to keep both paths symmetric.
+	if let Some(synthetic) = received_tx.blocks.last().filter(|last| {
+		last.number == 0 && received_tx.blocks.iter().any(|b| b.number > 0)
+	}) {
+		if let ForkAwareLedgerContext::Ledger8(ctx8) = &fork_ctx {
+			apply_block_8(ctx8, synthetic);
+		}
+	}
+
 	// 6. Save updated cache.
-	if let Some(final_block) = blocks.last() {
+	//
+	// Use `max_by_key(|b| b.number)` rather than `blocks.last()`:
+	// `SourceTransactions::from_blocks(_, dust_warp = true, _)` appends a
+	// synthetic timestamp-only block at the end of `blocks` with
+	// `RawBlockData::new_from_timestamp(...)`, which sets `number = 0`
+	// (see `ledger/helpers/src/fork/raw_block_data.rs:139`). Using
+	// `.last()` here would tag the cache with `block_height = 0` even
+	// though the inner state has been replayed to the actual head — on
+	// the next run the saved snapshot would be picked up, the replay
+	// would start at block 0, and dust events would be re-inserted into
+	// an already-full dust generation tree (non-linear insert panic in
+	// `ledger/helpers/src/versions/common/context.rs`).
+	if let Some(final_block) = blocks.iter().max_by_key(|b| b.number) {
 		try_save_cache_v2(&fork_ctx, wallet_seeds, chain_id, final_block.number, storage).await;
 	}
 


### PR DESCRIPTION
# Overview

Fixes two interacting bugs in `build_fork_aware_context_cached` that
surface when callers combine `dust_warp = true` with a persisted
`ledger_state_db`.

**Bug 1 — cache tagged at the wrong height.** The save logic used
`blocks.last()` to pick the height to tag the wallet/ledger snapshot
at, but `SourceTransactions::from_blocks(_, dust_warp = true, _)`
appends a synthetic timestamp-only block to the end of the list with
`RawBlockData::new_from_timestamp(...)`, which hard-codes `number = 0`
(`ledger/helpers/src/fork/raw_block_data.rs:139`). The cache was
therefore persisted with `block_height = 0` even though the inner
state had been replayed to the chain head. On subsequent runs the
snapshot was reloaded, replay restarted at block 0, and dust events
were re-inserted into an already-full generation tree — panic at
`ledger/helpers/src/versions/common/context.rs`: `"values inserted
non-linearly into dust generation tree; expected to insert index
170157, but received 99"`.

**Bug 2 — `--dust-warp` ignored on warm restore.** Even with bug 1
fixed, `--dust-warp` was effectively a no-op on every cache hit. The
warm-path filter `b.number > start_height` drops the synthetic block
(number=0), so `latest_block_context.tblock` kept whatever the cache
snapshot persisted from a previous run. Downstream callers
(`register_dust_address`, batch builders) read a `tblock` that's
potentially days stale.

## The fix

1. **Save-height computation**: `blocks.last()` →
   `blocks.iter().max_by_key(|b| b.number)`. With `dust_warp = false`
   behaviour is unchanged. With `dust_warp = true` the synthetic
   block is no longer picked, and the cache is tagged with the actual
   head block number.
2. **Re-apply synthetic block after replay** (new step 5b in
   `build_fork_aware_context_cached`). The synthetic is detected as
   last-block-number=0 alongside at least one block with number>0,
   and applied via `apply_block_8` after `replay_blocks` so the
   warped wall-clock time lands in `latest_block_context`. On the
   cold path the synthetic was already in the replay set, so the
   re-apply is an idempotent no-op (zero transactions, same block
   context); we run it unconditionally to keep both paths symmetric.

This is load-bearing for the upcoming Cardano Preview e2e warmup work
(PR #1569), which is the first caller in-tree to combine the two
options. Outside the e2e suite it's relevant for any operational
script that wants persisted wallet snapshots from `dust-balance` runs
that pass `--dust-warp`.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking) <!-- non-warp path unchanged -->
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [x] If the changes introduce a new feature, I have bumped the node minor version <!-- bug fix, not a feature; toolkit-only -->
- [x] Update documentation (if relevant) <!-- inline comments at both fix sites explain the synthetic-block invariant and the warm-restore re-apply -->
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- no build / arch / workflow changes -->
- [x] No new todos introduced

## 🧪 Testing Evidence

`cargo test -p midnight-node-toolkit --lib` — pass, including two new
tests added by this PR:

```
test serde_def::transactions::tests::from_blocks_with_dust_warp_appends_synthetic_block_at_number_zero ... ok
test commands::dust_balance::tests::check_balance_caches_at_real_head_with_dust_warp ... ok
```

- `from_blocks_with_dust_warp_appends_synthetic_block_at_number_zero`
  is a focused property test pinning the invariant the fix relies on:
  with `dust_warp = true`, `blocks.last().number == 0` while
  `blocks.iter().max_by_key(|b| b.number).number` equals the highest
  real block. With `dust_warp = false` the two agree.
- `check_balance_caches_at_real_head_with_dust_warp` drives
  `build_fork_aware_context_cached` directly with a
  `SourceTransactions` whose real blocks are renumbered 1..N
  (synthetic stays at number=0) so `chain_id()` resolves and both
  calls go through the cache path. Pins three invariants:
    1. After call 1, the wallet cache snapshot is tagged at the real
       chain head (`max(block.number)`), not at the synthetic
       dust-warp block's `number = 0`.
    2. No snapshot is ever stored at `block_height = 0`.
    3. After call 2 (warm restore), `latest_block_context.tblock >=
       test_start_secs` — confirming the dust-warp re-application
       step is wired correctly.

  Earlier versions of this test went through `dust_balance::execute`,
  which loads `SourceTransactions` via `from_batches`. That path
  hard-codes `RawBlockData::number = 0` for every block, making
  `chain_id()` return `None` and bypassing the cache path entirely —
  the test would have passed even if save/load were broken. The
  renumber forces both runs through the cache path.

`cargo test -p midnight-node-toolkit --test cli_tests` — README
trycmd doctests pass unchanged.

`cargo clippy -p midnight-node-toolkit -- -D warnings` — clean.

End-to-end validation is the e2e suite's `dust_balance_smoke_many`
(PR #1569) restored to its full configuration (`seeds = [01, 02,
03]`, `ledger_state_db = "toolkit_cache/ledger_cache_db"`). Before
this fix, that test panicked back-to-back; with this fix it should
run cleanly twice in a row (a slow first run, a fast warm-cache
second run).

Please describe any additional testing aside from CI:

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: toolkit library change only, no on-chain impact.
- [ ] N/A

## Links

Closes https://github.com/midnightntwrk/midnight-node/issues/1573
