### PR TITLE
test(e2e): add fetch_cache_config helper reading TOOLKIT_CACHE_DB_URL

### DIFF
--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -16,6 +16,28 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tokio::time::{Duration, timeout};
 
+// -------- TOOLKIT FETCH CACHE --------
+
+/// Returns the `FetchCacheConfig` for toolkit dust-balance / tx-generator
+/// calls in these e2e tests.
+///
+/// Reads `TOOLKIT_CACHE_DB_URL` from the environment (a Postgres connection
+/// string of the form
+/// `postgresql://user:pass@host:port/dbname?sslmode=require`). The nightly
+/// CI workflow injects it from a repo secret pointing at the shared
+/// `toolkit-cache` RDS in shielded-dev. Falls back to `InMemory` when the
+/// env var is unset or empty, so local-dev runs work without the shared
+/// cache.
+///
+/// See: shieldedtech/shielded-gitops#2152.
+#[allow(dead_code)]
+fn fetch_cache_config() -> FetchCacheConfig {
+    match std::env::var("TOOLKIT_CACHE_DB_URL") {
+        Ok(url) if !url.is_empty() => FetchCacheConfig::Postgres { database_url: url },
+        _ => FetchCacheConfig::InMemory,
+    }
+}
+
 // -------- GLOBAL ASYNC FAUCET MANAGER --------
 
 static FAUCET_MANAGER: OnceCell<Arc<FaucetManager>> = OnceCell::const_new();


### PR DESCRIPTION
# Overview

Companion to [midnightntwrk/midnight-node#1578](https://github.com/midnightntwrk/midnight-node/pull/1578) (workflow change on `main`). The workflow injects a `TOOLKIT_CACHE_DB_URL` env var pointing at the shared toolkit-cache RDS in shielded-dev (provisioned in [shieldedtech/shielded-iac#1437](https://github.com/shieldedtech/shielded-iac/pull/1437) + follow-ups). This PR adds the helper that converts that env var into a `FetchCacheConfig::Postgres` for the e2e tests.

Targets `e2e-cngd-for-cardano-preview` because that's the branch the nightly workflow actually checks out at runtime.

## What changes

`tests/e2e/tests/lib.rs` only:

\`\`\`rust
#[allow(dead_code)]
fn fetch_cache_config() -> FetchCacheConfig {
    match std::env::var(\"TOOLKIT_CACHE_DB_URL\") {
        Ok(url) if !url.is_empty() => FetchCacheConfig::Postgres { database_url: url },
        _ => FetchCacheConfig::InMemory,
    }
}
\`\`\`

- Reads `TOOLKIT_CACHE_DB_URL` from env.
- Falls back to `InMemory` when unset — local-dev runs without the shared cache still work as before.

## Why `#[allow(dead_code)]`

All current dust-balance / tx-generator call sites on this branch are commented out (lines 535, 559, 706, 1504, ...). Wiring the helper into those blocks belongs in the same PR(s) that revive them — I didn't want to touch test bodies that are mid-iteration. When you uncomment a block, swap each `FetchCacheConfig::InMemory` literal for `fetch_cache_config()` to opt the test into the shared cache.

## Closes the consumer-side AC item on shieldedtech/shielded-gitops#2152

> ... we'll switch the qanet branch to read from the TOOLKIT_CACHE_DB_URL env var (defaulting to the local URL for offline dev).

Implementation note: the AC's wording (\"defaulting to the local URL\") is slightly off for the new architecture. The original setup expected the shared DB to be Postgres-only and you'd pick the local URL when offline. With the `InMemory` fallback, offline dev gets zero-dependency behaviour instead of a connection-refused error from a missing local Postgres. Keeps the dev loop friction-free.

## Submission checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (helper is opt-in; existing tests unaffected)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: test-only addition on a feature branch
- [ ] If the changes introduce a new feature, I have bumped the node minor version - N/A
- [x] Update documentation (if relevant) - inline rustdoc covers it
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed - N/A
- [x] No new todos introduced

## Testing evidence

- `cargo check` passes on this branch with the helper added.
- Hetzner runner + NLB path proven end-to-end before opening this PR: SSH'd to `fsn1-runner-01`, ran `psql … -c 'SELECT 1;'` against the NLB DNS, got `1` back with engine `PostgreSQL 16.14`, db `toolkit_cache_qanet`.

Functional validation (helper picked up by an actual revived test) is downstream of whoever lands the test-body work.

## Links

- Workflow PR: [midnightntwrk/midnight-node#1578](https://github.com/midnightntwrk/midnight-node/pull/1578)
- Issue: [shieldedtech/shielded-gitops#2152](https://github.com/shieldedtech/shielded-gitops/issues/2152)
- Wider context: [shieldedtech/shielded-qa#50](https://github.com/shieldedtech/shielded-qa/issues/50)
- Infra: shielded-iac #1437, #1441, #1444, #1445, #1449