### PR TITLE
fix: c2m bridge unnecessary denomination

### DIFF
--- a/changes/runtime/changed/fix-c2m-bridge-denomination.md
+++ b/changes/runtime/changed/fix-c2m-bridge-denomination.md
@@ -1,0 +1,10 @@
+#c2m-bridge
+
+# Fix unnecessary denomination in C-to-M bridge
+
+The c2m-bridge pallet incorrectly assumed that amount handed by partner-chains bridge are NIGHT token.
+The amounts that are recorded on Cardano are STAR.
+Ledger operates on STAR as well, so there is no denomination required.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1608
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1607

--- a/pallets/c2m-bridge/src/lib.rs
+++ b/pallets/c2m-bridge/src/lib.rs
@@ -36,34 +36,6 @@ pub const MAX_APPROVALS_PER_BATCH: u32 = 32;
 /// Hash of a Midnight ledger transaction, returned by the system transaction executor.
 pub type MidnightTxHash = [u8; 32];
 
-/// Amount of STARS. One NIGHT is 10^6 STARS.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Stars(u128);
-
-// Build-time proof: `from_cnight` must handle the largest bridge `amount` without `u128` overflow.
-const _: Stars = Stars::from_cnight(u64::MAX);
-
-impl Stars {
-	const fn from_cnight(c_night: u64) -> Stars {
-		Stars(STARS_PER_NIGHT * c_night as u128)
-	}
-}
-
-impl From<u128> for Stars {
-	fn from(value: u128) -> Self {
-		Self(value)
-	}
-}
-
-impl From<Stars> for u128 {
-	fn from(value: Stars) -> u128 {
-		value.0
-	}
-}
-
-/// 10^6 STARS = 1 NIGHT. STAR is atomic.
-pub(crate) const STARS_PER_NIGHT: u128 = 1_000_000;
-
 #[derive(Debug, Decode, Encode, Default, TypeInfo, MaxEncodedLen, PartialEq, Eq)]
 pub struct SubminimalTransfersState {
 	count: u32,
@@ -102,8 +74,8 @@ pub mod pallet {
 
 	/// Provides access to the minimum bridge transfer amount from the Midnight ledger.
 	pub trait MinBridgeAmountProvider {
-		/// Returns the minimum bridge transfer amount from ledger parameters.
-		fn get_c_to_m_bridge_min_amount() -> Result<Stars, LedgerApiError>;
+		/// Returns the minimum bridge transfer amount, in STARS, from the ledger parameters.
+		fn get_c_to_m_bridge_min_amount() -> Result<u128, LedgerApiError>;
 	}
 
 	#[pallet::event]
@@ -336,9 +308,7 @@ pub mod pallet {
 
 		fn handle_invalid_transfer(mc_tx_hash: McTxHash, amount: u64) {
 			Self::execute_serialized_tx(
-				LedgerApi::construct_distribute_treasury_system_tx(
-					Stars::from_cnight(amount).into(),
-				),
+				LedgerApi::construct_distribute_treasury_system_tx(amount.into()),
 				|midnight_tx_hash| Event::InvalidTransfer { mc_tx_hash, amount, midnight_tx_hash },
 				&alloc::format!("'Invalid' transfer of {} from Cardano Tx: {}", amount, mc_tx_hash),
 			);
@@ -346,9 +316,7 @@ pub mod pallet {
 
 		fn handle_reserve_transfer(mc_tx_hash: McTxHash, amount: u64) {
 			Self::execute_serialized_tx(
-				LedgerApi::construct_distribute_reserve_system_tx(
-					Stars::from_cnight(amount).into(),
-				),
+				LedgerApi::construct_distribute_reserve_system_tx(amount.into()),
 				|midnight_tx_hash| Event::ReserveTransfer { mc_tx_hash, amount, midnight_tx_hash },
 				&alloc::format!("'Reserve' transfer of {} from Cardano Tx: {}", amount, mc_tx_hash),
 			);
@@ -361,9 +329,7 @@ pub mod pallet {
 				None => {
 					// Not pre-approved by governance — redirect funds to the Treasury.
 					Self::execute_serialized_tx(
-						LedgerApi::construct_distribute_treasury_system_tx(
-							Stars::from_cnight(amount).into(),
-						),
+						LedgerApi::construct_distribute_treasury_system_tx(amount.into()),
 						|midnight_tx_hash| Event::UnapprovedTransfer {
 							mc_tx_hash,
 							amount,
@@ -382,7 +348,7 @@ pub mod pallet {
 					let nonce = Self::generate_nonce();
 					Self::execute_serialized_tx(
 						LedgerApi::construct_distribute_night_cardano_bridge_system_tx(
-							Stars::from_cnight(amount).into(),
+							amount.into(),
 							recipient.as_bytes(),
 							nonce,
 						),
@@ -408,7 +374,7 @@ pub mod pallet {
 		fn handle_incoming_transfer(transfer: BridgeTransferV1<BridgeRecipient>) {
 			match T::MinBridgeAmountProvider::get_c_to_m_bridge_min_amount() {
 				Ok(min_amount) => {
-					if Stars::from_cnight(transfer.amount) < min_amount {
+					if u128::from(transfer.amount) < min_amount {
 						Self::handle_subminimal_transfer(transfer);
 					} else {
 						Self::handle_regular_transfer(transfer);

--- a/pallets/c2m-bridge/src/mock.rs
+++ b/pallets/c2m-bridge/src/mock.rs
@@ -9,12 +9,12 @@ pub type Block = frame_system::mocking::MockBlock<Test>;
 pub type AccountId = AccountId32;
 pub type MaxTxLength = ConstU32<1024>;
 
-pub const TEST_MINIMAL_TRANSFER_CNIGHT: u64 = 99;
+pub const TEST_MINIMAL_TRANSFER_CSTARS: u128 = 99;
 
 #[frame_support::pallet]
 pub mod mock_pallet {
 	use super::*;
-	use crate::{MinBridgeAmountProvider, Stars};
+	use crate::MinBridgeAmountProvider;
 	use frame_support::pallet_prelude::*;
 	use midnight_node_ledger::latest::api::LedgerApiError;
 
@@ -43,8 +43,8 @@ pub mod mock_pallet {
 
 	impl<T> MinBridgeAmountProvider for Pallet<T> {
 		// Returns value in STARS, pallet denominates it to cNIGHT
-		fn get_c_to_m_bridge_min_amount() -> Result<Stars, LedgerApiError> {
-			Ok(Stars::from_cnight(TEST_MINIMAL_TRANSFER_CNIGHT))
+		fn get_c_to_m_bridge_min_amount() -> Result<u128, LedgerApiError> {
+			Ok(TEST_MINIMAL_TRANSFER_CSTARS)
 		}
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -914,9 +914,8 @@ impl pallet_partner_chains_bridge::Config for Runtime {
 pub struct MidnightMinBridgeAmount;
 impl pallet_c2m_bridge::pallet::MinBridgeAmountProvider for MidnightMinBridgeAmount {
 	fn get_c_to_m_bridge_min_amount()
-	-> Result<pallet_c2m_bridge::Stars, midnight_node_ledger::types::active_version::LedgerApiError>
-	{
-		Ok(pallet_c2m_bridge::Stars::from(Midnight::get_c_to_m_bridge_min_amount()?))
+	-> Result<u128, midnight_node_ledger::types::active_version::LedgerApiError> {
+		Midnight::get_c_to_m_bridge_min_amount()
 	}
 }
 


### PR DESCRIPTION
# Overview

Removes unnecessary denomination in the c2m bridge pallet.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

#1607 
