### PR TITLE
ci(nightly-cnight-e2e-qanet): run job in container to drop sudo apt-get

### DIFF
--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -100,6 +100,19 @@ jobs:
         run: |
           cargo test --release --test e2e_tests --no-default-features --features "$E2E_FEATURE" -- cnight::observation:: --no-capture --test-threads 16
 
+      # `container:` runs as root, so the bind-mounted workspace (and
+      # target/) end up UID 0. Host-mode workflows on this self-hosted
+      # runner pool (see continuous-integration.yml, main.yml) then can't
+      # rm/replace these files during their own checkout. Chown back to
+      # whoever owns the workspace's parent directory — that's the runner
+      # user, by definition. `if: always()` so cancelled/failed jobs
+      # don't poison the runner either.
+      - name: Restore workspace ownership for next runner job
+        if: always()
+        shell: bash
+        run: |
+          chown -R --reference="$(dirname "$GITHUB_WORKSPACE")" "$GITHUB_WORKSPACE"
+
       - name: Notify Slack
         if: always()
         env:

--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -23,9 +23,10 @@ jobs:
     # Run inside a container so test deps are apt-installed as root.
     # The self-hosted runner user is not a passwordless sudoer and has
     # no tty, so `sudo apt-get` fails with "a terminal is required to
-    # read the password". The image pins Rust 1.95 to match
-    # rust-toolchain.toml (single source of truth, mirrored by the
-    # Earthfile's build-prepare stage).
+    # read the password". The Rust version below is duplicated from
+    # rust-toolchain.toml and must be bumped by hand on toolchain
+    # upgrades — #1661 tracks replacing this with a baked CI image
+    # that closes the drift.
     container:
       image: rust:1.95-trixie
     timeout-minutes: 360
@@ -52,8 +53,10 @@ jobs:
       # any other bindgen-using crate (subxt + sqlx + redb only). The
       # Earthfile installs clang because it builds the full node +
       # runtime wasm, a much heavier dep set than we need here.
-      # Clear apt caches afterwards so the ~4 h cargo build has disk
-      # headroom on this runner.
+      # Clear apt caches afterwards so the cargo test build has disk
+      # headroom on this runner — target/ grows several GB during the
+      # release compile (~8 min) that precedes the multi-hour Cardano
+      # stability waits.
       - name: Install system dependencies
         shell: bash
         run: |

--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -20,6 +20,14 @@ jobs:
     # Hetzner self-hosted; its static IP is on the toolkit-cache NLB
     # allowlist. ubuntu-latest cannot reach the shared cache.
     runs-on: [self-hosted, "tier:large"]
+    # Run inside a container so test deps are apt-installed as root.
+    # The self-hosted runner user is not a passwordless sudoer and has
+    # no tty, so `sudo apt-get` fails with "a terminal is required to
+    # read the password". The image pins Rust 1.95 to match
+    # rust-toolchain.toml (single source of truth, mirrored by the
+    # Earthfile's build-prepare stage).
+    container:
+      image: rust:1.95-trixie
     timeout-minutes: 360
 
     steps:
@@ -34,16 +42,28 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 #v1
-        with:
-          toolchain: stable
-
-      - name: Install system dependencies (protoc, postgresql-client)
+      # Running as root inside the container, so no sudo.
+      # `rust:1.95-trixie` already ships gcc/make/git/libssl-dev/libpq-dev/
+      # libsqlite3-dev, so we only add what's missing for this crate:
+      #   - protobuf-compiler: prost/scale-codec build scripts.
+      #   - postgresql-client: psql smoke test against toolkit-cache.
+      #   - pkg-config:        for -sys crates to discover system libs.
+      # No clang/libclang — the e2e test binary doesn't pull rocksdb or
+      # any other bindgen-using crate (subxt + sqlx + redb only). The
+      # Earthfile installs clang because it builds the full node +
+      # runtime wasm, a much heavier dep set than we need here.
+      # Clear apt caches afterwards so the ~4 h cargo build has disk
+      # headroom on this runner.
+      - name: Install system dependencies
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler postgresql-client
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            protobuf-compiler \
+            postgresql-client \
+            pkg-config
+          rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb
           protoc --version
 
       # Fail fast (~1 s) if the shared toolkit cache is unreachable,

--- a/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
+++ b/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
@@ -30,8 +30,9 @@ the e2e test binary depends on `subxt` + `sqlx` + `redb` only, none of
 which pull `rocksdb` or any other `bindgen`-using crate, so libclang
 is not needed (the Earthfile installs it because it builds the full
 node + runtime wasm, a heavier dep set than this job). Apt caches are
-cleared after install so the ~4 h cargo build has disk headroom on
-the runner.
+cleared after install so the cargo test build has disk headroom on
+the runner — `target/` grows several GB during the release compile
+(~8 min) that precedes the multi-hour Cardano stability waits.
 
 A final `if: always()` step chowns the workspace back to the runner
 user before the job exits. Without it, host-mode workflows landing on

--- a/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
+++ b/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
@@ -1,0 +1,37 @@
+#tests #ci
+# Run nightly cNIGHT e2e job inside a container
+
+The nightly `nightly-run-cnight-e2e-qanet` workflow failed on its
+first run after moving to the Hetzner self-hosted runner:
+
+```
+sudo: a terminal is required to read the password; either use the
+-S option to read from standard input or configure an askpass helper
+```
+
+The runner user is not a passwordless sudoer and has no tty, so
+`sudo apt-get …` cannot prompt for a password. `ubuntu-latest`
+configures passwordless sudo by default; self-hosted runners do not.
+
+The job now runs inside a `rust:1.95-trixie` container — same Rust
+version as `rust-toolchain.toml` and the Earthfile's `build-prepare`
+stage — so apt installs happen as root with no sudo needed. The
+container shares the host's network via Docker's default bridge, so
+outbound connections still SNAT to the runner's static IP and the
+toolkit-cache NLB allowlist keeps working.
+
+The `dtolnay/rust-toolchain@stable` step is dropped (the image ships
+rustup + Rust 1.95; the workspace's `rust-toolchain.toml` pulls any
+missing components on first cargo invocation). The apt dep list adds
+`pkg-config` on top of the existing `protobuf-compiler` and
+`postgresql-client` — `libssl-dev`, `libpq-dev`, and `libsqlite3-dev`
+are already in the image. `clang` is intentionally *not* installed:
+the e2e test binary depends on `subxt` + `sqlx` + `redb` only, none of
+which pull `rocksdb` or any other `bindgen`-using crate, so libclang
+is not needed (the Earthfile installs it because it builds the full
+node + runtime wasm, a heavier dep set than this job). Apt caches are
+cleared after install so the ~4 h cargo build has disk headroom on
+the runner.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1658
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1655

--- a/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
+++ b/changes/node/changed/nightly-cnight-e2e-self-hosted-container.md
@@ -33,5 +33,11 @@ node + runtime wasm, a heavier dep set than this job). Apt caches are
 cleared after install so the ~4 h cargo build has disk headroom on
 the runner.
 
+A final `if: always()` step chowns the workspace back to the runner
+user before the job exits. Without it, host-mode workflows landing on
+the same self-hosted runner afterwards would fail to clean up the
+root-owned `target/` and checkout artefacts the container leaves
+behind.
+
 PR: https://github.com/midnightntwrk/midnight-node/pull/1658
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1655


### PR DESCRIPTION
# Overview

The nightly `nightly-run-cnight-e2e-qanet` workflow's `sudo apt-get update` step failed on its first run after moving to the Hetzner self-hosted runner (#1578):

```
sudo: a terminal is required to read the password; either use the
-S option to read from standard input or configure an askpass helper
```

The runner user is not a passwordless sudoer and has no tty, so `sudo apt-get …` cannot prompt for a password. `ubuntu-latest` configures passwordless sudo by default; self-hosted runners do not.

## Approach

Move the job into a `rust:1.95-trixie` container — same Rust version as `rust-toolchain.toml` and the Earthfile's `build-prepare` stage — so apt installs happen as root with no sudo needed.

- The container shares the host's network via Docker's default bridge, so outbound connections still SNAT to the runner's static IP and the toolkit-cache NLB allowlist keeps working.
- The `dtolnay/rust-toolchain@stable` step is dropped: the image already ships rustup + Rust 1.95, and the workspace's `rust-toolchain.toml` pulls any missing components on first cargo invocation.
- Apt install is now `protobuf-compiler`, `postgresql-client`, and `pkg-config` only. `libssl-dev`, `libpq-dev`, and `libsqlite3-dev` are pre-installed in the image. `clang` is intentionally omitted: the e2e test binary depends on `subxt + sqlx + redb` only, none of which pull `rocksdb` or any other `bindgen`-using crate (the Earthfile installs `clang` because it builds the full node + runtime wasm, a heavier dep set than this job).
- Apt caches are cleared after install so the ~4 h cargo build has disk headroom on the runner.

Closes #1655.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- CI-only fix, but added one anyway for nightly visibility -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A — CI only, no node behaviour change -->
- [ ] Update documentation (if relevant) <!-- N/A -->
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- AGENTS.md does not document per-workflow internals -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Two trial runs against the self-hosted runner confirmed the fix:

1. **First run** failed during `apt-get install` with `E: You don't have enough free space in /var/cache/apt/archives/`. Investigation showed the failure was a transient host-state issue, but it also revealed that several packages I'd initially listed (`clang`, `libssl-dev`, `libpq-dev`, `libsqlite3-dev`) were either pre-installed in the image or not needed by this crate's dep tree. The squashed commit reflects the trimmed final list.
2. **Second run** passed the workflow steps this PR touches: container started, apt install completed, cargo build finished in 8m 27s, and all 11 cNIGHT observation tests started. The subsequent failure was a separate, unrelated runtime issue — the Cardano Preview faucet at `addr_test1vr5vxqpnpl…q3h90l6` is underfunded by ~1.5k tADA — tracked in #1657 with a proposed pre-flight smoke check to fail fast on this class of failure in future.

- [ ] Additional tests are provided (if possible) <!-- N/A — CI configuration change -->

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A

## Links

- Closes #1655 — `sudo apt-get` failure on self-hosted runner
- Related: #1657 — proposed faucet-balance smoke check (surfaced by the second trial run)
- Related: #1578 — original move to the Hetzner self-hosted runner

Assisted-by: Claude:claude-4.7-opus