### PR TITLE
Stack overflow on snapshot deserialization for long chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,7 +2964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7947,6 +7956,7 @@ dependencies = [
  "sidechain-domain",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2603)",
  "sqlx",
+ "stacker",
  "strum 0.28.0",
  "subxt 0.50.0",
  "subxt-signer 0.50.0",
@@ -11915,7 +11925,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11935,7 +11945,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -12003,6 +12013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -16840,6 +16860,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "staging-xcm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,7 @@ test-log = "0.2"
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "chrono", "migrate", "bigdecimal"] }
 prost = { version = "0.13.5", default-features = false}
 reqwest = { version = "0.12.22", default-features = false, features = [ "rustls-tls", "blocking", "json" ] }
+stacker = "0.1.24"
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "2", features = ["full", "extra-traits"] }
 

--- a/changes/toolkit/changed/trusted-deserialize-stacker.md
+++ b/changes/toolkit/changed/trusted-deserialize-stacker.md
@@ -1,0 +1,29 @@
+#toolkit
+# Fix stack overflow in `trusted_deserialize_tagged` on long-running chains
+
+`TrustedCacheLoader::get` recurses depth-first through the serialised
+ledger arena: every call invokes `T::from_binary_repr(...)`, which
+iterates the node's children and calls back into `Loader::get` for
+each, producing one stack frame per arena node visited. On chains
+long enough to produce deep storage trees (Cardano Preview after
+~1 M blocks; ~3.7 M arena nodes in the reproducing run) the
+recursion depth combined with per-frame size exceeded the default
+2 MiB tokio worker thread stack and the process aborted with SIGABRT
+mid-deserialise.
+
+Wraps the body of `Loader::get` in `stacker::maybe_grow(64 KiB, 1
+MiB, ...)`. When remaining stack drops below the red zone, `stacker`
+allocates a fresh 1 MiB extension stack and resumes the recursion on
+it; otherwise the call runs in place with essentially zero overhead.
+Same pattern rustc, regex, syn, swc, and deno use for
+deep-recursion-prone code. No API change, no caller responsibility,
+no env var — the workaround of setting `RUST_MIN_STACK` per
+invocation is no longer required.
+
+Surfaced while validating PR #1574's cache-tag fix end-to-end via the
+e2e suite's `dust_balance_smoke_many` (PR #1569). The bug was latent
+until #1574 made snapshots tagged at the real chain head, exercising
+the warm-cache restore path for the first time.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1576
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1575

--- a/util/toolkit/Cargo.toml
+++ b/util/toolkit/Cargo.toml
@@ -54,6 +54,7 @@ ogmios-client = { workspace = true, features = ["jsonrpsee-client"] }
 whisky.workspace = true
 sidechain-domain.workspace = true
 zeroize.workspace = true
+stacker.workspace = true
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/util/toolkit/src/fetcher/trusted_deserialize.rs
+++ b/util/toolkit/src/fetcher/trusted_deserialize.rs
@@ -38,6 +38,18 @@ use midnight_node_ledger_helpers::{
 use sha2::{Digest, Sha256};
 use std::{collections::HashMap, io};
 
+/// Minimum stack required before `stacker::maybe_grow` allocates an
+/// extension stack. Empirically ~64 KiB is enough headroom for a
+/// `Loader::get` frame plus the work `T::from_binary_repr` does at that
+/// frame; anything tighter risks an overflow before `maybe_grow` is
+/// re-evaluated at the next recursion level.
+const STACKER_RED_ZONE: usize = 64 * 1024;
+
+/// Size of each extension stack allocated by `stacker::maybe_grow`. 1
+/// MiB matches what rustc and other deep-recursion-prone crates use as
+/// the default extension chunk.
+const STACKER_GROW_SIZE: usize = 1024 * 1024;
+
 /// Reimplements `child_from` from `midnight-storage-core/storable.rs`.
 ///
 /// Must stay in sync with upstream's `child_from` + `is_in_small_object_limit`.
@@ -102,7 +114,14 @@ impl Loader<DefaultDB> for TrustedCacheLoader<'_> {
 		&self,
 		key: &ArenaKey<<DefaultDB as DB>::Hasher>,
 	) -> Result<Sp<T, DefaultDB>, io::Error> {
-		match key {
+		// `T::from_binary_repr` recursively calls back into `Loader::get`
+		// for each child node, which on a long-running chain's snapshot
+		// (millions of arena nodes, dust generation tree depth tracking
+		// log2(n)) can exhaust the default 2 MiB stack of a tokio worker
+		// thread. `stacker::maybe_grow` checks remaining stack and, only
+		// if it's below the red zone, allocates a fresh 1 MiB stack to
+		// continue on. Same pattern rustc / regex / syn / swc use.
+		stacker::maybe_grow(STACKER_RED_ZONE, STACKER_GROW_SIZE, || match key {
 			ArenaKey::Direct(node) => {
 				let child_loader = TrustedCacheLoader { node_map: self.node_map };
 				let value = T::from_binary_repr(
@@ -124,7 +143,7 @@ impl Loader<DefaultDB> for TrustedCacheLoader<'_> {
 				)?;
 				Ok(default_storage::<DefaultDB>().arena.alloc(value))
 			},
-		}
+		})
 	}
 
 	fn alloc<T: Storable<DefaultDB>>(&self, obj: T) -> Sp<T, DefaultDB> {


### PR DESCRIPTION
# Overview

Fixes a stack overflow in
`util/toolkit/src/fetcher/trusted_deserialize.rs::TrustedCacheLoader::get`
that surfaces when a `dust-balance` (or any other) call restores a
previously persisted ledger snapshot from `ledger_state_db` on a
long-running chain.

`Loader::get` recurses depth-first through the serialised arena:
every call invokes `T::from_binary_repr(...)`, which iterates the
node's children and calls `child_loader.get(child_key)` for each,
producing one stack frame per arena node visited. On Cardano Preview
after ~1 M blocks (~3.7 M arena nodes deserialised in our
reproduction) the recursion depth and per-frame size combined exceed
the default 2 MiB tokio worker thread stack and the process aborts
with SIGABRT mid-deserialise:

```
Trusted deserialize: complete in 10.249s (3713560 nodes)
Replaying 161 blocks after cache checkpoint (1088482..)

thread '...' (pid) has overflowed its stack
fatal runtime error: stack overflow, aborting
```

The fix wraps the body of `Loader::get` in `stacker::maybe_grow(64 KiB,
1 MiB, ...)`. When the remaining stack drops below the 64 KiB red
zone, `stacker` allocates a fresh 1 MiB extension stack and resumes
the recursion on it; otherwise the closure runs in place with
essentially zero overhead. Same pattern rustc, regex, syn, swc, and
deno use for deep-recursion-prone code paths. No API change, no
caller responsibility, no env var.

Pre-fix workaround was `RUST_MIN_STACK=33554432` (32 MiB) per
invocation — workable but every caller has to remember it and silent
failure otherwise. This PR removes the need for it.

Surfaced while validating the cache-tag fix (#1574) end-to-end via
the e2e suite's `dust_balance_smoke_many` (PR #1569). Before #1574 the
snapshot was always tagged at `block_height = 0` and was either
discarded or panicked with a non-linear dust-tree insertion before
deserialisation completed; nobody ran into this stack overflow because
nobody made it past the prerequisite cache-tag bug. Now that snapshots
are saved at the real chain head, the warm-cache restore path is
actually exercised — and the deserialiser hits this defect.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking) <!-- no API change; behaviour change is "doesn't abort", which existing callers strictly prefer -->
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [x] If the changes introduce a new feature, I have bumped the node minor version <!-- bug fix, not a feature; toolkit-only -->
- [x] Update documentation (if relevant) <!-- inline comments explain the maybe_grow rationale -->
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- no build / arch / workflow changes; new transitive dep `stacker = "0.1"` -->
- [x] No new todos introduced

## 🧪 Testing Evidence

`cargo test -p midnight-node-toolkit --lib` — 98/98 lib tests pass,
including all 6 `trusted_deserialize` cases (which exercise the
roundtrip the fix wraps) unchanged.

`cargo test -p midnight-node-toolkit --test cli_tests` — 1/1 README
trycmd doctests pass.

`cargo clippy -p midnight-node-toolkit -- -D warnings` — clean.

End-to-end validation is the e2e suite's `dust_balance_smoke_many`
(PR #1569) running back-to-back **without** `RUST_MIN_STACK`. Before
this PR, the second invocation aborts with SIGABRT during
`Trusted deserialize` after ~25 s. After this PR the second
invocation completes in ~37 s (warm cache hit, snapshot restored,
delta blocks applied).

Please describe any additional testing aside from CI:

- [x] Additional tests are provided (if possible) <!-- existing trusted_deserialize roundtrip test pins the deserialisation behaviour; the stack-exhaustion regime needs a multi-million-node tree which is impractical to fixture, so end-to-end qanet run is the regression case -->

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: toolkit library change only, no on-chain impact.
- [ ] N/A

## Links

Closes #1575
