### PR TITLE
fix(ci): harden self-hosted sync-test and local-env against shared-host state

### DIFF
--- a/.github/actions/local-environment-tests/action.yml
+++ b/.github/actions/local-environment-tests/action.yml
@@ -84,6 +84,25 @@ runs:
       run: npm install -g npm@11.11.0
       shell: bash
 
+    # The local-env stack publishes fixed host ports (1442, 1337, 8088, 4222,
+    # 5432, 30000, 32000). On a shared self-hosted host a container left behind
+    # by a cancelled or crashed prior run keeps a port bound, so the fresh stack
+    # fails with "Bind for 127.0.0.1:8088 failed: port is already allocated".
+    # The job's concurrency group only serialises this job against itself, not
+    # against leftovers. Tear down the project and reclaim any container still
+    # holding those ports before bringing the stack up.
+    - name: Reclaim leftover containers and ports (self-hosted shared host)
+      shell: bash
+      run: |
+        docker compose -p local-env down --remove-orphans --volumes 2>/dev/null || true
+        for port in 1442 1337 8088 4222 5432 30000 32000; do
+          cids=$(docker ps -q --filter "publish=$port" || true)
+          if [ -n "$cids" ]; then
+            echo "Reclaiming port $port from container(s): $cids"
+            docker rm -f $cids || true
+          fi
+        done
+
     - name: Deploy local environment
       run: |
         echo "🔍 Debug: Checking input values..."

--- a/.github/actions/local-environment-tests/action.yml
+++ b/.github/actions/local-environment-tests/action.yml
@@ -84,24 +84,24 @@ runs:
       run: npm install -g npm@11.11.0
       shell: bash
 
-    # The local-env stack publishes fixed host ports (1442, 1337, 8088, 4222,
-    # 5432, 30000, 32000). On a shared self-hosted host a container left behind
-    # by a cancelled or crashed prior run keeps a port bound, so the fresh stack
-    # fails with "Bind for 127.0.0.1:8088 failed: port is already allocated".
-    # The job's concurrency group only serialises this job against itself, not
-    # against leftovers. Tear down the project and reclaim any container still
-    # holding those ports before bringing the stack up.
-    - name: Reclaim leftover containers and ports (self-hosted shared host)
+    # The local-env stack uses fixed container_names and publishes fixed host
+    # ports (validators 30333-30337 / 9933-9944 / 9615-9619, plus 32000, 30000,
+    # 8088, 4222). On a shared self-hosted host a container left by a cancelled
+    # or crashed prior run keeps a name/port bound, so the fresh stack fails with
+    # "port is already allocated" or a name conflict. The job's concurrency group
+    # only serialises this job against itself, not against leftovers. Tear the
+    # whole compose project down by label so every leftover service is reclaimed
+    # regardless of which name/port it holds — rather than a hand-maintained port
+    # list, which drifts as the compose file changes.
+    - name: Reclaim leftover local-env stack (self-hosted shared host)
       shell: bash
       run: |
         docker compose -p local-env down --remove-orphans --volumes 2>/dev/null || true
-        for port in 1442 1337 8088 4222 5432 30000 32000; do
-          cids=$(docker ps -q --filter "publish=$port" || true)
-          if [ -n "$cids" ]; then
-            echo "Reclaiming port $port from container(s): $cids"
-            docker rm -f $cids || true
-          fi
-        done
+        leftovers=$(docker ps -aq --filter "label=com.docker.compose.project=local-env" || true)
+        if [ -n "$leftovers" ]; then
+          echo "Force-removing leftover local-env containers: $leftovers"
+          docker rm -f $leftovers || true
+        fi
 
     - name: Deploy local environment
       run: |

--- a/scripts/sync-test/run-sync.sh
+++ b/scripts/sync-test/run-sync.sh
@@ -27,9 +27,13 @@ POSTGRES_IMAGE=${POSTGRES_IMAGE:-postgres:17.4-alpine}
 SNAPSHOT=${SNAPSHOT:-snapshot.sql}
 CFG_PRESET=${CFG_PRESET:-mainnet}
 SYNC_UNTIL=${SYNC_UNTIL:-1000}
-NETWORK_NAME=${NETWORK_NAME:-midnight-sync-test}
-PG_CONTAINER=${PG_CONTAINER:-midnight-sync-test-pg}
-NODE_CONTAINER=${NODE_CONTAINER:-midnight-sync-test-node}
+# Suffix container/network names with a per-run id so concurrent jobs sharing a
+# docker host (e.g. self-hosted CI runner slots) don't collide on fixed names
+# and tear down each other's containers. Falls back to the shell PID off-CI.
+RUN_ID=${RUN_ID:-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}
+NETWORK_NAME=${NETWORK_NAME:-midnight-sync-test-$RUN_ID}
+PG_CONTAINER=${PG_CONTAINER:-midnight-sync-test-pg-$RUN_ID}
+NODE_CONTAINER=${NODE_CONTAINER:-midnight-sync-test-node-$RUN_ID}
 PG_PASSWORD=${PG_PASSWORD:-cardano}
 SYNC_TIMEOUT_SECS=${SYNC_TIMEOUT_SECS:-1800}
 STALL_TIMEOUT_SECS=${STALL_TIMEOUT_SECS:-180}
@@ -100,10 +104,18 @@ docker run -d --rm \
   "$POSTGRES_IMAGE" \
   -c "$PG_INIT" >/dev/null
 
-echo "==> Waiting for postgres..." >&2
+echo "==> Waiting for postgres (real server over TCP)..." >&2
+# Probe over TCP (-h 127.0.0.1), not the Unix socket. On first boot the postgres
+# image runs a temporary socket-only server (listen_addresses='') to create
+# POSTGRES_DB, logs "ready to accept connections", then shuts it down to start
+# the real server. pg_isready over the socket goes green against that temp
+# server, so the snapshot load below would race its shutdown and fail with
+# "the database system is shutting down". The temp init server never listens on
+# TCP, so a TCP query against cexplorer only succeeds once the real server is up.
 pg_ready=0
 for _ in $(seq 1 60); do
-  if docker exec "$PG_CONTAINER" pg_isready -U cardano -d cexplorer >/dev/null 2>&1; then
+  if docker exec -e PGPASSWORD="$PG_PASSWORD" "$PG_CONTAINER" \
+      psql -h 127.0.0.1 -U cardano -d cexplorer -tAc 'SELECT 1' >/dev/null 2>&1; then
     pg_ready=1
     break
   fi


### PR DESCRIPTION
# Overview

Two self-hosted CI jobs fail because of host-level state the runner migration exposed (distinct from the GHCR docker-config fix in #1585, which is working). Details in #1592.

**1. Mainnet Sync — postgres readiness race (`scripts/sync-test/run-sync.sh`)**

`pg_isready` over the Unix socket goes green against the postgres image's first-boot *temporary socket-only* init server (which creates `POSTGRES_DB`, then shuts down to start the real server). The snapshot-loading `psql` then raced that shutdown → `FATAL: the database system is shutting down`. Now probes over **TCP** (`-h 127.0.0.1`); the temp init server never listens on TCP, so a TCP query against `cexplorer` only succeeds once the real server is up. Container/network names are also suffixed with a per-run id so concurrent jobs on one host don't collide. (Non-blocking check, but flaky.)

**2. Local Environment Tests — fixed host port already allocated (composite action)**

`Bind for 127.0.0.1:8088 failed: port is already allocated`. The stack publishes fixed host ports; the job's concurrency group only serialises it against itself, so a container left by a cancelled/crashed prior run keeps a port bound and wedges the fresh stack. Added a pre-flight teardown (`docker compose -p local-env down --remove-orphans --volumes` + reclaim any container still publishing those ports). (This is a required, merge-blocking check.)

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Diagnosed from the failing run's captured logs: the postgres container log shows the temp-init-server shutdown sequence (mainnet-sync), and the compose error shows `port is already allocated` on 8088 (local-env). `bash -n` passes on the script; the composite action YAML parses. Final validation is the next self-hosted run on this PR — note `Mainnet Sync` is non-blocking, so watch `Local Environment Tests` specifically.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A

## Links

Closes #1592