### PR TITLE
feat(toolkit): add batched dust_balance::execute_many

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -69,17 +69,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+          # actions/checkout leaves the workspace on the PR merge commit in
+          # detached-HEAD state, so the EARTHLY_GIT_BRANCH builtin resolves to
+          # the literal string "HEAD" for every PR — useless for cache scoping.
+          # Use the actual head ref (PR source branch) or ref_name (push /
+          # merge_group). Sanitize: substitute any char outside [A-Za-z0-9._-]
+          # with '-' so e.g. `feat/foo` becomes `feat-foo`.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          GH_REF_FOR_BUILD: ${{ github.ref }}
         run: |
           PUSH_FLAG=""
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GH_REF_FOR_BUILD" = "refs/heads/main" ]; then
             PUSH_FLAG="--push"
           fi
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          # tr produces an empty string for empty input; guard so we never
+          # cache as `target-` (would silently merge all unkeyed runs).
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
           . ./.envrc && earthly -P \
             --secret GITHUB_TOKEN="$GITHUB_TOKEN" \
             --secret DOCKERHUB_USER="$DOCKERHUB_USER" \
             --secret DOCKERHUB_TOKEN="$DOCKERHUB_TOKEN" \
             --strict $PUSH_FLAG \
-            --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test +test
+            --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test \
+            +test --CACHE_KEY="$CACHE_KEY"
 
       - name: Upload test report artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -445,8 +445,19 @@ jobs:
 
       - name: Run pallet fixture tests
         if: steps.guard.outputs.hit != 'true'
+        env:
+          # See +test's `Run build` step for why EARTHLY_GIT_BRANCH is unsafe
+          # under actions/checkout; reach for the actual head/ref name instead.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
-          . ./.envrc && earthly -P --strict +test-pallet-fixtures
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
+          . ./.envrc && earthly -P --strict \
+            +test-pallet-fixtures --CACHE_KEY="$CACHE_KEY"
 
       - uses: ./.github/actions/tree-cache-guard/save
         if: steps.guard.outputs.hit != 'true'
@@ -535,15 +546,28 @@ jobs:
           # wrong auth; override to empty for the earthly call.
           ACTIONS_CACHE_URL: ""
           ACTIONS_RUNTIME_URL: ""
+          # +test-toolkit pulls in +build-test-toolkit's `target-${CACHE_KEY}`
+          # cache mount. Pass the PR ref so it's scoped per-branch on this
+          # shared self-hosted runner — see +test's `Run build` step for the
+          # full rationale and why EARTHLY_GIT_BRANCH is unsafe here.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          NODE_IMAGE_TAG: ${{ needs.run.outputs.node_image_tag }}
         run: |
           PUSH_FLAG=""
           if [ "$EVENT_NAME" = "merge_group" ]; then
             PUSH_FLAG="--push"
           fi
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
           . ./.envrc && earthly --secret GITHUB_TOKEN="$GITHUB_TOKEN" -P --strict $PUSH_FLAG \
             --remote-cache=ghcr.io/midnight-ntwrk/midnight-node:cache-test-toolkit \
-            --build-arg "NODE_IMAGE=ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}" \
-            +test-toolkit
+            +test-toolkit \
+              --NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:${NODE_IMAGE_TAG}" \
+              --CACHE_KEY="$CACHE_KEY"
 
       - uses: ./.github/actions/tree-cache-guard/save
         if: steps.guard.outputs.hit != 'true'

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,19 @@
 VERSION 0.8
 
+# Scopes the cargo build directory (`/target`) so PRs running on the same
+# self-hosted runner host don't share `.rmeta` / `.rlib` artifacts via a
+# stable auto-generated cache id. Without scoping, an in-flight branch
+# that's changed a pallet's trait surface can leak its build into the
+# next PR's job and cause spurious E0046 trait/impl mismatches.
+#
+# Default is constant so local invocations share one cache. CI must
+# override this with a per-branch value (passed via `--build-arg
+# CACHE_KEY=<sanitized PR head ref>`). The Earthly builtin
+# EARTHLY_GIT_BRANCH is NOT a reliable source here because actions/checkout
+# leaves the workspace on the PR merge commit in detached-HEAD state, so
+# the builtin resolves to the literal string `HEAD` across every PR.
+ARG --global CACHE_KEY=local
+
 # ================ Local Targets START ================
 # If you add a new one here, prefix it with "local-"
 # Add the target name to the doc string so it shows up
@@ -180,7 +194,8 @@ rebuild-sqlx:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
     COPY local-environment/localenv_postgres.password .
     RUN \
         DATABASE_URL=postgres://postgres:$(cat localenv_postgres.password)@$([ "$USEROS" = "linux" ] && echo "172.17.0.1" || echo "host.docker.internal"):5432/cexplorer \
@@ -767,7 +782,8 @@ planner:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
     RUN cargo chef prepare --recipe-path recipe.json
     SAVE ARTIFACT recipe.json /recipe.json
 
@@ -844,7 +860,8 @@ test:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # Test
     RUN mkdir /test-artifacts
@@ -887,7 +904,8 @@ test-pallet-fixtures:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # These tests use a mock runtime (MockBlock<Test>), not the real WASM runtime.
     # Debug mode skips LLVM optimization passes, compiling faster than release on free CI runners.
@@ -913,7 +931,8 @@ build-test-toolkit:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # Install dependencies for Node.js and docker CLI (for hardfork e2e tests)
     RUN microdnf -y install tar gzip xz docker && \

--- a/changes/toolkit/added/dust-balance-execute-many.md
+++ b/changes/toolkit/added/dust-balance-execute-many.md
@@ -1,0 +1,29 @@
+#toolkit
+# Add batched `dust_balance::execute_many` for multi-seed wallet cache warmup
+
+New library entry point `dust_balance::execute_many(DustBalanceManyArgs)`
+runs one shared block replay across `Vec<WalletSeed>` and returns per-seed
+`DustBalanceResult`s in input order. Existing single-seed
+`dust_balance::execute` is preserved and now delegates to `execute_many`.
+The CLI surface is unchanged.
+
+This lets callers populate the toolkit's file-based wallet cache for N
+seeds with one expensive replay instead of N: `execute` always restarts
+from genesis when its target seed is uncached, so N sequential
+single-seed calls each pay a full chain replay. One batched call shares
+that replay across all seeds. Useful for any operational workflow that
+needs balances for a known set of seeds (validator wallets,
+governance-member wallets, e2e test warmup), and load-bearing for the
+upcoming Cardano Preview e2e observation tests which generate ~13 random
+seeds per nightly run.
+
+Also bumps the block-replay progress log emitted from
+`replay_blocks_{7,8}` to info level at a throttled 30-second cadence
+(`REPLAY_INFO_HEARTBEAT`). Detailed per-batch progress remains at debug;
+the heartbeat is what users see by default during a multi-hour replay so
+it doesn't look like the process has hung, matching the existing
+fetch-progress info logging.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1603
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1568
+

--- a/util/toolkit/src/commands/dust_balance.rs
+++ b/util/toolkit/src/commands/dust_balance.rs
@@ -21,6 +21,13 @@ pub struct DustBalanceArgs {
 	pub dry_run: bool,
 }
 
+/// Batched form of [`DustBalanceArgs`]. See [`execute_many`].
+pub struct DustBalanceManyArgs {
+	pub source: Source,
+	pub seeds: Vec<WalletSeed>,
+	pub dry_run: bool,
+}
+
 #[derive(Debug, serde::Serialize)]
 pub struct GenerationInfoPair {
 	pub dust_output: QualifiedDustOutputSer,
@@ -40,40 +47,87 @@ pub enum DustBalanceResult {
 	DryRun(()),
 }
 
+/// Single-seed entry point. Thin wrapper around [`execute_many`] — see that
+/// function for the batched form that amortises chain replay across multiple
+/// seeds in one pass.
 pub async fn execute(
 	args: DustBalanceArgs,
 ) -> Result<DustBalanceResult, Box<dyn std::error::Error + Send + Sync>> {
+	let many =
+		DustBalanceManyArgs { source: args.source, seeds: vec![args.seed], dry_run: args.dry_run };
+	let mut results = execute_many(many).await?;
+	// `execute_many` returns one result per input seed; we passed exactly one.
+	Ok(results.pop().expect("execute_many with one seed must return one result").1)
+}
+
+/// Batched dust-balance: run one shared block replay across all `seeds` and
+/// return per-seed results in input order.
+///
+/// One batched call is the only way to amortise the genesis-replay cost across
+/// multiple uncached seeds — calling [`execute`] N times always replays from
+/// genesis N times when all seeds are uncached, because
+/// `build_fork_aware_context_cached` only short-circuits when *every* requested
+/// seed has a cached wallet snapshot.
+///
+/// Empty `seeds` returns `Ok(vec![])` without touching the source. `dry_run`
+/// returns one [`DustBalanceResult::DryRun`] per seed and performs no fetch.
+pub async fn execute_many(
+	args: DustBalanceManyArgs,
+) -> Result<Vec<(WalletSeed, DustBalanceResult)>, Box<dyn std::error::Error + Send + Sync>> {
+	if args.seeds.is_empty() {
+		return Ok(Vec::new());
+	}
+
+	// Construct the source eagerly so that source-argument validation
+	// (`SourceError::InvalidSourceArgs`) runs *before* the dry-run short
+	// circuit. Without this, `dry_run = true` would silently succeed even
+	// with an unusable source config, defeating dry-run as a preflight
+	// check.
 	let ledger_state_db = args.source.ledger_state_db.clone();
 	let fetch_cache = args.source.fetch_cache.clone();
 	let src = TxGenerator::source(args.source, args.dry_run).await?;
 
 	if args.dry_run {
-		log::info!("Dry-run: fetching wallet for seed {:?}", args.seed);
-		return Ok(DustBalanceResult::DryRun(()));
+		log::info!("Dry-run: fetching wallet state for {} seed(s)", args.seeds.len());
+		return Ok(args.seeds.into_iter().map(|s| (s, DustBalanceResult::DryRun(()))).collect());
 	}
 
 	let source_blocks = src.get_txs().await?;
 	let wallet_cache = create_file_wallet_cache(&ledger_state_db, &fetch_cache);
 
-	let fork_ctx = build_fork_aware_context_cached(
-		&[args.seed.clone()],
-		&source_blocks,
-		wallet_cache.as_deref(),
-	)
-	.await;
+	let fork_ctx =
+		build_fork_aware_context_cached(&args.seeds, &source_blocks, wallet_cache.as_deref()).await;
 
-	let json = fork_ctx.dispatch(
+	// `dispatch` consumes the context, so iterate the seeds *inside* the
+	// closure: one context, N per-seed balance extractions.
+	let seeds = args.seeds;
+	let jsons: Vec<DustBalanceJson> = fork_ctx.dispatch(
 		|ctx| {
-			let seed_v7 =
-				crate::tx_generator::builder::builders::ledger_7::type_convert::convert_wallet_seed(
-					args.seed.clone(),
-				);
-			crate::commands::fork::ledger_7::dust_balance::dust_balance(&ctx, seed_v7)
+			seeds
+				.iter()
+				.map(|seed| {
+					let seed_v7 = crate::tx_generator::builder::builders::ledger_7::type_convert::convert_wallet_seed(
+						seed.clone(),
+					);
+					crate::commands::fork::ledger_7::dust_balance::dust_balance(&ctx, seed_v7)
+				})
+				.collect::<Result<Vec<_>, _>>()
 		},
-		|ctx| crate::commands::fork::ledger_8::dust_balance::dust_balance(&ctx, args.seed.clone()),
+		|ctx| {
+			seeds
+				.iter()
+				.map(|seed| {
+					crate::commands::fork::ledger_8::dust_balance::dust_balance(&ctx, seed.clone())
+				})
+				.collect::<Result<Vec<_>, _>>()
+		},
 	)?;
 
-	Ok(DustBalanceResult::Json(json))
+	Ok(seeds
+		.into_iter()
+		.zip(jsons)
+		.map(|(seed, json)| (seed, DustBalanceResult::Json(json)))
+		.collect())
 }
 
 #[cfg(test)]
@@ -87,30 +141,102 @@ mod tests {
 		[env!("CARGO_MANIFEST_DIR"), "/test-data/", &filepath].concat().to_string()
 	}
 
+	fn source_for(src_files: Vec<String>) -> Source {
+		Source {
+			src_url: None,
+			fetch_concurrency: 1,
+			fetch_compute_concurrency: None,
+			src_files: Some(src_files),
+			dust_warp: true,
+			ignore_block_context: false,
+			fetch_only_cached: false,
+			fetch_cache: FetchCacheConfig::InMemory,
+			ledger_state_db: String::new(),
+		}
+	}
+
 	#[test_case("0000000000000000000000000000000000000000000000000000000000000001", vec![td("genesis/genesis_block_undeployed.mn")]; "when using seed 01")]
 	#[tokio::test]
 	async fn check_balance_non_zero(seed: &str, src_files: Vec<String>) {
 		let seed = WalletSeed::try_from_hex_str(seed).unwrap();
-		let args = DustBalanceArgs {
-			source: Source {
-				src_url: None,
-				fetch_concurrency: 1,
-				fetch_compute_concurrency: None,
-				src_files: Some(src_files),
-				dust_warp: true,
-				ignore_block_context: false,
-				fetch_only_cached: false,
-				fetch_cache: FetchCacheConfig::InMemory,
-				ledger_state_db: String::new(),
-			},
-			seed,
-			dry_run: false,
-		};
+		let args = DustBalanceArgs { source: source_for(src_files), seed, dry_run: false };
 
 		let res = execute(args).await.expect("result was not Ok");
 
+		assert!(matches!(res, DustBalanceResult::Json(DustBalanceJson { total, .. }) if total > 0));
+	}
+
+	#[tokio::test]
+	async fn check_balance_many_returns_in_input_order() {
+		// Two seeds against the same genesis fixture. The first is the
+		// known funded seed (matches `check_balance_non_zero`); the second
+		// has no balance. We assert that:
+		//   - the result vector length matches the input,
+		//   - results come back in the order the seeds were supplied,
+		//   - the funded seed reports a non-zero balance.
+		let seeds = vec![
+			WalletSeed::try_from_hex_str(
+				"0000000000000000000000000000000000000000000000000000000000000001",
+			)
+			.unwrap(),
+			WalletSeed::try_from_hex_str(
+				"0000000000000000000000000000000000000000000000000000000000000002",
+			)
+			.unwrap(),
+		];
+		let args = DustBalanceManyArgs {
+			source: source_for(vec![td("genesis/genesis_block_undeployed.mn")]),
+			seeds: seeds.clone(),
+			dry_run: false,
+		};
+
+		let res = execute_many(args).await.expect("result was not Ok");
+
+		assert_eq!(res.len(), 2, "expected one result per input seed");
+		assert_eq!(&res[0].0, &seeds[0], "results should be in input order");
+		assert_eq!(&res[1].0, &seeds[1], "results should be in input order");
 		assert!(
-			matches!(res, DustBalanceResult::Json( DustBalanceJson { total, .. }) if total > 0 )
+			matches!(&res[0].1, DustBalanceResult::Json(DustBalanceJson { total, .. }) if *total > 0),
+			"seed 01 should have a non-zero balance"
 		);
+	}
+
+	#[tokio::test]
+	async fn check_balance_many_empty_seeds_is_noop() {
+		let args = DustBalanceManyArgs {
+			source: source_for(vec![td("genesis/genesis_block_undeployed.mn")]),
+			seeds: Vec::new(),
+			dry_run: false,
+		};
+		let res = execute_many(args).await.expect("result was not Ok");
+		assert!(res.is_empty(), "empty seeds should yield empty result without touching source");
+	}
+
+	#[tokio::test]
+	async fn check_balance_many_dry_run_skips_fetch() {
+		let seeds = vec![
+			WalletSeed::try_from_hex_str(
+				"0000000000000000000000000000000000000000000000000000000000000001",
+			)
+			.unwrap(),
+			WalletSeed::try_from_hex_str(
+				"0000000000000000000000000000000000000000000000000000000000000002",
+			)
+			.unwrap(),
+		];
+		let args = DustBalanceManyArgs {
+			source: source_for(vec![td("genesis/genesis_block_undeployed.mn")]),
+			seeds: seeds.clone(),
+			dry_run: true,
+		};
+		let res = execute_many(args).await.expect("result was not Ok");
+		assert_eq!(res.len(), seeds.len(), "dry-run yields one DryRun per input seed");
+		for (i, (seed, result)) in res.iter().enumerate() {
+			assert_eq!(seed, &seeds[i], "dry-run preserves input order");
+			assert!(
+				matches!(result, DustBalanceResult::DryRun(())),
+				"dry-run must not produce a Json result"
+			);
+		}
 	}
 }

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -809,12 +809,19 @@ type Db8 = midnight_node_ledger_helpers::ledger_8::DefaultDB;
 
 const DUST_BATCH_SIZE: usize = 1000;
 
+/// Interval between info-level "replay progress: …" log lines emitted from
+/// `replay_blocks_{7,8}`. Fine-grained per-batch progress remains at
+/// `log::debug!`; this throttle is what users see by default during a
+/// multi-hour replay so it doesn't look like the process has hung.
+const REPLAY_INFO_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(30);
+
 fn replay_blocks_7(
 	ctx: &midnight_node_ledger_helpers::ledger_7::context::LedgerContext<Db7>,
 	blocks_sorted_by_height: &[&RawBlockData],
 ) {
 	let mut events: Vec<midnight_node_ledger_helpers::ledger_7::Event<Db7>> = Vec::new();
 	let total = blocks_sorted_by_height.len();
+	let mut last_info_at = std::time::Instant::now();
 
 	for (i, block) in blocks_sorted_by_height.iter().enumerate() {
 		events.extend(apply_block_7(ctx, block));
@@ -824,6 +831,20 @@ fn replay_blocks_7(
 			ctx.update_dust_from_events(events.as_slice());
 			events.clear();
 			log::debug!("[perf] replay_blocks_7 progress: {}/{} blocks", i + 1, total);
+		}
+
+		// Heartbeat lives outside the flush branch so a long stretch of
+		// blocks with no dust events still gets a "still alive" signal.
+		// Inside the flush branch this would only fire on `DUST_BATCH_SIZE`
+		// or `is_last`, which on sparse chains can be far apart.
+		if last_info_at.elapsed() >= REPLAY_INFO_HEARTBEAT {
+			log::info!(
+				"replay progress: {}/{} blocks ({:.1}%)",
+				i + 1,
+				total,
+				(i + 1) as f64 / total as f64 * 100.0,
+			);
+			last_info_at = std::time::Instant::now();
 		}
 	}
 
@@ -840,6 +861,7 @@ fn replay_blocks_8(
 	let mut events: Vec<midnight_node_ledger_helpers::ledger_8::Event<Db8>> = Vec::new();
 	let mut remaining = wallets_sorted_by_height;
 	let total = blocks_sorted_by_height.len();
+	let mut last_info_at = std::time::Instant::now();
 
 	for (i, block) in blocks_sorted_by_height.iter().enumerate() {
 		let n = remaining.partition_point(|(_, ws)| ws.block_height < block.number);
@@ -861,6 +883,19 @@ fn replay_blocks_8(
 			ctx.update_dust_from_events(events.as_slice());
 			events.clear();
 			log::debug!("[perf] replay_blocks_8 progress: {}/{} blocks", i + 1, total);
+		}
+
+		// See note in `replay_blocks_7`: heartbeat must be evaluated every
+		// iteration, not gated on the event-flush condition, so sparse
+		// chains still get a "still alive" signal at the 30 s cadence.
+		if last_info_at.elapsed() >= REPLAY_INFO_HEARTBEAT {
+			log::info!(
+				"replay progress: {}/{} blocks ({:.1}%)",
+				i + 1,
+				total,
+				(i + 1) as f64 / total as f64 * 100.0,
+			);
+			last_info_at = std::time::Instant::now();
 		}
 	}
 


### PR DESCRIPTION
# Overview

Add a sibling library function `dust_balance::execute_many` next to the existing
single-seed `execute` in `util/toolkit/src/commands/dust_balance.rs`, accepting
`Vec<WalletSeed>` and running one shared block replay through
`build_fork_aware_context_cached` (which already takes `&[WalletSeed]`). Returns
per-seed `DustBalanceResult`s in input order. Existing `execute` is refactored
to delegate to `execute_many` via a single-element vec; CLI surface is
unchanged.

This is the missing primitive that lets callers populate the toolkit's wallet
cache for N seeds with one expensive replay instead of N. The current
single-seed `execute` always restarts from genesis when its target seed is
uncached (`build_fork_ctx_v2` sets `start_height = 0` whenever *any* requested
seed is uncached), so N sequential single-seed calls each pay a full chain
replay. One batched call shares it.

Motivating use case: the Cardano Preview e2e observation tests register ~13
random seeds per nightly run; without batching they blow past the GH Actions
6 h ceiling. Also useful for any operational workflow that needs balances for
a known set of seeds (validator wallets, governance-member wallets, audit
batches).

Alongside execute_many, this also closes a long-standing UX gap in
the toolkit's replay path: replay_blocks_{7,8} only logged
per-batch progress at log::debug!, so a multi-hour replay looked
silent at default verbosity even though fetch progress is logged at
info. A REPLAY_INFO_HEARTBEAT (30 s) throttle now emits one
replay progress: N/M blocks (X.X%) info line every 30 s plus one
at completion. Existing debug-level per-batch progress is unchanged,
so detailed diagnostics still work for anyone running with
-v / RUST_LOG=debug.

Closes #1568 

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Manually verified against qanet (~1.07M blocks): after the fetch
phase finishes the run emits one replay progress: ... (X.X%)
info line every ~30 s, ending with a (100.0%) line. Without the
heartbeat the same run was silent for the full multi-hour replay
stretch.

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
