### PR TITLE
Backport ci and runners fixes

### DIFF
--- a/.github/actions/local-environment-tests/action.yml
+++ b/.github/actions/local-environment-tests/action.yml
@@ -80,6 +80,25 @@ runs:
       run: npm install -g npm@11.11.0
       shell: bash
 
+    # The local-env stack uses fixed container_names and publishes fixed host
+    # ports (validators 30333-30337 / 9933-9944 / 9615-9619, plus 32000, 30000,
+    # 8088, 4222). On a shared self-hosted host a container left by a cancelled
+    # or crashed prior run keeps a name/port bound, so the fresh stack fails with
+    # "port is already allocated" or a name conflict. The job's concurrency group
+    # only serialises this job against itself, not against leftovers. Tear the
+    # whole compose project down by label so every leftover service is reclaimed
+    # regardless of which name/port it holds — rather than a hand-maintained port
+    # list, which drifts as the compose file changes.
+    - name: Reclaim leftover local-env stack (self-hosted shared host)
+      shell: bash
+      run: |
+        docker compose -p local-env down --remove-orphans --volumes 2>/dev/null || true
+        leftovers=$(docker ps -aq --filter "label=com.docker.compose.project=local-env" || true)
+        if [ -n "$leftovers" ]; then
+          echo "Force-removing leftover local-env containers: $leftovers"
+          docker rm -f $leftovers || true
+        fi
+
     - name: Deploy local environment
       run: |
         echo "🔍 Debug: Checking input values..."

--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -46,12 +46,36 @@ jobs:
       - name: Run build
         env:
           GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+          # actions/checkout leaves the workspace on the PR merge commit in
+          # detached-HEAD state, so the EARTHLY_GIT_BRANCH builtin resolves to
+          # the literal string "HEAD" for every PR — useless for cache scoping.
+          # Use the actual head ref (PR source branch) or ref_name (push /
+          # merge_group). Sanitize: substitute any char outside [A-Za-z0-9._-]
+          # with '-' so e.g. `feat/foo` becomes `feat-foo`.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          GH_REF_FOR_BUILD: ${{ github.ref }}
         run: |
           PUSH_FLAG=""
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GH_REF_FOR_BUILD" = "refs/heads/main" ]; then
             PUSH_FLAG="--push"
           fi
-          . ./.envrc && earthly -P --secret GITHUB_TOKEN="$GITHUB_TOKEN" --strict $PUSH_FLAG --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test +test
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          # tr produces an empty string for empty input; guard so we never
+          # cache as `target-` (would silently merge all unkeyed runs).
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
+          . ./.envrc && earthly -P \
+            --secret GITHUB_TOKEN="$GITHUB_TOKEN" \
+            --secret DOCKERHUB_USER="$DOCKERHUB_USER" \
+            --secret DOCKERHUB_TOKEN="$DOCKERHUB_TOKEN" \
+            --strict $PUSH_FLAG \
+            --remote-cache=ghcr.io/midnightntwrk/midnight-node:cache-test \
+            +test --CACHE_KEY="$CACHE_KEY"
 
       - name: Upload test report artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -368,8 +368,20 @@ jobs:
         run: scripts/free-disk-space.sh
 
       - name: Run pallet fixture tests
+        if: steps.guard.outputs.hit != 'true'
+        env:
+          # See +test's `Run build` step for why EARTHLY_GIT_BRANCH is unsafe
+          # under actions/checkout; reach for the actual head/ref name instead.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
-          . ./.envrc && earthly -P --strict +test-pallet-fixtures
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
+          . ./.envrc && earthly -P --strict \
+            +test-pallet-fixtures --CACHE_KEY="$CACHE_KEY"
 
   # Gate job for toolkit E2E tests - if this fails, toolkit E2E tests are skipped
   test-toolkit:
@@ -458,15 +470,28 @@ jobs:
           # wrong auth; override to empty for the earthly call.
           ACTIONS_CACHE_URL: ""
           ACTIONS_RUNTIME_URL: ""
+          # +test-toolkit pulls in +build-test-toolkit's `target-${CACHE_KEY}`
+          # cache mount. Pass the PR ref so it's scoped per-branch on this
+          # shared self-hosted runner — see +test's `Run build` step for the
+          # full rationale and why EARTHLY_GIT_BRANCH is unsafe here.
+          GITHUB_REF_RAW: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          NODE_IMAGE_TAG: ${{ needs.run.outputs.node_image_tag }}
         run: |
           PUSH_FLAG=""
           if [ "$EVENT_NAME" = "merge_group" ]; then
             PUSH_FLAG="--push"
           fi
+          CACHE_KEY=$(printf '%s' "$GITHUB_REF_RAW" | tr -c 'A-Za-z0-9._-' '-')
+          if [ -z "$CACHE_KEY" ]; then
+            echo "::error::could not derive CACHE_KEY from refs (head_ref=$GITHUB_REF_RAW)"
+            exit 1
+          fi
+          echo "Using CACHE_KEY=$CACHE_KEY"
           . ./.envrc && earthly --secret GITHUB_TOKEN="$GITHUB_TOKEN" -P --strict $PUSH_FLAG \
             --remote-cache=ghcr.io/midnight-ntwrk/midnight-node:cache-test-toolkit \
-            --build-arg "NODE_IMAGE=ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}" \
-            +test-toolkit
+            +test-toolkit \
+              --NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:${NODE_IMAGE_TAG}" \
+              --CACHE_KEY="$CACHE_KEY"
 
       - uses: ./.github/actions/tree-cache-guard/save
         if: steps.guard.outputs.hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,12 +55,57 @@ jobs:
         id: get_sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # TEST ONLY — let earthly manage its own buildkitd on the self-hosted
+      # runner, but without TLS (no certs are provisioned). Earthly defaults
+      # to TLS for its managed buildkitd, which fails on a fresh runner.
+      # Appending `tls_enabled: false` to the repo's existing .earthly/config.yml
+      # keeps the rest of midnight-node's earthly settings intact.
+      - name: Disable earthly TLS (self-hosted runner has no certs)
+        run: |
+          echo "    tls_enabled: false" >> .earthly/config.yml
+          echo "--- updated .earthly/config.yml ---"
+          cat .earthly/config.yml
+
+      # Self-hosted runners share a persistent HOME (/opt/actions-runner) across
+      # every runner slot on the host, making ~/.docker/config.json shared
+      # mutable state. Concurrent jobs' `docker login` (read-modify-write) race
+      # and clobber each other's registry entries — e.g. a Docker Hub login
+      # wiping the ghcr.io entry — leaving the build's push with no GHCR creds
+      # (anonymous token -> 403). Pin DOCKER_CONFIG to the per-slot runner temp
+      # dir so each job gets an isolated docker config that docker/login-action
+      # writes to and earthly reads from (earthly honors DOCKER_CONFIG). Set via
+      # $GITHUB_ENV in a step because runner.temp is unavailable in job-level env.
+      - name: Isolate docker config (self-hosted shared HOME)
+        run: |
+          mkdir -p "$RUNNER_TEMP/.docker"
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
+
       - name: Login to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 #v4.0.0
         with:
           registry: ghcr.io
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      # Earthfile FROMs midnightntwrk/midnight-node-ci and several library/*
+      # images that resolve to docker.io. With --push, earthly tries to write
+      # inline cache back to the midnightntwrk Docker Hub namespace and fails
+      # auth without this login.
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+
+      # Both logins above wrote to the isolated $DOCKER_CONFIG/config.json (see
+      # the DOCKER_CONFIG note at job level). Confirm both registries are present
+      # before the build so an auth regression surfaces here rather than as an
+      # opaque anonymous-token 403 mid-push.
+      - name: Verify registry creds visible to earthly
+        run: |
+          echo "DOCKER_CONFIG=${DOCKER_CONFIG:-<unset>}"
+          echo "Registries with creds:"
+          jq '.auths | keys' "$DOCKER_CONFIG/config.json"
 
       - name: Compute image tags
         id: image_tags
@@ -346,6 +391,371 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
+
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+
+      - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          version: v0.8.16
+          github-token: ${{ github.token }}
+          use-cache: false
+
+      # Isolate docker config per runner slot — see the matching step in the
+      # `run` job. runner.temp is not available in job-level env, so set it here.
+      - name: Isolate docker config (self-hosted shared HOME)
+        if: steps.guard.outputs.hit != 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/.docker"
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        if: steps.guard.outputs.hit != 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      # Earthfile FROMs midnightntwrk/midnight-node-ci and other docker.io
+      # images; earthly pushes inline cache back to those repos under --push,
+      # which needs Docker Hub auth.
+      - name: Login to Docker Hub
+        if: steps.guard.outputs.hit != 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+
+      - name: Free disk space
+        if: steps.guard.outputs.hit != 'true' && runner.environment != 'self-hosted'
+        run: scripts/free-disk-space.sh
+
+      # Self-hosted-runner-specific: earthly's managed buildkitd defaults to TLS
+      # but no certs are provisioned on the runner. Append tls_enabled: false
+      # to the workspace .earthly/config.yml so earthly skips TLS for its own
+      # buildkitd container.
+      - name: Disable earthly TLS (self-hosted runner has no certs)
+        if: steps.guard.outputs.hit != 'true'
+        run: |
+          echo "    tls_enabled: false" >> .earthly/config.yml
+
+      - name: Run toolkit tests
+        if: steps.guard.outputs.hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+          EVENT_NAME: ${{ github.event_name }}
+          # Self-hosted-runner-specific: runner systemd unit has PrivateTmp=true.
+          # Force earthly's tempdir to live under $RUNNER_TEMP which is
+          # outside the per-service PrivateTmp namespace.
+          TMPDIR: ${{ runner.temp }}
+          # Force-clear in case a runner process has stale EARTHLY_REMOTE_CACHE
+          # from before we cleaned the runner .env.
+          EARTHLY_REMOTE_CACHE: ""
+          # The runner's .env redirects ACTIONS_CACHE_URL to a local cache
+          # server. Earthly auto-detects this and tries to push to it with the
+          # wrong auth; override to empty for the earthly call.
+          ACTIONS_CACHE_URL: ""
+          ACTIONS_RUNTIME_URL: ""
+        run: |
+          PUSH_FLAG=""
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            PUSH_FLAG="--push"
+          fi
+          . ./.envrc && earthly --secret GITHUB_TOKEN="$GITHUB_TOKEN" -P --strict $PUSH_FLAG \
+            --remote-cache=ghcr.io/midnight-ntwrk/midnight-node:cache-test-toolkit \
+            --build-arg "NODE_IMAGE=ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}" \
+            +test-toolkit
+
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  toolkit-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit E2E
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  toolkit-update-ledger-parameters-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit Update Ledger Parameters E2E
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-update-ledger-parameters-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  toolkit-maintenance-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit Maintenance E2E
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-maintenance-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  toolkit-mint-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit Mint E2E
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-mint-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  toolkit-tokens-minter-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit Unshielded Token E2E
+    needs: [ run ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-tokens-minter-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  metadata-check:
+    permissions:
+      contents: read
+      actions: write
+    name: Metadata Check
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          version: v0.8.16
+          github-token: ${{ github.token }}
+          use-cache: false
+      - name: Login to GHCR
+        if: steps.guard.outputs.hit != 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+
+      - name: Run metadata check
+        if: steps.guard.outputs.hit != 'true'
+        run: |
+          . ./.envrc && earthly --ci -P \
+            --build-arg "NODE_IMAGE=ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}" \
+            +check-metadata
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  mainnet-sync-test:
+    permissions:
+      contents: read
+      packages: read
+    name: Mainnet Sync (1000 blocks)
+    needs: [run]
+    runs-on: [self-hosted, "tier:medium"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
+      # Isolate docker config per runner slot — see the matching step in the
+      # `run` job. runner.temp is not available in job-level env, so set it here.
+      - name: Isolate docker config (self-hosted shared HOME)
+        run: |
+          mkdir -p "$RUNNER_TEMP/.docker"
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+
+      - name: Sync first 1000 blocks of mainnet
+        env:
+          NODE_IMAGE: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          SNAPSHOT: static/sync-test/snapshot.sql.xz
+          CFG_PRESET: mainnet
+          SYNC_UNTIL: "1000"
+          SYNC_TIMEOUT_SECS: "1800"
+        run: bash scripts/sync-test/run-sync.sh
+
+      - name: Print sync logs
+        if: always()
+        run: |
+          echo "::group::midnight-node.log"
+          cat /tmp/midnight-node.log 2>/dev/null || echo "(no node log)"
+          echo "::endgroup::"
+          echo "::group::midnight-pg.log"
+          cat /tmp/midnight-pg.log 2>/dev/null || echo "(no postgres log)"
+          echo "::endgroup::"
+
+      - name: Upload sync logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: mainnet-sync-logs
+          path: |
+            /tmp/midnight-node.log
+            /tmp/midnight-pg.log
+          if-no-files-found: ignore
+
+  toolkit-contracts-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Toolkit Contracts E2E
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: toolkit-contracts-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          toolkit-image: ghcr.io/midnight-ntwrk/midnight-node-toolkit:${{ needs.run.outputs.toolkit_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  startup-dev-e2e:
+    permissions:
+      contents: read
+      actions: write
+    name: Startup E2E in dev mode
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          submodules: true
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+      - uses: ./.github/actions/reusable-e2e-tests
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          just-command: startup-dev-e2e
+          node-image: ghcr.io/midnight-ntwrk/midnight-node:${{ needs.run.outputs.node_image_tag }}
+          ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      - uses: ./.github/actions/tree-cache-guard/save
+        if: steps.guard.outputs.hit != 'true'
+        with:
+          key: ${{ steps.guard.outputs.key }}
+
+  chainspec-validation:
+    permissions:
+      contents: read
+    name: Chainspec Validation
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Login to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 #v4.0.0
@@ -671,6 +1081,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
+
+      - id: guard
+        uses: ./.github/actions/tree-cache-guard
+
+      # Isolate docker config per runner slot — see the matching step in the
+      # `run` job. The concurrency group only serializes this job against itself;
+      # other self-hosted jobs on the same host can still clobber the shared
+      # ~/.docker. Inherited by the composite action's docker login and pulls.
+      - name: Isolate docker config (self-hosted shared HOME)
+        if: steps.guard.outputs.hit != 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/.docker"
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
 
       - name: Deploy and test against local environment
         uses: ./.github/actions/local-environment-tests

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,19 @@
 VERSION 0.8
 
+# Scopes the cargo build directory (`/target`) so PRs running on the same
+# self-hosted runner host don't share `.rmeta` / `.rlib` artifacts via a
+# stable auto-generated cache id. Without scoping, an in-flight branch
+# that's changed a pallet's trait surface can leak its build into the
+# next PR's job and cause spurious E0046 trait/impl mismatches.
+#
+# Default is constant so local invocations share one cache. CI must
+# override this with a per-branch value (passed via `--build-arg
+# CACHE_KEY=<sanitized PR head ref>`). The Earthly builtin
+# EARTHLY_GIT_BRANCH is NOT a reliable source here because actions/checkout
+# leaves the workspace on the PR merge commit in detached-HEAD state, so
+# the builtin resolves to the literal string `HEAD` across every PR.
+ARG --global CACHE_KEY=local
+
 # ================ Local Targets START ================
 # If you add a new one here, prefix it with "local-"
 # Add the target name to the doc string so it shows up
@@ -180,7 +194,8 @@ rebuild-sqlx:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
     COPY local-environment/localenv_postgres.password .
     RUN \
         DATABASE_URL=postgres://postgres:$(cat localenv_postgres.password)@$([ "$USEROS" = "linux" ] && echo "172.17.0.1" || echo "host.docker.internal"):5432/cexplorer \
@@ -765,7 +780,8 @@ planner:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
     RUN cargo chef prepare --recipe-path recipe.json
     SAVE ARTIFACT recipe.json /recipe.json
 
@@ -842,7 +858,8 @@ test:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # Test
     RUN mkdir /test-artifacts
@@ -879,7 +896,8 @@ test-pallet-fixtures:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # These tests use a mock runtime (MockBlock<Test>), not the real WASM runtime.
     # Debug mode skips LLVM optimization passes, compiling faster than release on free CI runners.
@@ -905,7 +923,8 @@ build-test-toolkit:
     FROM +prep
     CACHE --sharing shared --id cargo-git /usr/local/cargo/git
     CACHE --sharing shared --id cargo-reg /usr/local/cargo/registry
-    CACHE /target
+    # See top-of-file CACHE_KEY ARG for why this is scoped.
+    CACHE --id target-${CACHE_KEY} /target
 
     # Install dependencies for Node.js and docker CLI (for hardfork e2e tests)
     RUN microdnf -y install tar gzip xz docker && \

--- a/changes/changed/backport-self-hosted-runner-hardening.md
+++ b/changes/changed/backport-self-hosted-runner-hardening.md
@@ -1,0 +1,33 @@
+# Backport self-hosted runner hardening to release/node-1.0.1
+
+Backports four CI-side fixes from `main` that harden the self-hosted
+GitHub Actions runner pool against shared-host state leakage. No
+runtime, node, or toolkit code is touched — workflow / Earthfile /
+runner config / one e2e script only.
+
+- **#1483** — migrate paid x86_64 CI workflows to the self-hosted
+  runner pool. Drops the GitHub-hosted spend on the largest jobs and
+  brings the release branch's runner usage in line with main.
+- **#1585** — isolate docker config per self-hosted runner slot.
+  Concurrent jobs on the same host were stepping on each other's
+  Docker auth; this scopes `DOCKER_CONFIG` to `$RUNNER_TEMP/.docker`
+  via `$GITHUB_ENV` so every job (run, test-toolkit,
+  mainnet-sync-test, local-environment-tests) gets an isolated
+  config that `docker/login-action` writes to and earthly reads from.
+- **#1593** — harden self-hosted sync-test and local-env against
+  shared-host state. Unique container names per job and pre-flight
+  teardown of the local-env compose project (by label rather than
+  hand-maintained port list) so leftover containers from a cancelled
+  or crashed prior run don't block the fresh stack.
+- **Earthly `/target` cache scoped by CI-derived key**
+  (`fix(ci): scope earthly /target cache by an explicit CI-derived
+  key`). `EARTHLY_GIT_BRANCH` was unsafe under `actions/checkout`'s
+  detached-HEAD checkout (resolved to the literal `HEAD` for every
+  PR); the workflow now derives `CACHE_KEY` from `github.head_ref`
+  / `github.ref_name`, sanitizes via `tr`, and passes it as a
+  build-arg to `+test`, `+test-pallet-fixtures`, and `+test-toolkit`.
+  Prevents `.rmeta` / `.rlib` from one PR poisoning another's build
+  on the same self-hosted host.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1611
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1599


### PR DESCRIPTION
# Overview

Backports four self-hosted-runner hardening commits from `main` to
`release/node-1.0.1`. CI workflows, Earthfile, runner config, and one
e2e script only — no runtime, node, or toolkit code. Goal is to bring
the release branch's CI in line with main so that release-branch PRs
aren't subject to the shared-host failures we've been fixing on main
over the last few weeks.

Backported PRs:

- **#1483** — migrate paid x86_64 CI workflows to the self-hosted
  runner pool. Drops the GitHub-hosted spend on the largest jobs.
- **#1585** — isolate docker config per self-hosted runner slot.
  Concurrent jobs on the same host were stepping on each other's
  Docker auth; this scopes `DOCKER_CONFIG` to `$RUNNER_TEMP/.docker`
  via `$GITHUB_ENV` so every self-hosted job (run, test-toolkit,
  mainnet-sync-test, local-environment-tests) gets an isolated
  config that `docker/login-action` writes to and earthly reads from.
- **#1593** — harden self-hosted sync-test and local-env against
  shared-host state. Unique container names per job and pre-flight
  teardown of the local-env compose project (by label rather than
  a hand-maintained port list), so leftover containers from a
  cancelled / crashed prior run don't block the fresh stack.
- **Earthly `/target` cache scoped by CI-derived key**
  (`fix(ci): scope earthly /target cache by an explicit CI-derived
  key`). `EARTHLY_GIT_BRANCH` was unsafe under `actions/checkout`'s
  detached-HEAD checkout (resolved to the literal `HEAD` for every
  PR), so the workflow now derives `CACHE_KEY` from
  `github.head_ref` / `github.ref_name`, sanitizes via `tr`, and
  passes it as a build-arg to `+test`, `+test-pallet-fixtures`, and
  `+test-toolkit`. Prevents `.rmeta` / `.rlib` from one PR poisoning
  another's build on the same self-hosted host.

Scope is deliberately tight: only the four runner-pool / CI hardening
fixes. Other in-flight CI work on main (tree-cache-guard #889,
mainnet sync test #1460, fork-network workflow #1353, dependabot
bumps) is out of scope for this PR and can be backported separately
if needed.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking) <!-- CI-only, no code changes -->
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [x] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A — CI backport -->
- [x] Update documentation (if relevant) <!-- no user-facing docs changes -->
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- workflows changed but the AGENTS.md guidance on them is unchanged -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Each backported change has already been validated on `main` via its
original PR's CI run. This PR re-validates the same workflow files
running against `release/node-1.0.1` head, which is the only new
variable.

Expected indicators that the backport landed cleanly:

- `+test`, `+test-pallet-fixtures`, `+test-toolkit` log a
  `Using CACHE_KEY=<sanitized-head-ref>` line at the top of each
  invocation, and the line is distinct per PR rather than the
  literal `HEAD` (which was the symptom of the earthly-cache bug
  before the cache-key fix).
- Concurrent PRs on the same self-hosted host no longer collide on
  Docker auth (no `Error: error pulling image …: unauthorized` /
  `name "/postgres-..." is already in use` failures) — covered by
  #1585 and #1593.

Please describe any additional testing aside from CI:

- [x] Additional tests are provided (if possible) <!-- N/A: backport of already-tested changes -->

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: CI / workflow / Earthfile / runner config / one e2e
  script only — no on-chain or client-binary impact. No fork action
  required.
- [ ] N/A

## Links

Closes https://github.com/midnightntwrk/midnight-node/issues/1599

Originating PRs on `main`:
- https://github.com/midnightntwrk/midnight-node/pull/1483
- https://github.com/midnightntwrk/midnight-node/pull/1585
- https://github.com/midnightntwrk/midnight-node/pull/1593
- The earthly cache-key fix landed via squash into the toolkit
  multi-seed cache-bug PR; see commit on `main`:
  `6db0166b fix(ci): scope earthly /target cache by an explicit
  CI-derived key`
