### PR TITLE
ci: defensively tear down leaked local-env stack on self-hosted host

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1160,12 +1160,22 @@ jobs:
       # (local-env-r<slot>), so it can never touch the other runners sharing the
       # host. RUNNER_SLOT is set per slot in the runner's .env; RUNNER_NAME
       # (e.g. fsn1-runner-01-runner-4) is the fallback.
+      #
+      # Removal is by docker compose label rather than `docker compose down`:
+      # this step has no compose file on its cwd (the repo root), and we want a
+      # file-independent teardown that is guaranteed to drop both the containers
+      # (where the cardano chain data lives, in the writable layers) and the
+      # named volumes, identified purely by the project label. Force `rm -f`
+      # also avoids the graceful-SIGTERM stop hanging on cardano-node/db-sync.
       - name: Tear down this slot's local-env stack (defensive)
         if: always()
         shell: bash
         run: |
           proj="local-env-r${RUNNER_SLOT:-${RUNNER_NAME##*-}}"
-          docker compose -p "$proj" down --volumes --remove-orphans --timeout 20 || true
+          docker ps -aq --filter "label=com.docker.compose.project=${proj}" \
+            | xargs -r docker rm -f || true
+          docker volume ls -q --filter "label=com.docker.compose.project=${proj}" \
+            | xargs -r docker volume rm -f || true
 
       - uses: ./.github/actions/tree-cache-guard/save
         if: steps.guard.outputs.hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1151,6 +1151,22 @@ jobs:
           tests: premerge
           ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
+      # Defensive host-side teardown. The premerge stack runs inside earthly's
+      # nested dockerd (+local-env-ci) and is normally ephemeral, but if a
+      # change or an interrupted run ever leaves a host-side local-env stack for
+      # THIS runner slot, remove it so leaked stacks can't accumulate and fill
+      # the shared self-hosted host's disk (jobs then fail at "Set up job" with
+      # "No space left on device"). Scoped to this slot's compose project
+      # (local-env-r<slot>), so it can never touch the other runners sharing the
+      # host. RUNNER_SLOT is set per slot in the runner's .env; RUNNER_NAME
+      # (e.g. fsn1-runner-01-runner-4) is the fallback.
+      - name: Tear down this slot's local-env stack (defensive)
+        if: always()
+        shell: bash
+        run: |
+          proj="local-env-r${RUNNER_SLOT:-${RUNNER_NAME##*-}}"
+          docker compose -p "$proj" down --volumes --remove-orphans --timeout 20 || true
+
       - uses: ./.github/actions/tree-cache-guard/save
         if: steps.guard.outputs.hit != 'true'
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1151,22 +1151,11 @@ jobs:
           tests: premerge
           ghcr-password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
 
-      # Defensive host-side teardown. The premerge stack runs inside earthly's
-      # nested dockerd (+local-env-ci) and is normally ephemeral, but if a
-      # change or an interrupted run ever leaves a host-side local-env stack for
-      # THIS runner slot, remove it so leaked stacks can't accumulate and fill
-      # the shared self-hosted host's disk (jobs then fail at "Set up job" with
-      # "No space left on device"). Scoped to this slot's compose project
-      # (local-env-r<slot>), so it can never touch the other runners sharing the
-      # host. RUNNER_SLOT is set per slot in the runner's .env; RUNNER_NAME
-      # (e.g. fsn1-runner-01-runner-4) is the fallback.
-      #
-      # Removal is by docker compose label rather than `docker compose down`:
-      # this step has no compose file on its cwd (the repo root), and we want a
-      # file-independent teardown that is guaranteed to drop both the containers
-      # (where the cardano chain data lives, in the writable layers) and the
-      # named volumes, identified purely by the project label. Force `rm -f`
-      # also avoids the graceful-SIGTERM stop hanging on cardano-node/db-sync.
+      # Defensive cleanup of an orphaned local-env stack for this runner slot, so
+      # leaked stacks can't accumulate and fill the shared self-hosted host disk.
+      # Scoped to this slot's compose project (local-env-r<slot>) so it never
+      # touches other runners on the host. RUNNER_SLOT comes from the runner .env;
+      # RUNNER_NAME (e.g. fsn1-runner-01-runner-4) is the fallback.
       - name: Tear down this slot's local-env stack (defensive)
         if: always()
         shell: bash


### PR DESCRIPTION
# Overview

The premerge local-env e2e stack runs inside earthly's nested dockerd (`+local-env-ci`) and is normally ephemeral. But interrupted runs (and host-side bring-ups on some branches, e.g. WIP e2e work) can leave a host-side `local-env-r<slot>` docker-compose stack behind on the shared self-hosted runner. Those leaked stacks accumulate on `/var` (the cardano chain data sits in the container writable layers, hundreds of GB each), and once the disk fills, **every** job on that host fails at "Set up job" with `No space left on device` (seen 2026-06-08 on `fsn1-runner-01`).

This adds an `if: always()` teardown step to the **Local Environment Tests** job that removes this job's own stack. It is **scoped to the runner slot's compose project** (`local-env-r<slot>`), so by construction it can never touch the 7 other runners sharing the host — safe under parallelism. It is a no-op when nothing is up.

This is the workflow-side first line ("polluter pays"). The shared runner host also gets a slot-idle reaper backstop (in shielded-iac) that covers the case this step can't — a hard-killed/OOM'd runner where `always()` never runs.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI-only change, no product/image impact
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow — parses OK.
- `shellcheck` on the embedded run script — clean.
- The teardown idiom `docker compose -p "$proj" down --volumes --remove-orphans` mirrors the manual recovery used to clear the 2026-06-08 incident, scoped to a single project. `RUNNER_SLOT` is set per slot in the runner `.env`; `${RUNNER_NAME##*-}` (e.g. `fsn1-runner-01-runner-4` -> `4`) is the fallback.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A

## Links

- Related: shielded-iac reaper backstop (host-side, slot-idle) for the same incident.