### PR TITLE
ci(nightly-e2e-qanet): integrate shared toolkit fetch cache

### DIFF
--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -14,7 +14,12 @@ concurrency:
 
 jobs:
   rust_e2e:
-    runs-on: ubuntu-latest
+    # Self-hosted Hetzner runner (fsn1-runner-01.hetzner.shielded.tools).
+    # The runner's static public IP (178.63.134.209) is on the
+    # toolkit-cache NLB security-group allowlist, so it can talk directly
+    # to the shared RDS without VPN/SDM. `ubuntu-latest` is NOT supported
+    # for this workflow - GH-hosted runner egress is unallowlistable.
+    runs-on: [self-hosted, "tier:large"]
     timeout-minutes: 360
 
     steps:
@@ -36,17 +41,42 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install system dependencies (protoc)
+      - name: Install system dependencies (protoc, postgresql-client)
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler postgresql-client
           protoc --version
+          psql --version
+
+      # Toolkit fetch cache: shared RDS Postgres in shielded-dev fronted
+      # by an NLB locked to this runner's static IP. See:
+      #   - shieldedtech/shielded-iac    aws/dev/eu-west-1/toolkit-cache-rds
+      #   - shieldedtech/shielded-gitops issue #2152
+      #
+      # TOOLKIT_CACHE_DB_URL is a repo secret of the form:
+      #   postgresql://toolkit_cache_admin:<pw>@toolkit-cache-nlb-...elb.eu-west-1.amazonaws.com:5432/toolkit_cache_qanet?sslmode=require
+      - name: Smoke test toolkit-cache DB
+        shell: bash
+        env:
+          TOOLKIT_CACHE_DB_URL: ${{ secrets.TOOLKIT_CACHE_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TOOLKIT_CACHE_DB_URL" ]; then
+            echo "::error::TOOLKIT_CACHE_DB_URL secret is not set"
+            exit 1
+          fi
+          psql "$TOOLKIT_CACHE_DB_URL" -c 'SELECT 1;' >/dev/null
+          echo "toolkit-cache DB reachable from this runner."
 
       - name: Run e2e tests (all)
         working-directory: tests/e2e/tests
         env:
           RUST_BACKTRACE: "1"
+          # Consumed by tests/e2e/tests/lib.rs::fetch_cache_config() on
+          # the qanet branch - pending a consumer change on the
+          # e2e-cngd-for-cardano-preview branch that reads this env var.
+          TOOLKIT_CACHE_DB_URL: ${{ secrets.TOOLKIT_CACHE_DB_URL }}
         run: |
           cargo test --test e2e_tests cnight --no-default-features --features "${{ steps.vars.outputs.env }}" -- --no-capture
 
@@ -61,9 +91,9 @@ jobs:
         shell: bash
         run: |
           if [ "$STATUS" = "success" ]; then
-            MESSAGE="✅ ${ENV_NAME} env nightly e2e cNgD passed successfully\n${RUN_URL}"
+            MESSAGE="OK ${ENV_NAME} env nightly e2e cNgD passed successfully\n${RUN_URL}"
           else
-            MESSAGE="❌ ${ENV_NAME} env nightly e2e cNgD failed\n${RUN_URL}"
+            MESSAGE="FAIL ${ENV_NAME} env nightly e2e cNgD failed\n${RUN_URL}"
           fi
 
           curl -X POST -H "Content-type: application/json" \

--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -14,11 +14,8 @@ concurrency:
 
 jobs:
   rust_e2e:
-    # Self-hosted Hetzner runner (fsn1-runner-01.hetzner.shielded.tools).
-    # The runner's static public IP (178.63.134.209) is on the
-    # toolkit-cache NLB security-group allowlist, so it can talk directly
-    # to the shared RDS without VPN/SDM. `ubuntu-latest` is NOT supported
-    # for this workflow - GH-hosted runner egress is unallowlistable.
+    # Hetzner self-hosted; its static IP is on the toolkit-cache NLB
+    # allowlist. ubuntu-latest cannot reach the shared cache.
     runs-on: [self-hosted, "tier:large"]
     timeout-minutes: 360
 
@@ -47,15 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler postgresql-client
           protoc --version
-          psql --version
 
-      # Toolkit fetch cache: shared RDS Postgres in shielded-dev fronted
-      # by an NLB locked to this runner's static IP. See:
-      #   - shieldedtech/shielded-iac    aws/dev/eu-west-1/toolkit-cache-rds
-      #   - shieldedtech/shielded-gitops issue #2152
-      #
-      # TOOLKIT_CACHE_DB_URL is a repo secret of the form:
-      #   postgresql://toolkit_cache_admin:<pw>@toolkit-cache-nlb-...elb.eu-west-1.amazonaws.com:5432/toolkit_cache_qanet?sslmode=require
       - name: Smoke test toolkit-cache DB
         shell: bash
         env:
@@ -67,15 +56,11 @@ jobs:
             exit 1
           fi
           psql "$TOOLKIT_CACHE_DB_URL" -c 'SELECT 1;' >/dev/null
-          echo "toolkit-cache DB reachable from this runner."
 
       - name: Run e2e tests (all)
         working-directory: tests/e2e/tests
         env:
           RUST_BACKTRACE: "1"
-          # Consumed by tests/e2e/tests/lib.rs::fetch_cache_config() on
-          # the qanet branch - pending a consumer change on the
-          # e2e-cngd-for-cardano-preview branch that reads this env var.
           TOOLKIT_CACHE_DB_URL: ${{ secrets.TOOLKIT_CACHE_DB_URL }}
         run: |
           cargo test --test e2e_tests cnight --no-default-features --features "${{ steps.vars.outputs.env }}" -- --no-capture
@@ -91,9 +76,9 @@ jobs:
         shell: bash
         run: |
           if [ "$STATUS" = "success" ]; then
-            MESSAGE="OK ${ENV_NAME} env nightly e2e cNgD passed successfully\n${RUN_URL}"
+            MESSAGE="✅ ${ENV_NAME} env nightly e2e cNgD passed successfully\n${RUN_URL}"
           else
-            MESSAGE="FAIL ${ENV_NAME} env nightly e2e cNgD failed\n${RUN_URL}"
+            MESSAGE="❌ ${ENV_NAME} env nightly e2e cNgD failed\n${RUN_URL}"
           fi
 
           curl -X POST -H "Content-type: application/json" \


### PR DESCRIPTION
# Overview

Wire the nightly qanet cNgD e2e workflow into the shared toolkit fetch cache (Postgres RDS in shielded-dev, fronted by an NLB whose security group only allows the Hetzner runner's static IP). Cold-cache sync on qanet costs ~3h per run today; the shared cache eliminates that.

Closes [shieldedtech/shielded-gitops#2152](https://github.com/shieldedtech/shielded-gitops/issues/2152).

## What changes

`.github/workflows/nightly-run-cnight-e2e-qanet.yml` only:

- `runs-on`: `ubuntu-latest` → `[self-hosted, "tier:large"]` (Hetzner fleet). Required because the toolkit-cache NLB is locked to specific static IPs — GH-hosted runners have unallowlistable egress.
- Install `postgresql-client` alongside `protoc`.
- New pre-flight smoke step: `psql -c 'SELECT 1;'` against `TOOLKIT_CACHE_DB_URL`. Fails fast (~1s) if the DB or NLB is broken, before the ~4h cargo test job starts.
- Pass `TOOLKIT_CACHE_DB_URL` to the cargo test step via `env`.

## Verified before opening

End-to-end SQL round-trip from `fsn1-runner-01` through the NLB to the RDS:

- Runner egress IP `178.63.134.209` → NLB SG allow.
- NLB DNS resolves to the three EIPs (`34.253.0.153`, `54.246.98.89`, `52.208.163.70`).
- TCP probe to NLB:5432 succeeds.
- `psql … -c 'SELECT 1;'` returns `1`, DB `toolkit_cache_qanet`, engine PostgreSQL 16.14.

## Prereqs (already done)

- [x] `TOOLKIT_CACHE_DB_URL` repo secret set (rotate via: `pw=$(AWS_PROFILE=shielded-dev aws secretsmanager get-secret-value --secret-id toolkit-cache/master --region eu-west-1 --query SecretString --output text | jq -r .password); printf '%s' "postgresql://toolkit_cache_admin:${pw}@toolkit-cache-nlb-a6d7b387f8880acb.elb.eu-west-1.amazonaws.com:5432/toolkit_cache_qanet?sslmode=require" | gh secret set TOOLKIT_CACHE_DB_URL --repo midnightntwrk/midnight-node`).

## Out of scope

Consumer-side wiring of individual test bodies — when QA revives a commented dust-balance / tx-generator block on `e2e-cngd-for-cardano-preview`, they convert each `FetchCacheConfig::InMemory` literal to:

```rust
let url = std::env::var("TOOLKIT_CACHE_DB_URL").unwrap_or_default();
let fetch_cache = if url.is_empty() {
    FetchCacheConfig::InMemory  // local-dev fallback
} else {
    FetchCacheConfig::Postgres { database_url: url }
};
```

The integration contract this PR establishes is the env var. The wiring lives naturally in the same PR(s) that revive those tests.

## Submission checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (workflow on a different runner pool; e2e test logic untouched)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version — N/A
- [x] Update documentation (if relevant) — see shielded-iac stack README
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed — N/A
- [x] No new todos introduced

## Links

- Issue: [shieldedtech/shielded-gitops#2152](https://github.com/shieldedtech/shielded-gitops/issues/2152)
- Wider context: [shieldedtech/shielded-qa#50](https://github.com/shieldedtech/shielded-qa/issues/50)
- Infra: shielded-iac [#1437](https://github.com/shieldedtech/shielded-iac/pull/1437), [#1441](https://github.com/shieldedtech/shielded-iac/pull/1441), [#1444](https://github.com/shieldedtech/shielded-iac/pull/1444), [#1445](https://github.com/shieldedtech/shielded-iac/pull/1445), [#1449](https://github.com/shieldedtech/shielded-iac/pull/1449)
