### PR TITLE
fix(local-env): patch cnight mapping_validator_address from compiled contracts

### DIFF
--- a/changes/node/changed/local-env-cnight-mapping-validator-from-contracts-info.md
+++ b/changes/node/changed/local-env-cnight-mapping-validator-from-contracts-info.md
@@ -1,0 +1,16 @@
+#node #local-env
+# Patch cnight mapping_validator_address from freshly compiled contracts
+
+The midnight-setup entrypoint built the runtime `cnight-config.json` directly
+from `res/local-environment/cnight-config.json`, which hardcodes the mapping
+validator address. Without this fix, bumping the contracts submodule changes
+the deployed address but the runtime keeps the stale one, and cnight tests
+fail.
+
+The entrypoint now extracts the `cNIGHT Generates Dust` address from
+`/runtime-values/contracts-info.json` and patches it into the cnight config
+before chain-spec generation, mirroring how council / tech-auth /
+federated-ops policy IDs and addresses are already patched in.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1653
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1397

--- a/local-environment/src/networks/local-env/configurations/midnight-setup/entrypoint.sh
+++ b/local-environment/src/networks/local-env/configurations/midnight-setup/entrypoint.sh
@@ -53,6 +53,7 @@ COUNCIL_POLICY_ID=$(jq -r '.[] | select(.name == "Council Forever") | .scriptHas
 COUNCIL_SCRIPT_ADDRESS=$(jq -r '.[] | select(.name == "Council Forever") | .address' $CONTRACT_INFO)
 TECHAUTH_POLICY_ID=$(jq -r '.[] | select(.name == "Tech Auth Forever") | .scriptHash' $CONTRACT_INFO)
 TECHAUTH_SCRIPT_ADDRESS=$(jq -r '.[] | select(.name == "Tech Auth Forever") | .address' $CONTRACT_INFO)
+CNIGHT_MAPPING_VALIDATOR_ADDRESS=$(jq -r '.[] | select(.name == "cNIGHT Generates Dust") | .address' $CONTRACT_INFO)
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.[] | select(.name == "Federated Ops Forever") | .scriptHash' $CONTRACT_INFO)
 export GENESIS_UTXO="0000000000000000000000000000000000000000000000000000000000000000#0"
 
@@ -120,7 +121,10 @@ cat /tmp/registered-candidates-addresses.json
 
 
 echo "Creating cnight-config.json..."
-jq '.observed_utxos.end = .observed_utxos.start
+echo "  cNIGHT mapping validator address: $CNIGHT_MAPPING_VALIDATOR_ADDRESS"
+jq --arg mapping_addr "$CNIGHT_MAPPING_VALIDATOR_ADDRESS" \
+  '.addresses.mapping_validator_address = $mapping_addr
+  | .observed_utxos.end = .observed_utxos.start
   | .observed_utxos.utxos = []
   | .mappings = {}
   | .utxo_owners = {}


### PR DESCRIPTION
# Overview

The midnight-setup entrypoint built the runtime `cnight-config.json` directly from `res/local-environment/cnight-config.json`, which hardcodes the mapping validator address. With #1397 fixed, if we update contracts submodule, cnight tests will fail.

This PR extracts the `cNIGHT Generates Dust` address from `/runtime-values/contracts-info.json` and patches it into the cnight config before chain-spec generation, mirroring how council / tech-auth / federated-ops policy IDs and addresses are already patched in.

Closes #1397

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Local verification:
- Bring up local-env from a clean state so the contract compiler runs.
- Confirm `/runtime-values/contracts-info.json` contains a `cNIGHT Generates Dust` entry with the freshly deployed address.
- Inspect the generated `chain-spec.json` and the `cnight` pallet genesis — the `mapping_validator_address` should match the contracts-info value, not the previously hardcoded `addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng`.

Ran the cNIGHT observation test against local-env twice — once with the old contracts and once with the freshly compiled contracts — both runs passed:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 27 filtered out; finished in 47.89s
```

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

Local-environment tooling only — no impact on deployed networks.

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

- Closes #1397

Assisted-by: Claude:claude-4.7-opus