### PR TITLE
test: c2m-bridge subminimal-transfer edge cases

### DIFF
--- a/changes/node/changed/subminimal-transfer-edge-tests.md
+++ b/changes/node/changed/subminimal-transfer-edge-tests.md
@@ -1,0 +1,12 @@
+#tests
+
+# Edge-case tests for c2m-bridge subminimal-transfer accumulation
+
+Add unit tests for `handle_subminimal_transfer` covering: the strict `sum > threshold` boundary
+(below / at / above), a single subminimal that flushes immediately, accumulator reset and
+restart after a flush, subminimal routing precedence over Invalid / unapproved User recipients,
+governance-driven threshold lowering against a non-empty accumulator, and non-interference
+between regular and subminimal transfers.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1677
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1248

--- a/changes/node/changed/subminimal-transfer-edge-tests.md
+++ b/changes/node/changed/subminimal-transfer-edge-tests.md
@@ -3,10 +3,9 @@
 # Edge-case tests for c2m-bridge subminimal-transfer accumulation
 
 Add unit tests for `handle_subminimal_transfer` covering: the strict `sum > threshold` boundary
-(below / at / above), a single subminimal that flushes immediately, accumulator reset and
-restart after a flush, subminimal routing precedence over Invalid / unapproved User recipients,
-governance-driven threshold lowering against a non-empty accumulator, and non-interference
-between regular and subminimal transfers.
+(below / at / above), accumulator reset and restart after a flush, subminimal routing precedence
+over Invalid / unapproved User recipients, and non-interference between regular and subminimal
+transfers.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1677
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1248

--- a/pallets/c2m-bridge/src/tests.rs
+++ b/pallets/c2m-bridge/src/tests.rs
@@ -269,30 +269,6 @@ fn subminimal_flushes_just_above_threshold() {
 }
 
 #[test]
-fn single_subminimal_above_threshold_flushes_immediately() {
-	new_test_ext().execute_with(|| {
-		// Threshold below a single subminimal amount → the very first transfer
-		// flushes with count=1, exercising the `count: 0 → 1` saturating add
-		// in the same call as the flush.
-		set_flush_threshold(50);
-		C2MBridge::handle_incoming_transfer(subminimal_transfer());
-		assert_eq!(
-			pallet::SubminimalTransfers::<Test>::get(),
-			SubminimalTransfersState { count: 0, sum: 0 }
-		);
-		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
-		assert_eq!(
-			subminimal_events(),
-			vec![Event::SubminimalFlushTransfer {
-				amount: 90,
-				count: 1,
-				midnight_tx_hash: [0u8; 32],
-			}],
-		);
-	})
-}
-
-#[test]
 fn subminimal_state_resets_after_flush_and_accumulates_again() {
 	new_test_ext().execute_with(|| {
 		set_flush_threshold(180);
@@ -376,42 +352,6 @@ fn subminimal_unapproved_user_accumulates_not_unlocks() {
 		);
 		assert!(subminimal_events().is_empty());
 		assert!(mock_pallet::Transfers::<Test>::get().is_empty());
-	})
-}
-
-#[test]
-fn governance_lowering_threshold_flushes_existing_accumulator() {
-	new_test_ext().execute_with(|| {
-		// Start with a threshold the accumulator cannot reach with two transfers.
-		set_flush_threshold(200);
-		C2MBridge::handle_incoming_transfer(subminimal_transfer());
-		assert_eq!(
-			pallet::SubminimalTransfers::<Test>::get(),
-			SubminimalTransfersState { count: 1, sum: 90 }
-		);
-
-		// Governance lowers the threshold below what two transfers will sum to,
-		// but the resulting sum (180) still sits below the original threshold (200) —
-		// so the flush proves the new config is what's in effect.
-		assert_ok!(C2MBridge::set_subminimal_transfers_config(
-			frame_system::RawOrigin::Root.into(),
-			SubminimalTransfersConfig { subminimal_transfers_flush_threshold: 100 },
-		));
-
-		C2MBridge::handle_incoming_transfer(subminimal_transfer());
-		assert_eq!(
-			pallet::SubminimalTransfers::<Test>::get(),
-			SubminimalTransfersState { count: 0, sum: 0 }
-		);
-		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
-		assert_eq!(
-			subminimal_events(),
-			vec![Event::SubminimalFlushTransfer {
-				amount: 180,
-				count: 2,
-				midnight_tx_hash: [0u8; 32],
-			}],
-		);
 	})
 }
 

--- a/pallets/c2m-bridge/src/tests.rs
+++ b/pallets/c2m-bridge/src/tests.rs
@@ -203,6 +203,261 @@ fn subminimal_transfer_handling() {
 	})
 }
 
+fn set_flush_threshold(threshold: u64) {
+	pallet::SubminimalTransfersConfiguration::<Test>::set(SubminimalTransfersConfig {
+		subminimal_transfers_flush_threshold: threshold,
+	});
+}
+
+fn subminimal_events() -> Vec<Event<Test>> {
+	frame_system::Pallet::<Test>::read_events_for_pallet::<Event<Test>>()
+}
+
+#[test]
+fn subminimal_no_flush_just_below_threshold() {
+	new_test_ext().execute_with(|| {
+		// sum = 180, threshold = 181 → 180 > 181 is false, no flush.
+		set_flush_threshold(181);
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 2, sum: 180 }
+		);
+		assert!(subminimal_events().is_empty());
+		assert!(mock_pallet::Transfers::<Test>::get().is_empty());
+	})
+}
+
+#[test]
+fn subminimal_no_flush_at_exact_threshold() {
+	new_test_ext().execute_with(|| {
+		// sum = 180, threshold = 180 → strict `sum > threshold` is false, no flush.
+		set_flush_threshold(180);
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 2, sum: 180 }
+		);
+		assert!(subminimal_events().is_empty());
+		assert!(mock_pallet::Transfers::<Test>::get().is_empty());
+	})
+}
+
+#[test]
+fn subminimal_flushes_just_above_threshold() {
+	new_test_ext().execute_with(|| {
+		// sum = 180, threshold = 179 → 180 > 179 is true, flush.
+		set_flush_threshold(179);
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 0, sum: 0 }
+		);
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			subminimal_events(),
+			vec![Event::SubminimalFlushTransfer {
+				amount: 180,
+				count: 2,
+				midnight_tx_hash: [0u8; 32],
+			}],
+		);
+	})
+}
+
+#[test]
+fn single_subminimal_above_threshold_flushes_immediately() {
+	new_test_ext().execute_with(|| {
+		// Threshold below a single subminimal amount → the very first transfer
+		// flushes with count=1, exercising the `count: 0 → 1` saturating add
+		// in the same call as the flush.
+		set_flush_threshold(50);
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 0, sum: 0 }
+		);
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			subminimal_events(),
+			vec![Event::SubminimalFlushTransfer {
+				amount: 90,
+				count: 1,
+				midnight_tx_hash: [0u8; 32],
+			}],
+		);
+	})
+}
+
+#[test]
+fn subminimal_state_resets_after_flush_and_accumulates_again() {
+	new_test_ext().execute_with(|| {
+		set_flush_threshold(180);
+		// Accumulate to (count=2, sum=180) — no flush at strict equality.
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 2, sum: 180 }
+		);
+		// 3rd transfer pushes sum to 270 > 180 → flush, storage reset.
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 0, sum: 0 }
+		);
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+
+		// New subminimal after a flush must restart the accumulator from zero,
+		// not inherit any residue from the prior cycle.
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+		// Still only the flush from the first cycle — the 4th transfer must
+		// not have produced a second system tx.
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			subminimal_events(),
+			vec![Event::SubminimalFlushTransfer {
+				amount: 270,
+				count: 3,
+				midnight_tx_hash: [0u8; 32],
+			}],
+		);
+	})
+}
+
+#[test]
+fn subminimal_invalid_recipient_accumulates_not_unlocks() {
+	new_test_ext().execute_with(|| {
+		// `handle_incoming_transfer` routes by amount before recipient kind,
+		// so a subminimal `Invalid` transfer accumulates rather than emitting
+		// `InvalidTransfer` / `UnlockToTreasury`.
+		set_flush_threshold(1_000);
+		let transfer = BridgeTransferV1 {
+			amount: 90,
+			mc_tx_hash: McTxHash([42; 32]),
+			recipient: TransferRecipient::Invalid,
+		};
+		C2MBridge::handle_incoming_transfer(transfer);
+
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+		assert!(subminimal_events().is_empty());
+		assert!(mock_pallet::Transfers::<Test>::get().is_empty());
+	})
+}
+
+#[test]
+fn subminimal_unapproved_user_accumulates_not_unlocks() {
+	new_test_ext().execute_with(|| {
+		// Same routing argument as the invalid-recipient case: an addressed
+		// subminimal with no governance approval must accumulate, not emit
+		// `UnapprovedTransfer`.
+		set_flush_threshold(1_000);
+		let transfer = BridgeTransferV1 {
+			amount: 90,
+			mc_tx_hash: McTxHash([7; 32]),
+			recipient: TransferRecipient::Address { recipient: recipient() },
+		};
+		assert!(!pallet::ApprovedMcTxHashes::<Test>::contains_key(transfer.mc_tx_hash));
+		C2MBridge::handle_incoming_transfer(transfer);
+
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+		assert!(subminimal_events().is_empty());
+		assert!(mock_pallet::Transfers::<Test>::get().is_empty());
+	})
+}
+
+#[test]
+fn governance_lowering_threshold_flushes_existing_accumulator() {
+	new_test_ext().execute_with(|| {
+		// Start with a threshold the accumulator cannot reach with two transfers.
+		set_flush_threshold(200);
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+
+		// Governance lowers the threshold below what two transfers will sum to,
+		// but the resulting sum (180) still sits below the original threshold (200) —
+		// so the flush proves the new config is what's in effect.
+		assert_ok!(C2MBridge::set_subminimal_transfers_config(
+			frame_system::RawOrigin::Root.into(),
+			SubminimalTransfersConfig { subminimal_transfers_flush_threshold: 100 },
+		));
+
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 0, sum: 0 }
+		);
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			subminimal_events(),
+			vec![Event::SubminimalFlushTransfer {
+				amount: 180,
+				count: 2,
+				midnight_tx_hash: [0u8; 32],
+			}],
+		);
+	})
+}
+
+#[test]
+fn regular_transfer_does_not_disturb_subminimal_accumulator() {
+	new_test_ext().execute_with(|| {
+		set_flush_threshold(1_000);
+		// Seed the accumulator.
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+
+		// A regular approved User transfer interleaves; it must take the
+		// regular path (system tx + UserTransfer event) and leave the
+		// subminimal accumulator untouched.
+		let tx = addressed_transfer();
+		approve(tx.mc_tx_hash);
+		C2MBridge::handle_incoming_transfer(tx);
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 1, sum: 90 }
+		);
+
+		// Next subminimal continues accumulating from where it left off.
+		C2MBridge::handle_incoming_transfer(subminimal_transfer());
+		assert_eq!(
+			pallet::SubminimalTransfers::<Test>::get(),
+			SubminimalTransfersState { count: 2, sum: 180 }
+		);
+		// Still just the one regular system tx — no flush.
+		assert_eq!(mock_pallet::Transfers::<Test>::get().len(), 1);
+		assert_eq!(
+			subminimal_events(),
+			vec![Event::UserTransfer {
+				mc_tx_hash: McTxHash([1; 32]),
+				amount: 100,
+				recipient: recipient(),
+				midnight_tx_hash: [0u8; 32],
+			}],
+		);
+	})
+}
+
 fn batch(hashes: Vec<McTxHash>) -> BoundedVec<McTxHash, ConstU32<MAX_APPROVALS_PER_BATCH>> {
 	BoundedVec::try_from(hashes).expect("batch exceeds bound")
 }


### PR DESCRIPTION
# Overview

QA follow-up for #1248 ("Accumulate too small transactions"). The c2m-bridge subminimal-transfer accumulator has a happy-path e2e (PR #1654) and one unit test, but several branches in `handle_subminimal_transfer` were untested. This PR fills those gaps at unit level.

**Unit tests** added to `pallets/c2m-bridge/src/tests.rs`:
- Strict `sum > threshold` boundary — three tests for sum just below / equal / just above the threshold (equality must NOT flush).
- Post-flush state reset — after a flush, the next subminimal restarts the accumulator from zero (verified via storage, not just events).
- Routing precedence over `TransferRecipient::Invalid` and unapproved User — subminimal-Invalid / subminimal-unapproved-User must accumulate, not emit `InvalidTransfer` / `UnapprovedTransfer`.
- Non-interference between regular and subminimal — a regular approved User transfer in between two subminimals must take the regular path and leave the accumulator untouched.

A storage-level e2e assertion (reading `SubminimalTransfers` between submissions) was tried and then reverted — the accumulator's `(count, sum)` is an implementation detail, and the transition-level guarantees are better expressed at unit level. The existing e2e already covers the user-observable behavior via flush events and `UnlockToTreasury`.

Two earlier test cases (`single_subminimal_above_threshold_flushes_immediately`, `governance_lowering_threshold_flushes_existing_accumulator`) were dropped per LGLO review — the first tested a code path only reachable with invalid configuration (`flush_threshold < c_to_m_bridge_min_amount`), the second pinned down accumulator behaviour across mid-flight config changes that isn't a spec requirement.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A: tests only -->
- [ ] Update documentation (if relevant) <!-- N/A -->
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- N/A -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Unit tests — `cargo test -p pallet-c2m-bridge`:

```
running 16 tests
test tests::subminimal_no_flush_just_below_threshold ... ok
test tests::subminimal_no_flush_at_exact_threshold ... ok
test tests::subminimal_flushes_just_above_threshold ... ok
test tests::subminimal_state_resets_after_flush_and_accumulates_again ... ok
test tests::subminimal_invalid_recipient_accumulates_not_unlocks ... ok
test tests::subminimal_unapproved_user_accumulates_not_unlocks ... ok
test tests::regular_transfer_does_not_disturb_subminimal_accumulator ... ok
... (existing tests also pass)
test result: ok. 16 passed; 0 failed
```

E2E (existing test, unchanged) — verified against local-env:

```
E2E_SKIP_DEPLOY_GATE=1 cargo test --test e2e_tests --no-default-features --features local \
  subminimal_transfers_accumulate_and_flush_on_threshold_breach -- --test-threads=1 --nocapture
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 250.80s
```

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A <!-- test-only -->

## Links

Closes #1248