### PR TITLE
fix(e2e): read qanet contracts info from reserve-contracts submodule

### DIFF
--- a/changes/node/changed/e2e-qanet-contracts-from-submodule.md
+++ b/changes/node/changed/e2e-qanet-contracts-from-submodule.md
@@ -1,0 +1,27 @@
+#node #tests
+# Decouple qanet e2e tests from local-env docker artefacts
+
+`tests/e2e/src/config.rs` always read `contracts-info.json` /
+`plutus-local.json` from
+`local-environment/src/networks/local-env/runtime-values/`, which only
+exists after `docker compose up` in local-env has been run on the host.
+The qanet nightly job, after switching to a clean container runner,
+started panicking at `Settings::default()` because the directory was
+absent.
+
+The qanet feature now points at the `midnight-reserve-contracts`
+submodule's qanet deployment snapshot
+(`deployments/qanet/contract-info.json` +
+`deployed-scripts/qanet/plutus.json`), which is checked in alongside the
+submodule pin. `local-*` features still read the docker-generated
+runtime-values dir, and `RUNTIME_VALUES_DIR` continues to work as the
+historic per-dir override.
+
+`mapping_validator_address` and `mapping_validator_policy_id` now derive
+from the compiled validator script (same pattern as
+`cnight_token_policy_id`), because the upstream qanet `contract-info.json`
+has no `cNIGHT Generates Dust` entry. Both features compute the same
+values they did before.
+
+PR: <link to PR>
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1609

--- a/changes/node/changed/e2e-qanet-contracts-from-submodule.md
+++ b/changes/node/changed/e2e-qanet-contracts-from-submodule.md
@@ -23,5 +23,5 @@ from the compiled validator script (same pattern as
 has no `cNIGHT Generates Dust` entry. Both features compute the same
 values they did before.
 
-PR: <link to PR>
+PR: https://github.com/midnightntwrk/midnight-node/pull/1666
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1609

--- a/tests/e2e/src/config.rs
+++ b/tests/e2e/src/config.rs
@@ -4,23 +4,25 @@ use whisky::{LanguageVersion, Network as CardanoNetwork};
 
 // Default location of the contract-info and plutus blueprint files.
 // `local-*` features read what local-env's docker stack writes to disk;
-// `qanet` reads the snapshot of actually-deployed contracts pinned via the
-// `midnight-reserve-contracts` submodule — so the qanet suite has no dependency
-// on local-env ever having been brought up on the host. Both can be overridden
-// via `RUNTIME_VALUES_DIR`, which keeps the historic single-dir layout
-// (contracts-info.json + plutus-local.json) for ad-hoc use.
+// every other network feature reads the snapshot of actually-deployed
+// contracts pinned via the `midnight-reserve-contracts` submodule — so the
+// non-local-env suite has no dependency on local-env ever having been brought
+// up on the host. Both can be overridden via `RUNTIME_VALUES_DIR`, which keeps
+// the historic single-dir layout (contracts-info.json + plutus-local.json)
+// for ad-hoc use.
 fn contracts_info_path() -> String {
     if let Ok(dir) = std::env::var("RUNTIME_VALUES_DIR") {
         return format!("{dir}/contracts-info.json");
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    #[cfg(feature = "qanet")]
-    let p = format!(
-        "{manifest_dir}/../../midnight-reserve-contracts/deployments/qanet/contract-info.json"
-    );
-    #[cfg(not(feature = "qanet"))]
+    #[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
     let p = format!(
         "{manifest_dir}/../../local-environment/src/networks/local-env/runtime-values/contracts-info.json"
+    );
+    #[cfg(not(any(feature = "local", feature = "local-dev", feature = "local-ci")))]
+    let p = format!(
+        "{manifest_dir}/../../midnight-reserve-contracts/deployments/{}/contract-info.json",
+        submodule_network()
     );
     p
 }
@@ -30,15 +32,24 @@ fn plutus_path() -> String {
         return format!("{dir}/plutus-local.json");
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    #[cfg(feature = "qanet")]
-    let p = format!(
-        "{manifest_dir}/../../midnight-reserve-contracts/deployed-scripts/qanet/plutus.json"
-    );
-    #[cfg(not(feature = "qanet"))]
+    #[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
     let p = format!(
         "{manifest_dir}/../../local-environment/src/networks/local-env/runtime-values/plutus-local.json"
     );
+    #[cfg(not(any(feature = "local", feature = "local-dev", feature = "local-ci")))]
+    let p = format!(
+        "{manifest_dir}/../../midnight-reserve-contracts/deployed-scripts/{}/plutus.json",
+        submodule_network()
+    );
     p
+}
+
+#[cfg(not(any(feature = "local", feature = "local-dev", feature = "local-ci")))]
+fn submodule_network() -> &'static str {
+    #[cfg(feature = "qanet")]
+    {
+        "qanet"
+    }
 }
 
 fn read_contracts_info_entry(name: &str) -> serde_json::Value {

--- a/tests/e2e/src/config.rs
+++ b/tests/e2e/src/config.rs
@@ -1,38 +1,70 @@
 use std::time::Duration;
-use whisky::csl::NetworkInfo as CardanoNetworkInfo;
+use whisky::csl::{Credential, EnterpriseAddress, NetworkInfo as CardanoNetworkInfo, ScriptHash};
 use whisky::{LanguageVersion, Network as CardanoNetwork};
 
-fn runtime_values_dir() -> String {
-    std::env::var("RUNTIME_VALUES_DIR").unwrap_or_else(|_| {
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        format!("{manifest_dir}/../../local-environment/src/networks/local-env/runtime-values")
-    })
+// Default location of the contract-info and plutus blueprint files.
+// `local-*` features read what local-env's docker stack writes to disk;
+// `qanet` reads the snapshot of actually-deployed contracts pinned via the
+// `midnight-reserve-contracts` submodule — so the qanet suite has no dependency
+// on local-env ever having been brought up on the host. Both can be overridden
+// via `RUNTIME_VALUES_DIR`, which keeps the historic single-dir layout
+// (contracts-info.json + plutus-local.json) for ad-hoc use.
+fn contracts_info_path() -> String {
+    if let Ok(dir) = std::env::var("RUNTIME_VALUES_DIR") {
+        return format!("{dir}/contracts-info.json");
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    #[cfg(feature = "qanet")]
+    let p = format!(
+        "{manifest_dir}/../../midnight-reserve-contracts/deployments/qanet/contract-info.json"
+    );
+    #[cfg(not(feature = "qanet"))]
+    let p = format!(
+        "{manifest_dir}/../../local-environment/src/networks/local-env/runtime-values/contracts-info.json"
+    );
+    p
+}
+
+fn plutus_path() -> String {
+    if let Ok(dir) = std::env::var("RUNTIME_VALUES_DIR") {
+        return format!("{dir}/plutus-local.json");
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    #[cfg(feature = "qanet")]
+    let p = format!(
+        "{manifest_dir}/../../midnight-reserve-contracts/deployed-scripts/qanet/plutus.json"
+    );
+    #[cfg(not(feature = "qanet"))]
+    let p = format!(
+        "{manifest_dir}/../../local-environment/src/networks/local-env/runtime-values/plutus-local.json"
+    );
+    p
 }
 
 fn read_contracts_info_entry(name: &str) -> serde_json::Value {
-    let path = format!("{}/contracts-info.json", runtime_values_dir());
+    let path = contracts_info_path();
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read contracts-info.json at {path}: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to read contract-info at {path}: {e}"));
     let entries: Vec<serde_json::Value> =
-        serde_json::from_str(&content).expect("Failed to parse contracts-info.json");
+        serde_json::from_str(&content).expect("Failed to parse contract-info json");
     entries
         .into_iter()
         .find(|entry| entry["name"].as_str() == Some(name))
-        .unwrap_or_else(|| panic!("{name} not found in contracts-info.json"))
+        .unwrap_or_else(|| panic!("{name} not found in {path}"))
 }
 
 fn read_plutus_compiled_code(title: &str) -> String {
-    let path = format!("{}/plutus-local.json", runtime_values_dir());
+    let path = plutus_path();
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read plutus-local.json at {path}: {e}"));
+        .unwrap_or_else(|e| panic!("Failed to read plutus blueprint at {path}: {e}"));
     let blueprint: serde_json::Value =
-        serde_json::from_str(&content).expect("Failed to parse plutus-local.json");
+        serde_json::from_str(&content).expect("Failed to parse plutus blueprint");
     blueprint["validators"]
         .as_array()
         .expect("validators should be an array")
         .iter()
         .find(|v| v["title"].as_str() == Some(title))
-        .unwrap_or_else(|| panic!("{title} not found in plutus-local.json"))["compiledCode"]
+        .unwrap_or_else(|| panic!("{title} not found in {path}"))["compiledCode"]
         .as_str()
         .expect("compiledCode should be a string")
         .to_string()
@@ -187,19 +219,26 @@ pub struct Payments {
     pub funded_address_vkey_cbor: String,
 }
 pub fn mapping_validator_address() -> String {
-    let entry = read_contracts_info_entry("cNIGHT Generates Dust");
-    entry["address"]
-        .as_str()
-        .expect("address should be a string")
-        .to_string()
+    // Derive the bech32 enterprise address from the compiled validator script.
+    // The qanet contract-info snapshot does not carry a `cNIGHT Generates Dust`
+    // entry, but plutus.json does, and the script hash uniquely determines the
+    // address for any given Cardano network. Both supported features target
+    // Preview testnet, so the network id matches local-env's `bun cli info`
+    // output and the historical contracts-info.json `address` field.
+    let script_hash = ScriptHash::from_hex(&mapping_validator_policy_id())
+        .expect("Failed to decode mapping_validator script hash");
+    let cred = Credential::from_scripthash(&script_hash);
+    let network_id = CardanoNetworkInfo::testnet_preview().network_id();
+    EnterpriseAddress::new(network_id, &cred)
+        .to_address()
+        .to_bech32(None)
+        .expect("Failed to encode mapping_validator address")
 }
 
 pub fn mapping_validator_policy_id() -> String {
-    let entry = read_contracts_info_entry("cNIGHT Generates Dust");
-    entry["scriptHash"]
-        .as_str()
-        .expect("scriptHash should be a string")
-        .to_string()
+    let cbor_double_encoded = mapping_validator_cbor_double_encoding();
+    whisky::get_script_hash(&cbor_double_encoded, LanguageVersion::V3)
+        .expect("Error calculating mapping_validator_policy_id")
 }
 
 pub fn mapping_validator_cbor_double_encoding() -> String {


### PR DESCRIPTION
# Overview

`tests/e2e/src/config.rs` always read `contracts-info.json` and `plutus-local.json` from `local-environment/src/networks/local-env/runtime-values/`, which only exists after local-env's docker stack has been brought up on the host. The qanet nightly job, after moving to a clean container runner, panicked at `Settings::default()` because the directory was absent.

This PR points the qanet feature at the `midnight-reserve-contracts` submodule's deployed-contracts snapshot, pinned by the submodule SHA:
- `deployments/qanet/contract-info.json`
- `deployed-scripts/qanet/plutus.json`

`local-*` features keep reading the docker-generated runtime-values path; `RUNTIME_VALUES_DIR` continues to work as the per-dir override.

`mapping_validator_address` and `mapping_validator_policy_id` now derive from the compiled validator script (same pattern as `cnight_token_policy_id`) because qanet's upstream `contract-info.json` has no `cNIGHT Generates Dust` entry. The `cnight_generates_dust` validator has no one-shot-hash parameter, so the derivation produces the same hash (`7e69087d…`) and address (`addr_test1wplxjzr…`) on both networks — verified to match the historical `contracts-info.json` values for local-env, so this is value-preserving for the existing suite.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Re-ran the failing test path on both backends:

```
cargo test -p midnight-node-e2e --no-default-features --features qanet --test e2e_tests cnight::alice_cannot_deregister_bob -- --nocapture
# test cnight::alice_cannot_deregister_bob ... ok (224.80s)

cargo test -p midnight-node-e2e --no-default-features --features local  --test e2e_tests cnight::alice_cannot_deregister_bob -- --nocapture
# test cnight::alice_cannot_deregister_bob ... ok (13.83s)
```

In both runs the registration UTXO lands at `addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng` carrying policy `7e69087d98fac5869eac14e13dfb6f98228c41e638aa2a59d1f85e9c` — confirms the derived address and policy match the deployed mapping validator end-to-end.

Sanity-checked against the local-env-recorded `contracts-info.json`: the derived hash equals the existing `scriptHash`, and the derived bech32 equals the existing `address`, so this is a no-op for already-passing local suites.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: e2e tests only, no runtime/client impact.
- [x] N/A

## Links

Closes #1609