### PR TITLE
ci: make Docker Hub login non-fatal (continue-on-error)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,7 +99,12 @@ jobs:
       # images that resolve to docker.io. With --push, earthly tries to write
       # inline cache back to the midnightntwrk Docker Hub namespace and fails
       # auth without this login.
+      # Non-fatal: the +images push targets ghcr.io only (authed by the GHCR
+      # login above) and the docker.io base images are public, so the build
+      # still pulls + pushes without these creds. Dependabot runs don't have
+      # the DOCKERHUB_* secrets, so this step would otherwise hard-fail there.
       - name: Login to Docker Hub
+        continue-on-error: true
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
@@ -577,8 +582,12 @@ jobs:
       # Earthfile FROMs midnightntwrk/midnight-node-ci and other docker.io
       # images; earthly pushes inline cache back to those repos under --push,
       # which needs Docker Hub auth.
+      # Non-fatal: pushes target ghcr.io and the docker.io base images are
+      # public, so the build proceeds without these creds (e.g. Dependabot runs,
+      # which don't have the DOCKERHUB_* secrets).
       - name: Login to Docker Hub
         if: steps.guard.outputs.hit != 'true'
+        continue-on-error: true
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}


### PR DESCRIPTION
## Summary

The `Login to Docker Hub` steps in `continuous-integration.yml` were a hard gate in front of a build that doesn't actually need Docker Hub auth:

- The `+images` push targets **`ghcr.io` only** (`Earthfile:1148` node, `:1241` toolkit), authenticated by the **GHCR** login that runs just above.
- The `docker.io` base images it pulls (`midnightntwrk/midnight-node-ci` at `Earthfile:688`, plus `library/*` / `alpine` / `dind`) are **public** — anonymous pull returns HTTP 200.

So Docker Hub auth only buys rate-limit headroom on pulls; it is not required for the build to pull or push. But when the `DOCKERHUB_*` secrets are absent the step hard-fails the whole job. This breaks **Dependabot PRs**, whose secret store has the GHCR secret (`MIDNIGHTCI_PACKAGES_WRITE`, so GHCR login succeeds) but not `DOCKERHUB_MIDNIGHTNTWRK_USER` / `_TOKEN` — e.g. the failed build on PR #1614 (`Username and password required`).

This marks **both** Docker Hub login steps `continue-on-error: true`. When creds are present (normal PRs) the login succeeds and behaviour is unchanged, keeping the authenticated pull rate limit. When creds are missing/empty (Dependabot) the step degrades to anonymous pulls instead of failing the job.

### Trade-off
The 8 self-hosted Hetzner runners share one egress IP, so anonymous fallback pulls count against Docker Hub's per-IP anonymous limit and could occasionally `429`. That only affects runs where creds are genuinely absent (Dependabot); normal PRs still authenticate.

## Testing

- `ruby -ryaml -e "YAML.load_file(...)"` → YAML parses.
- Verified `docker.io/midnightntwrk/midnight-node-ci` is anonymously pullable (anon token + `tags/list` → HTTP 200).
- Confirmed `+images` `SAVE IMAGE --push` targets are `ghcr.io`-only, so the publish path is unaffected by Docker Hub auth.

## Links

- Failing Dependabot build: https://github.com/midnightntwrk/midnight-node/actions/runs/26663512321/job/78834958090