### PR TITLE
ci(local-env): per-runner port isolation for concurrent Local Environment Tests

### DIFF
--- a/.github/actions/local-environment-tests/action.yml
+++ b/.github/actions/local-environment-tests/action.yml
@@ -84,24 +84,77 @@ runs:
       run: npm install -g npm@11.11.0
       shell: bash
 
-    # The local-env stack uses fixed container_names and publishes fixed host
-    # ports (validators 30333-30337 / 9933-9944 / 9615-9619, plus 32000, 30000,
-    # 8088, 4222). On a shared self-hosted host a container left by a cancelled
-    # or crashed prior run keeps a name/port bound, so the fresh stack fails with
-    # "port is already allocated" or a name conflict. The job's concurrency group
-    # only serialises this job against itself, not against leftovers. Tear the
-    # whole compose project down by label so every leftover service is reclaimed
-    # regardless of which name/port it holds — rather than a hand-maintained port
-    # list, which drifts as the compose file changes.
-    - name: Reclaim leftover local-env stack (self-hosted shared host)
+    # Per-runner port isolation. The shared self-hosted host runs up to 8 runner
+    # slots against one Docker daemon; the local-env stack publishes ~22 fixed
+    # host ports and uses fixed container names, so concurrent jobs collide. Give
+    # each slot a disjoint host-port block + a unique compose project name and
+    # container-name suffix, derived from the runner slot. The bring-up's own
+    # slot-aware `npm run stop:local-env` reclaims this slot's prior leftovers, so
+    # no separate cross-job teardown is needed.
+    #
+    # This is the bash mirror of local-environment/src/lib/ports.ts — the
+    # PORT_SPEC order and the BASE/BLOCK constants MUST stay in lockstep with it.
+    # Exports MN*_RPC_HOST_PORT etc. so later host steps (verify-finality,
+    # toolkit, e2e build-args) target this slot's ports.
+    - name: Compute per-runner local-env port slot
       shell: bash
       run: |
-        docker compose -p local-env down --remove-orphans --volumes 2>/dev/null || true
-        leftovers=$(docker ps -aq --filter "label=com.docker.compose.project=local-env" || true)
-        if [ -n "$leftovers" ]; then
-          echo "Force-removing leftover local-env containers: $leftovers"
-          docker rm -f $leftovers || true
+        slot=0
+        if [[ "${RUNNER_NAME:-}" =~ -runner-([0-9]+)$ ]]; then
+          # Force base 10: a zero-padded match like "08"/"09" would otherwise be
+          # read as an (invalid) octal literal by the arithmetic below and abort
+          # the step with "value too great for base".
+          slot=$((10#${BASH_REMATCH[1]}))
         fi
+        echo "Runner '${RUNNER_NAME:-unknown}' -> local-env slot $slot"
+
+        BASE=21000
+        BLOCK=64
+        # envVar:legacyPort, in fixed offset order (append-only).
+        specs=(
+          "CARDANO_NODE_HOST_PORT:32000"
+          "CARDANO_SOCAT_HOST_PORT:30000"
+          "KUPO_HOST_PORT:1442"
+          "OGMIOS_HOST_PORT:1337"
+          "POSTGRES_HOST_PORT:5432"
+          "INDEXER_API_HOST_PORT:8088"
+          "NATS_HOST_PORT:4222"
+          "MN1_P2P_HOST_PORT:30333"
+          "MN1_RPC_HOST_PORT:9933"
+          "MN1_PROM_HOST_PORT:9615"
+          "MN2_P2P_HOST_PORT:30334"
+          "MN2_RPC_HOST_PORT:9934"
+          "MN2_PROM_HOST_PORT:9616"
+          "MN3_P2P_HOST_PORT:30335"
+          "MN3_RPC_HOST_PORT:9935"
+          "MN3_PROM_HOST_PORT:9617"
+          "MN4_P2P_HOST_PORT:30336"
+          "MN4_RPC_HOST_PORT:9936"
+          "MN4_PROM_HOST_PORT:9618"
+          "MN5_P2P_HOST_PORT:30337"
+          "MN5_RPC_HOST_PORT:9944"
+          "MN5_PROM_HOST_PORT:9619"
+        )
+        i=0
+        for s in "${specs[@]}"; do
+          var="${s%%:*}"
+          legacy="${s##*:}"
+          if [ "$slot" -ge 1 ]; then
+            port=$((BASE + (slot - 1) * BLOCK + i))
+          else
+            port="$legacy"
+          fi
+          echo "${var}=${port}" >> "$GITHUB_ENV"
+          i=$((i + 1))
+        done
+        if [ "$slot" -ge 1 ]; then
+          echo "COMPOSE_PROJECT_NAME=local-env-r${slot}" >> "$GITHUB_ENV"
+          echo "LOCALENV_NAME_SUFFIX=-r${slot}" >> "$GITHUB_ENV"
+        else
+          echo "COMPOSE_PROJECT_NAME=local-env" >> "$GITHUB_ENV"
+          echo "LOCALENV_NAME_SUFFIX=" >> "$GITHUB_ENV"
+        fi
+        echo "LOCALENV_RUNNER_SLOT=${slot}" >> "$GITHUB_ENV"
 
     - name: Deploy local environment
       run: |
@@ -121,7 +174,8 @@ runs:
           --NODE_IMAGE="${NODE_IMAGE}" \
           --INDEXER_API_IMAGE="${INDEXER_API_IMAGE}" \
           --CHAIN_INDEXER_IMAGE="${CHAIN_INDEXER_IMAGE}" \
-          --WALLET_INDEXER_IMAGE="${WALLET_INDEXER_IMAGE}"
+          --WALLET_INDEXER_IMAGE="${WALLET_INDEXER_IMAGE}" \
+          --LOCALENV_RUNNER_SLOT="${LOCALENV_RUNNER_SLOT:-0}"
       shell: bash
       env:
         NODE_IMAGE: ${{ inputs.image }}
@@ -148,7 +202,13 @@ runs:
       id: e2e-tests
       # Source .envrc so EARTHLY_CONFIG matches other self-hosted jobs (see
       # comment on the earlier earthly invocation in this action for why).
-      run: . ./.envrc && earthly +local-env-e2e
+      # Pass this slot's node/ogmios host ports through to the e2e container
+      # (it reaches the host stack via 172.17.0.1:<port>).
+      run: |
+        . ./.envrc
+        earthly +local-env-e2e \
+          --E2E_NODE_RPC_PORT="${MN1_RPC_HOST_PORT:-9933}" \
+          --E2E_OGMIOS_PORT="${OGMIOS_HOST_PORT:-1337}"
       shell: bash
 
     - name: toolkit-multi-dest-e2e

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1099,14 +1099,12 @@ jobs:
     needs: [run, build-indexer-images]
     runs-on: [self-hosted, "tier:medium"]
     # The local-env stack (kupo, ogmios, db-sync, indexers, postgres, nats,
-    # cardano-node, ...) binds fixed ports on 0.0.0.0 — 1442, 1337, 8088,
-    # 4222, 5432, 30000, 32000 — so concurrent jobs on the same self-hosted
-    # runner host collide. Serialize across the whole repo with a fixed
-    # concurrency group; queue rather than cancel so a long-running stack
-    # actually finishes (the next PR's job picks up when this one is done).
-    concurrency:
-      group: local-environment-tests-self-hosted
-      cancel-in-progress: false
+    # cardano-node, ...) used to bind fixed ports + container names on the shared
+    # self-hosted host, so concurrent jobs collided and this job was serialized
+    # repo-wide with a fixed concurrency group. The `Compute per-runner local-env
+    # port slot` step in the composite action now gives each runner slot a
+    # disjoint host-port block + unique compose project name, so jobs run
+    # concurrently — the serialization gate has been removed (see shielded-sre#281).
     permissions:
       pull-requests: write
       packages: read

--- a/Earthfile
+++ b/Earthfile
@@ -1474,12 +1474,21 @@ testnet-sync-e2e:
 # local-env-e2e executes any tests that depend on a running local-env
 local-env-e2e:
     FROM +prep
+    # Host ports of the local-env stack this test connects to (via 172.17.0.1).
+    # On the shared self-hosted host each runner slot publishes them on
+    # slot-specific ports; the caller passes them through so the e2e config
+    # (tests/e2e/src/config.rs, local-ci feature) targets the right stack.
+    # Defaults reproduce the legacy single-tenant ports.
+    ARG E2E_NODE_RPC_PORT=9933
+    ARG E2E_OGMIOS_PORT=1337
     COPY --keep-ts --dir Cargo.lock Cargo.toml docs .sqlx \
     ledger node pallets primitives metadata res runtime util tests relay partner-chains local-environment scripts .
     COPY static/contracts/simple-merkle-tree /test-static/simple-merkle-tree
     ENV MIDNIGHT_LEDGER_TEST_STATIC_DIR=/test-static
     WORKDIR tests/e2e
     ENV RUSTFLAGS="-C debuginfo=1"
+    ENV E2E_NODE_RPC_PORT=$E2E_NODE_RPC_PORT
+    ENV E2E_OGMIOS_PORT=$E2E_OGMIOS_PORT
     RUN cargo test --test e2e_tests -- --test-threads=6 --nocapture
 
 # compares chain parameters with testnet-02
@@ -1551,6 +1560,11 @@ start-local-env-with-indexer-ci:
     ARG INDEXER_API_IMAGE
     ARG CHAIN_INDEXER_IMAGE
     ARG WALLET_INDEXER_IMAGE
+    # Per-runner slot (1..N) selects a disjoint host-port block + compose project
+    # name so concurrent jobs on the same self-hosted host don't collide. 0 (the
+    # default) keeps the legacy single-tenant layout. The orchestrator derives
+    # every port/name from this single value (local-environment/src/lib/ports.ts).
+    ARG LOCALENV_RUNNER_SLOT=0
     WORKDIR local-environment
     RUN npm ci
     # Tear down any stack left over from a previous run before starting a fresh
@@ -1560,8 +1574,8 @@ start-local-env-with-indexer-ci:
     # breaks chain-indexer with "unsupported protocol version" when the
     # genesis/runtime expectations disagree. The non-CI sibling target
     # `+start-local-env-with-indexer` does this same down already.
-    RUN ARCHITECTURE=$USERARCH MIDNIGHT_NODE_IMAGE=$NODE_IMAGE INDEXER_CHAIN_IMAGE=$CHAIN_INDEXER_IMAGE INDEXER_WALLET_IMAGE=$WALLET_INDEXER_IMAGE INDEXER_API_IMAGE=$INDEXER_API_IMAGE npm run stop:local-env -- -p withindexer
-    RUN ARCHITECTURE=$USERARCH MIDNIGHT_NODE_IMAGE=$NODE_IMAGE INDEXER_CHAIN_IMAGE=$CHAIN_INDEXER_IMAGE INDEXER_WALLET_IMAGE=$WALLET_INDEXER_IMAGE INDEXER_API_IMAGE=$INDEXER_API_IMAGE npm run run:local-env-with-indexer -- -p withindexer
+    RUN LOCALENV_RUNNER_SLOT=$LOCALENV_RUNNER_SLOT ARCHITECTURE=$USERARCH MIDNIGHT_NODE_IMAGE=$NODE_IMAGE INDEXER_CHAIN_IMAGE=$CHAIN_INDEXER_IMAGE INDEXER_WALLET_IMAGE=$WALLET_INDEXER_IMAGE INDEXER_API_IMAGE=$INDEXER_API_IMAGE npm run stop:local-env -- -p withindexer
+    RUN LOCALENV_RUNNER_SLOT=$LOCALENV_RUNNER_SLOT ARCHITECTURE=$USERARCH MIDNIGHT_NODE_IMAGE=$NODE_IMAGE INDEXER_CHAIN_IMAGE=$CHAIN_INDEXER_IMAGE INDEXER_WALLET_IMAGE=$WALLET_INDEXER_IMAGE INDEXER_API_IMAGE=$INDEXER_API_IMAGE npm run run:local-env-with-indexer -- -p withindexer
 
 
 stop-local-env:

--- a/local-environment/check-health.sh
+++ b/local-environment/check-health.sh
@@ -19,7 +19,7 @@
 # GRANDPA voting (i.e. fails if some validators are stuck or panicking).
 
 timeout=360  # Default 6 minutes
-address="http://localhost:9933"  # Default address
+address="http://localhost:${MN1_RPC_HOST_PORT:-9933}"  # Default address (per-runner host port; falls back to legacy 9933)
 target_block="1"  # Default to block 1
 mode="head"  # Default: check head block; "finalized" checks finalized block
 

--- a/local-environment/src/commands/run.ts
+++ b/local-environment/src/commands/run.ts
@@ -23,6 +23,7 @@ import {
 } from "../lib/localEnv";
 import { assertWellKnownNamespace, RunOptions } from "../lib/types";
 import { runDockerCompose } from "../lib/docker";
+import { currentLayout, layoutEnv } from "../lib/ports";
 import {
   discoverComposeDataMounts,
   restoreSnapshot,
@@ -221,6 +222,19 @@ async function runLocalEnvironment(runOptions: RunOptions) {
     ...env,
     ...cleanEnv(process.env),
   };
+
+  // Apply per-runner port isolation. Computed from LOCALENV_RUNNER_SLOT and
+  // merged last so the derived host ports, compose project name, and
+  // container-name suffix win over anything inherited. Slot 0 reproduces the
+  // legacy single-tenant layout exactly.
+  const layout = currentLayout();
+  env = { ...env, ...layoutEnv(layout) };
+  if (layout.slot > 0) {
+    console.log(
+      `🔢 Runner slot ${layout.slot}: compose project '${layout.projectName}', ` +
+        `node-1 RPC on host port ${layout.hostPorts.MN1_RPC_HOST_PORT}`,
+    );
+  }
 
   const missing = requiredImageVars.filter((key) => !env[key]);
   if (missing.length > 0) {

--- a/local-environment/src/commands/stop.ts
+++ b/local-environment/src/commands/stop.ts
@@ -23,6 +23,7 @@ import {
   loadEnvDefault,
   requiredImageVars,
 } from "../lib/localEnv";
+import { currentLayout, layoutEnv } from "../lib/ports";
 
 export async function stop(network: string, runOptions: RunOptions) {
   if (network === "local-env") {
@@ -74,10 +75,14 @@ function stopLocalEnvironment(runOptions: RunOptions) {
 
   const localEnvSecretVars = getLocalEnvSecretVars();
   const envDefault = loadEnvDefault();
+  // Match the layout used at bring-up so `down` targets this slot's compose
+  // project (and its volumes), not a sibling runner's stack.
+  const layout = currentLayout();
   const finalEnv: Record<string, string> = {
     ...envDefault,
     ...localEnvSecretVars,
     ...cleanEnv(process.env),
+    ...layoutEnv(layout),
   };
 
   const missing = requiredImageVars.filter((key) => !finalEnv[key]);

--- a/local-environment/src/lib/discoverValidators.ts
+++ b/local-environment/src/lib/discoverValidators.ts
@@ -128,19 +128,67 @@ function findHostPort(service: unknown, containerPort: number): number | null {
 function parsePortMapping(entry: unknown): PortMapping | null {
   if (typeof entry === "string") {
     const [withoutProto] = entry.split("/");
-    const parts = withoutProto.split(":");
+    // Split on ':' separators only, ignoring the ':' inside a compose
+    // interpolation default like `${MN1_RPC_HOST_PORT:-9933}`.
+    const parts = splitTopLevelColons(withoutProto);
     if (parts.length < 2) return null;
-    const host = Number.parseInt(parts[parts.length - 2], 10);
-    const container = Number.parseInt(parts[parts.length - 1], 10);
-    if (!Number.isFinite(host) || !Number.isFinite(container)) return null;
+    const host = resolvePortToken(parts[parts.length - 2]);
+    const container = resolvePortToken(parts[parts.length - 1]);
+    if (host === null || container === null) return null;
     return { host, container };
   }
   if (entry && typeof entry === "object") {
     const obj = entry as Record<string, unknown>;
-    const host = Number(obj.published);
-    const container = Number(obj.target);
-    if (!Number.isFinite(host) || !Number.isFinite(container)) return null;
+    const host = resolvePortToken(String(obj.published));
+    const container = resolvePortToken(String(obj.target));
+    if (host === null || container === null) return null;
     return { host, container };
   }
   return null;
+}
+
+/**
+ * Resolve a compose port token to a number. Handles plain integers as well as
+ * compose interpolation — `${VAR}` and `${VAR:-default}` — by reading the
+ * current process environment, which carries the per-runner host ports injected
+ * at bring-up. Returns null if the token can't be resolved to a finite number.
+ */
+function resolvePortToken(token: string): number | null {
+  const trimmed = token.trim();
+  const interp = trimmed.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(\d+))?\}$/);
+  if (interp) {
+    const [, name, fallback] = interp;
+    const fromEnv = process.env[name];
+    const raw =
+      fromEnv !== undefined && fromEnv !== "" ? fromEnv : (fallback ?? "");
+    const value = Number.parseInt(raw, 10);
+    return Number.isFinite(value) ? value : null;
+  }
+  const value = Number.parseInt(trimmed, 10);
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Split a compose port string on its ':' separators while treating any
+ * `${...}` interpolation as opaque, so the ':' in a `${VAR:-default}` default
+ * is not mistaken for a host/container separator.
+ */
+function splitTopLevelColons(s: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth = Math.max(0, depth - 1);
+
+    if (ch === ":" && depth === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
 }

--- a/local-environment/src/lib/ports.ts
+++ b/local-environment/src/lib/ports.ts
@@ -1,0 +1,158 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-runner port isolation for the local-env stack.
+//
+// The self-hosted CI host runs up to 8 GitHub Actions runner slots against a
+// single shared Docker daemon. The local-env stack publishes ~22 fixed host
+// ports and uses fixed container names, so two jobs on the same host collide
+// ("port is already allocated" / name conflict). To let jobs run concurrently
+// we give each runner slot a disjoint block of host ports plus a unique compose
+// project name and container-name suffix.
+//
+// Slot 0 (the default, when LOCALENV_RUNNER_SLOT is unset or not a positive
+// integer) preserves the historical behaviour exactly: legacy host ports,
+// project name "local-env", and no container-name suffix. This keeps local
+// developer workflows and existing docs/tooling unchanged.
+//
+// NOTE: the equivalent computation is mirrored in pure bash in
+// `.github/actions/local-environment-tests/action.yml` (the host has no
+// guaranteed node deps when it needs the values for e2e build-args). The
+// ordered PORT_SPEC list and the `BASE_PORT`/`BLOCK` constants below MUST stay
+// in lockstep with that script.
+
+/** First host port of the per-runner range. Chosen to sit clear of the legacy
+ * defaults and below the typical ephemeral range (32768+). */
+export const BASE_PORT = 21000;
+
+/** Host ports reserved per runner slot. Must exceed PORT_SPEC.length so that
+ * adjacent slots' blocks never overlap. */
+export const BLOCK = 64;
+
+/**
+ * Ordered list of every published host port. The index in this array is the
+ * port's offset within a runner slot's block, so entries MUST NOT be reordered
+ * (append only). `envVar` is the compose interpolation variable; `legacy` is
+ * the historical host port used at slot 0.
+ */
+export const PORT_SPEC: { envVar: string; legacy: number }[] = [
+  { envVar: "CARDANO_NODE_HOST_PORT", legacy: 32000 },
+  { envVar: "CARDANO_SOCAT_HOST_PORT", legacy: 30000 },
+  { envVar: "KUPO_HOST_PORT", legacy: 1442 },
+  { envVar: "OGMIOS_HOST_PORT", legacy: 1337 },
+  { envVar: "POSTGRES_HOST_PORT", legacy: 5432 },
+  { envVar: "INDEXER_API_HOST_PORT", legacy: 8088 },
+  { envVar: "NATS_HOST_PORT", legacy: 4222 },
+  { envVar: "MN1_P2P_HOST_PORT", legacy: 30333 },
+  { envVar: "MN1_RPC_HOST_PORT", legacy: 9933 },
+  { envVar: "MN1_PROM_HOST_PORT", legacy: 9615 },
+  { envVar: "MN2_P2P_HOST_PORT", legacy: 30334 },
+  { envVar: "MN2_RPC_HOST_PORT", legacy: 9934 },
+  { envVar: "MN2_PROM_HOST_PORT", legacy: 9616 },
+  { envVar: "MN3_P2P_HOST_PORT", legacy: 30335 },
+  { envVar: "MN3_RPC_HOST_PORT", legacy: 9935 },
+  { envVar: "MN3_PROM_HOST_PORT", legacy: 9617 },
+  { envVar: "MN4_P2P_HOST_PORT", legacy: 30336 },
+  { envVar: "MN4_RPC_HOST_PORT", legacy: 9936 },
+  { envVar: "MN4_PROM_HOST_PORT", legacy: 9618 },
+  { envVar: "MN5_P2P_HOST_PORT", legacy: 30337 },
+  { envVar: "MN5_RPC_HOST_PORT", legacy: 9944 },
+  { envVar: "MN5_PROM_HOST_PORT", legacy: 9619 },
+];
+
+export interface LocalEnvLayout {
+  /** 0 = default/legacy single-tenant; 1..N = per-runner slot. */
+  slot: number;
+  /** Compose project name (isolates networks and volumes). */
+  projectName: string;
+  /** Suffix appended to every `container_name` (isolates host-global names). */
+  nameSuffix: string;
+  /** Compose interpolation var -> resolved host port. */
+  hostPorts: Record<string, number>;
+}
+
+/**
+ * Read the runner slot from the environment. Anything that is not a positive
+ * integer (unset, empty, "0", non-numeric) resolves to slot 0 — the legacy,
+ * single-tenant layout.
+ */
+export function resolveSlot(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.LOCALENV_RUNNER_SLOT;
+  if (!raw) return 0;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1) return 0;
+  return n;
+}
+
+/** Compute the full layout (project name, suffix, host ports) for a slot. */
+export function computeLayout(slot: number): LocalEnvLayout {
+  if (slot < 1) {
+    const hostPorts: Record<string, number> = {};
+    for (const spec of PORT_SPEC) hostPorts[spec.envVar] = spec.legacy;
+    return {
+      slot: 0,
+      projectName: "local-env",
+      nameSuffix: "",
+      hostPorts,
+    };
+  }
+
+  const blockStart = BASE_PORT + (slot - 1) * BLOCK;
+  const lastPort = blockStart + PORT_SPEC.length - 1;
+  if (PORT_SPEC.length > BLOCK) {
+    throw new Error(
+      `PORT_SPEC has ${PORT_SPEC.length} ports but BLOCK is ${BLOCK}; adjacent runner slots would overlap`,
+    );
+  }
+  if (lastPort > 65535) {
+    throw new Error(
+      `Runner slot ${slot} maps to host port ${lastPort}, which exceeds 65535. Reduce slot count or BASE_PORT.`,
+    );
+  }
+
+  const hostPorts: Record<string, number> = {};
+  PORT_SPEC.forEach((spec, index) => {
+    hostPorts[spec.envVar] = blockStart + index;
+  });
+
+  return {
+    slot,
+    projectName: `local-env-r${slot}`,
+    nameSuffix: `-r${slot}`,
+    hostPorts,
+  };
+}
+
+/**
+ * Build the environment overrides docker compose needs to publish this slot's
+ * ports and namespace its project/containers. Merge the result over the base
+ * env handed to `docker compose`.
+ */
+export function layoutEnv(layout: LocalEnvLayout): Record<string, string> {
+  const env: Record<string, string> = {
+    COMPOSE_PROJECT_NAME: layout.projectName,
+    LOCALENV_NAME_SUFFIX: layout.nameSuffix,
+    LOCALENV_RUNNER_SLOT: String(layout.slot),
+  };
+  for (const [key, port] of Object.entries(layout.hostPorts)) {
+    env[key] = String(port);
+  }
+  return env;
+}
+
+/** Convenience: layout for the current process environment. */
+export function currentLayout(
+  env: NodeJS.ProcessEnv = process.env,
+): LocalEnvLayout {
+  return computeLayout(resolveSlot(env));
+}

--- a/local-environment/src/networks/local-env/docker-compose.yml
+++ b/local-environment/src/networks/local-env/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cardano-node-1:
-    container_name: cardano-node-1
+    container_name: cardano-node-1${LOCALENV_NAME_SUFFIX:-}
     image: ${CARDANO_IMAGE}
     platform: linux/amd64
     healthcheck:
@@ -41,10 +41,10 @@ services:
       - CARDANO_NODE_SOCKET_PATH=/data/node.socket
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
     ports:
-      - "32000:32000"
+      - "${CARDANO_NODE_HOST_PORT:-32000}:32000"
 
   cardano-node-socat:
-    container_name: cardano-node-1-socat
+    container_name: cardano-node-1-socat${LOCALENV_NAME_SUFFIX:-}
     image: alpine/socat@sha256:78b3a1f99ca8f9179c9dbbdcd09d9ceee4c5fa8349847a42cfa3d0c279be8022
     command: TCP-LISTEN:30000,fork,reuseaddr, UNIX-CONNECT:/data/node.socket
     depends_on:
@@ -52,10 +52,10 @@ services:
     volumes:
       - cardano-node-1-data:/data
     ports:
-      - "30000:30000"
+      - "${CARDANO_SOCAT_HOST_PORT:-30000}:30000"
 
   contract-compiler:
-    container_name: contract-compiler
+    container_name: contract-compiler${LOCALENV_NAME_SUFFIX:-}
     platform: ${ARCHITECTURE}
     build:
       context: ./configurations/contract-compiler
@@ -76,7 +76,7 @@ services:
       - ALL
 
   kupo:
-    container_name: kupo
+    container_name: kupo${LOCALENV_NAME_SUFFIX:-}
     image: ${KUPO_IMAGE}
     depends_on:
       cardano-node-1:
@@ -95,10 +95,10 @@ services:
       - cardano-node-1-data:/node-ipc
       - ./configurations/busybox:/busybox
     ports:
-      - "${KUPO_PORT}:${KUPO_PORT}"
+      - "${KUPO_HOST_PORT:-1442}:${KUPO_PORT}"
 
   ogmios:
-    container_name: ogmios
+    container_name: ogmios${LOCALENV_NAME_SUFFIX:-}
     image: ${OGMIOS_IMAGE}
     platform: linux/amd64
     depends_on:
@@ -119,7 +119,7 @@ services:
       - cardano-node-1-data:/node-ipc
       - ./configurations/busybox:/busybox
     ports:
-      - "${OGMIOS_PORT}:${OGMIOS_PORT}"
+      - "${OGMIOS_HOST_PORT:-1337}:${OGMIOS_PORT}"
     healthcheck:
       test: "busybox wget -O - http://localhost:${OGMIOS_PORT}/health"
     deploy:
@@ -129,7 +129,7 @@ services:
           memory: ${MEM_OGMIOS:-}
 
   db-sync:
-    container_name: db-sync
+    container_name: db-sync${LOCALENV_NAME_SUFFIX:-}
     image: ${DBSYNC_IMAGE}
     platform: linux/amd64
     depends_on:
@@ -163,7 +163,7 @@ services:
           memory: ${MEM_DBSYNC:-}
 
   postgres:
-    container_name: postgres
+    container_name: postgres${LOCALENV_NAME_SUFFIX:-}
     image: ${POSTGRES_IMAGE}
     platform: ${ARCHITECTURE}
     command: >
@@ -187,7 +187,7 @@ services:
       - PGDATA=/pgdata
       - POSTGRES_MULTIPLE_DATABASES=cexplorer,qa_demo
     ports:
-      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+      - "${POSTGRES_HOST_PORT:-5432}:${POSTGRES_PORT}"
     entrypoint: ["/bin/bash", "/usr/local/bin/custom-entrypoint.sh"]
     volumes:
       - ./configurations/postgres/entrypoint.sh:/usr/local/bin/custom-entrypoint.sh
@@ -200,7 +200,7 @@ services:
 
   chain-indexer:
     profiles: ["withindexer"]
-    container_name: chain-indexer
+    container_name: chain-indexer${LOCALENV_NAME_SUFFIX:-}
     platform: ${ARCHITECTURE}
     depends_on:
       postgres-indexer:
@@ -229,7 +229,7 @@ services:
 
   wallet-indexer:
     profiles: ["withindexer"]
-    container_name: wallet-indexer
+    container_name: wallet-indexer${LOCALENV_NAME_SUFFIX:-}
     platform: ${ARCHITECTURE}
     depends_on:
       postgres-indexer:
@@ -255,7 +255,7 @@ services:
 
   indexer-api:
     profiles: ["withindexer"]
-    container_name: indexer-api
+    container_name: indexer-api${LOCALENV_NAME_SUFFIX:-}
     platform: ${ARCHITECTURE}
     depends_on:
       postgres-indexer:
@@ -265,7 +265,7 @@ services:
     image: ${INDEXER_API_IMAGE}
     restart: "no"
     ports:
-      - "8088:8088"
+      - "${INDEXER_API_HOST_PORT:-8088}:8088"
     environment:
       RUST_LOG: "indexer_api=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
       APP__INFRA__SECRET: "${APP__INFRA__SECRET}"
@@ -286,7 +286,7 @@ services:
 
   postgres-indexer:
     profiles: ["withindexer"]
-    container_name: postgres-indexer
+    container_name: postgres-indexer${LOCALENV_NAME_SUFFIX:-}
     platform: linux/amd64
     image: "postgres:17.1-alpine@sha256:0d9624535618a135c5453258fd629f4963390338b11aaffb92292c12df3a6c17"
     restart: "always"
@@ -306,20 +306,20 @@ services:
 
   nats:
     profiles: ["withindexer"]
-    container_name: nats
+    container_name: nats${LOCALENV_NAME_SUFFIX:-}
     image: "nats:2.11.8@sha256:e7ecc3cf81f4ccada9d24f8466d157ff472c20a12a5f8dddaeb26d71e7b42ee1"
     restart: "always"
     command:
       ["--user", "indexer", "--pass", "${APP__INFRA__PUB_SUB__PASSWORD}", "-js"]
     ports:
-      - "4222:4222"
+      - "${NATS_HOST_PORT:-4222}:4222"
     volumes:
       - nats-data:/tmp/nats
     security_opt:
       - no-new-privileges:true
 
   midnight-node-1:
-    container_name: midnight-node-1
+    container_name: midnight-node-1${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
@@ -338,9 +338,9 @@ services:
       io.midnight.role: validator
       io.midnight.rpc-port: "9933"
     ports:
-      - "30333:30333"
-      - "9933:9933"
-      - "9615:9615"
+      - "${MN1_P2P_HOST_PORT:-30333}:30333"
+      - "${MN1_RPC_HOST_PORT:-9933}:9933"
+      - "${MN1_PROM_HOST_PORT:-9615}:9615"
     restart: always
     deploy:
       resources:
@@ -349,7 +349,7 @@ services:
           memory: ${MEM_MIDNIGHT_NODE:-}
 
   midnight-node-2:
-    container_name: midnight-node-2
+    container_name: midnight-node-2${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
@@ -368,9 +368,9 @@ services:
       io.midnight.role: validator
       io.midnight.rpc-port: "9934"
     ports:
-      - "30334:30334"
-      - "9934:9934"
-      - "9616:9616"
+      - "${MN2_P2P_HOST_PORT:-30334}:30334"
+      - "${MN2_RPC_HOST_PORT:-9934}:9934"
+      - "${MN2_PROM_HOST_PORT:-9616}:9616"
     restart: always
     deploy:
       resources:
@@ -379,7 +379,7 @@ services:
           memory: ${MEM_MIDNIGHT_NODE:-}
 
   midnight-node-3:
-    container_name: midnight-node-3
+    container_name: midnight-node-3${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
@@ -398,9 +398,9 @@ services:
       io.midnight.role: validator
       io.midnight.rpc-port: "9935"
     ports:
-      - "30335:30335"
-      - "9935:9935"
-      - "9617:9617"
+      - "${MN3_P2P_HOST_PORT:-30335}:30335"
+      - "${MN3_RPC_HOST_PORT:-9935}:9935"
+      - "${MN3_PROM_HOST_PORT:-9617}:9617"
     restart: always
     deploy:
       resources:
@@ -409,7 +409,7 @@ services:
           memory: ${MEM_MIDNIGHT_NODE:-}
 
   midnight-node-4:
-    container_name: midnight-node-4
+    container_name: midnight-node-4${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
@@ -430,9 +430,9 @@ services:
       io.midnight.role: validator
       io.midnight.rpc-port: "9936"
     ports:
-      - "30336:30336"
-      - "9936:9936"
-      - "9618:9618"
+      - "${MN4_P2P_HOST_PORT:-30336}:30336"
+      - "${MN4_RPC_HOST_PORT:-9936}:9936"
+      - "${MN4_PROM_HOST_PORT:-9618}:9618"
     restart: always
     deploy:
       resources:
@@ -441,7 +441,7 @@ services:
           memory: ${MEM_MIDNIGHT_NODE:-}
 
   midnight-node-5:
-    container_name: midnight-node-5
+    container_name: midnight-node-5${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:
@@ -462,9 +462,9 @@ services:
       io.midnight.role: validator
       io.midnight.rpc-port: "9944"
     ports:
-      - "30337:30337"
-      - "9944:9944"
-      - "9619:9619"
+      - "${MN5_P2P_HOST_PORT:-30337}:30337"
+      - "${MN5_RPC_HOST_PORT:-9944}:9944"
+      - "${MN5_PROM_HOST_PORT:-9619}:9619"
     restart: always
     deploy:
       resources:
@@ -473,7 +473,7 @@ services:
           memory: ${MEM_MIDNIGHT_NODE:-}
 
   midnight-setup:
-    container_name: midnight-setup
+    container_name: midnight-setup${LOCALENV_NAME_SUFFIX:-}
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: ${ARCHITECTURE}
     depends_on:

--- a/scripts/tests/toolkit-multi-dest-e2e.sh
+++ b/scripts/tests/toolkit-multi-dest-e2e.sh
@@ -73,13 +73,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
-NODE_1="ws://localhost:9933"
-NODE_2="ws://localhost:9934"
-NODE_3="ws://localhost:9935"
-NODE_4="ws://localhost:9936"
+# Validator RPC host ports. On the self-hosted CI host each runner slot
+# publishes these on a slot-specific port; the job exports MN{1..4}_RPC_HOST_PORT
+# (see local-environment per-runner port isolation). Falls back to the legacy
+# ports for slot 0 / local runs.
+NODE_1="ws://localhost:${MN1_RPC_HOST_PORT:-9933}"
+NODE_2="ws://localhost:${MN2_RPC_HOST_PORT:-9934}"
+NODE_3="ws://localhost:${MN3_RPC_HOST_PORT:-9935}"
+NODE_4="ws://localhost:${MN4_RPC_HOST_PORT:-9936}"
 
 echo "Checking if local-environment is running..."
-if ! ./local-environment/check-health.sh -u http://localhost:9933 -t 30; then
+if ! ./local-environment/check-health.sh -u "http://localhost:${MN1_RPC_HOST_PORT:-9933}" -t 30; then
     echo "ERROR: local-environment is not running"
     echo "Please start it with: cd local-environment && npm run run:local-env"
     exit 1
@@ -222,6 +226,6 @@ else
 fi
 
 echo "Step 5: Verify transactions were processed"
-./local-environment/check-health.sh -u http://localhost:9933 -b 50 -t 120
+./local-environment/check-health.sh -u "http://localhost:${MN1_RPC_HOST_PORT:-9933}" -b 50 -t 120
 
 echo "Toolkit Multi-Destination URL E2E Test completed successfully"

--- a/tests/e2e/src/config.rs
+++ b/tests/e2e/src/config.rs
@@ -56,8 +56,16 @@ impl Settings {
                     #[cfg(feature = "local")]
                     base_url: "ws://127.0.0.1:9933".into(),
 
+                    // On the self-hosted CI host each runner slot publishes the
+                    // node RPC on a slot-specific host port (see
+                    // local-environment per-runner port isolation). The
+                    // bring-up passes it through as E2E_NODE_RPC_PORT; default
+                    // to the legacy 9933 for slot 0 / local runs.
                     #[cfg(feature = "local-ci")]
-                    base_url: "ws://172.17.0.1:9933".into(),
+                    base_url: format!(
+                        "ws://172.17.0.1:{}",
+                        std::env::var("E2E_NODE_RPC_PORT").unwrap_or_else(|_| "9933".to_string())
+                    ),
 
                     #[cfg(feature = "qanet")]
                     base_url: "wss://rpc.qanet.dev.midnight.network".into(),
@@ -66,7 +74,10 @@ impl Settings {
                     #[cfg(any(feature = "local", feature = "local-dev"))]
                     base_url: "ws://127.0.0.1:1337".into(),
                     #[cfg(feature = "local-ci")]
-                    base_url: "ws://172.17.0.1:1337".into(),
+                    base_url: format!(
+                        "ws://172.17.0.1:{}",
+                        std::env::var("E2E_OGMIOS_PORT").unwrap_or_else(|_| "1337".to_string())
+                    ),
                     #[cfg(feature = "qanet")]
                     base_url: "wss://ogmios.qanet.dev.midnight.network".into(),
                     timeout_seconds: 180,


### PR DESCRIPTION
## Summary

Lets `Local Environment Tests` run concurrently on the shared self-hosted host instead of being serialized repo-wide. Refs shieldedtech/shielded-sre#281.

The host runs up to 8 runner slots against **one** Docker daemon. The local-env stack published fixed host ports (9933–9944, 30333–30337, 1337/1442/5432/8088/4222/30000/32000) and used fixed `container_name`s, so two jobs on the same host collided. The job was therefore gated by a fixed `concurrency` group, throttling every PR.

This gives each runner slot a **disjoint host-port block + unique compose project name + container-name suffix**, all derived from a single `LOCALENV_RUNNER_SLOT` parsed from `$RUNNER_NAME` (e.g. `fsn1-runner-01-runner-3` → slot 3). **Slot 0** (the default, and any non-self-hosted runner) reproduces the legacy single-tenant layout byte-for-byte, so local dev and existing tooling are unchanged.

`local-environment/src/lib/ports.ts` is the source of truth (`BASE_PORT=21000`, `BLOCK=64`, 22-entry ordered `PORT_SPEC`). Container-*internal* ports never change — only host bindings shift — so intra-stack DNS/P2P is untouched. Compose project naming isolates networks and named volumes automatically.

### Changes
- `ports.ts` — slot → {projectName, nameSuffix, hostPorts}
- `run.ts` / `stop.ts` — inject the slot layout into the compose env (bring-up + teardown target the same project)
- `discoverValidators.ts` — resolve `${VAR:-default}` host ports from the env (incl. fixing a `:`-in-`${...}` split bug)
- `docker-compose.yml` — every published host port parameterized; every `container_name` suffixed
- `tests/e2e/src/config.rs`, `check-health.sh`, `toolkit-multi-dest-e2e.sh` — honor the slot's ports (legacy fallbacks)
- `Earthfile` — thread `LOCALENV_RUNNER_SLOT` into the `LOCALLY` bring-up; pass node/ogmios host ports into the hermetic `local-env-e2e` target
- `action.yml` — compute slot + ports (bash mirror of `ports.ts`); drop the obsolete shared-host teardown workaround
- `continuous-integration.yml` — **remove the repo-wide serialization gate**

## Testing

Static validation only — full integration is CI-only (needs node images + the self-hosted host + earthly):
- `tsc --noEmit`, `eslint`, `prettier --check`: clean
- `docker compose config`: slot 0 → legacy names/ports (`midnight-node-1`, 9933); slot 3 → isolated (`midnight-node-1-r3`, 21136, project/volumes/network `local-env-r3_*`)
- ts-node harness: `ports.ts` slots 1–8 disjoint + in-range; `discoverValidators` resolves env ports with legacy fallback
- bash port formula in `action.yml` cross-checked identical to `ports.ts` (slots 1/3/8)
- `shellcheck` on both scripts: clean
- `cargo check -p midnight-node-e2e --features local-ci --tests`: clean

**Needs CI to prove:** two PRs actually running `Local Environment Tests` concurrently without collision, and the e2e step connecting to the right slot's ports.

## Notes / follow-ups
- Passing `E2E_*_PORT` as earthly build-args means the `local-env-e2e` cargo layer is cache-keyed per slot (up to 8 variants). Acceptable; can be optimized later if cache pressure shows.
- The `governance-runtime-upgrade` command's default `--rpc-url` (9944) is **not** slot-aware — out of scope (not in the tests job); pass `--rpc-url` explicitly if running it against a slotted stack.
- The per-slot `DOCKER_CONFIG` isolation step is intentionally **kept** — it guards the shared-`~/.docker` login race and is still required under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)