### PR TITLE
ci: remove manual `workflow_dispatch` from qanet nightly e2e workflow

### DIFF
--- a/.github/workflows/nightly-run-cnight-e2e-qanet.yml
+++ b/.github/workflows/nightly-run-cnight-e2e-qanet.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Runs every night at 00:00 UTC against the default branch.
     - cron: "0 0 * * *"
-  # Manual dispatch lets you pick any branch from the GitHub UI's
-  # "Use workflow from" dropdown (defaults to the default branch).
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- Prevent unreviewed branch code from running on the privileged Hetzner self-hosted runner with repository secrets by removing the manual `workflow_dispatch` trigger that allowed selecting arbitrary refs.

### Description
- Remove the `workflow_dispatch` block from `.github/workflows/nightly-run-cnight-e2e-qanet.yml` so the job only runs on the scheduled default-branch context while preserving the existing scheduled job and runner configuration.

### Testing
- Verified the `workflow_dispatch` lines are no longer present with a pattern search, parsed the workflow YAML with Ruby's `YAML` loader, and ran `git diff --check` to ensure no accidental whitespace or syntax issues; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2680af3c188333a4fa8f0de2190454)