### PR TITLE
fix(ci): harden release workflow inputs

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -82,6 +82,16 @@ jobs:
           echo "::error::At least one component must be selected for release. All three skip flags are set."
           exit 1
 
+      - name: Validate suffix
+        if: inputs.suffix != ''
+        env:
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
+          if [[ ! "$SUFFIX" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "::error::suffix may only contain letters, numbers, dots, underscores, and hyphens"
+            exit 1
+          fi
+
   prepare-release:
     permissions:
       contents: read
@@ -620,8 +630,9 @@ jobs:
       - name: Extract node binary from Docker image
         if: inputs.skip-node != true
         id: extract-node
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          PLATFORM="${{ matrix.platform }}"
           NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:${IMAGE_TAG_RELEASE}"
           NODE_RELEASE="midnight-node-${IMAGE_TAG_RELEASE}-linux-${PLATFORM}.tar.gz"
 
@@ -639,8 +650,9 @@ jobs:
       - name: Extract toolkit binary from Docker image
         if: inputs.skip-toolkit != true
         id: extract-toolkit
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          PLATFORM="${{ matrix.platform }}"
           TOOLKIT_IMAGE="ghcr.io/midnight-ntwrk/midnight-node-toolkit:${TOOLKIT_TAG_RELEASE}"
           TOOLKIT_RELEASE="midnight-node-toolkit-${TOOLKIT_TAG_RELEASE}-linux-${PLATFORM}.tar.gz"
 
@@ -658,11 +670,12 @@ jobs:
         env:
           NODE_RELEASE: ${{ steps.extract-node.outputs.node_release }}
           TOOLKIT_RELEASE: ${{ steps.extract-toolkit.outputs.toolkit_release }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          if [ -n "$NODE_RELEASE" ]; then sha256sum "$NODE_RELEASE" >> "SHA256SUMS-${{ matrix.platform }}"; fi
-          if [ -n "$TOOLKIT_RELEASE" ]; then sha256sum "$TOOLKIT_RELEASE" >> "SHA256SUMS-${{ matrix.platform }}"; fi
+          if [ -n "$NODE_RELEASE" ]; then sha256sum "$NODE_RELEASE" >> "SHA256SUMS-$PLATFORM"; fi
+          if [ -n "$TOOLKIT_RELEASE" ]; then sha256sum "$TOOLKIT_RELEASE" >> "SHA256SUMS-$PLATFORM"; fi
           echo "Generated checksums:"
-          cat "SHA256SUMS-${{ matrix.platform }}"
+          cat "SHA256SUMS-$PLATFORM"
 
       - name: Attest node release binary
         if: inputs.skip-node != true
@@ -681,12 +694,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_FILE: ${{ steps.extract-node.outputs.node_release }}
           TOOLKIT_FILE: ${{ steps.extract-toolkit.outputs.toolkit_release }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           echo "Uploading assets to release: $GIT_TAG_RELEASE"
           FILES=()
           [ -n "$NODE_FILE" ] && FILES+=("$NODE_FILE")
           [ -n "$TOOLKIT_FILE" ] && FILES+=("$TOOLKIT_FILE")
-          FILES+=("SHA256SUMS-${{ matrix.platform }}")
+          FILES+=("SHA256SUMS-$PLATFORM")
           gh release upload --repo "$GITHUB_REPOSITORY" "$GIT_TAG_RELEASE" "${FILES[@]}"
 
   srtool-build:

--- a/.github/workflows/srtool-build.yml
+++ b/.github/workflows/srtool-build.yml
@@ -62,6 +62,16 @@ jobs:
         run: |
           . ./.envrc && earthly +srtool-build
 
+      - name: Validate runtime tag release
+        if: inputs.runtime-tag-release != ''
+        env:
+          RTAG: ${{ inputs.runtime-tag-release }}
+        run: |
+          if [[ ! "$RTAG" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "::error::runtime-tag-release may only contain letters, numbers, dots, underscores, and hyphens"
+            exit 1
+          fi
+
       - name: Rename WASM assets with version
         if: inputs.runtime-tag-release != ''
         env:
@@ -97,12 +107,16 @@ jobs:
 
       - name: Generate checksums
         if: inputs.release-tag != ''
+        env:
+          WASM_FILE: ${{ steps.wasm-names.outputs.wasm }}
+          COMPACT_WASM_FILE: ${{ steps.wasm-names.outputs.compact }}
+          COMPRESSED_WASM_FILE: ${{ steps.wasm-names.outputs.compressed }}
         run: |
           cd artifacts/srtool || exit 1
           {
-            sha256sum "${{ steps.wasm-names.outputs.wasm }}"
-            sha256sum "${{ steps.wasm-names.outputs.compact }}"
-            sha256sum "${{ steps.wasm-names.outputs.compressed }}"
+            sha256sum "$WASM_FILE"
+            sha256sum "$COMPACT_WASM_FILE"
+            sha256sum "$COMPRESSED_WASM_FILE"
           } >> SHA256SUMS-srtool
 
           echo "Generated checksums:"
@@ -131,12 +145,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release-tag }}
+          WASM_FILE: ${{ steps.wasm-names.outputs.wasm }}
+          COMPACT_WASM_FILE: ${{ steps.wasm-names.outputs.compact }}
+          COMPRESSED_WASM_FILE: ${{ steps.wasm-names.outputs.compressed }}
         run: |
           cd artifacts/srtool || exit 1
           echo "Uploading srtool artifacts to release: $RELEASE_TAG"
           gh release upload --clobber --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" \
-            "${{ steps.wasm-names.outputs.wasm }}" \
-            "${{ steps.wasm-names.outputs.compact }}" \
-            "${{ steps.wasm-names.outputs.compressed }}" \
+            "$WASM_FILE" \
+            "$COMPACT_WASM_FILE" \
+            "$COMPRESSED_WASM_FILE" \
             srtool-digest.json \
             SHA256SUMS-srtool


### PR DESCRIPTION
### Motivation
- A user-controlled `runtime-tag-release` / `suffix` value was being interpolated directly into `run:` shell blocks, allowing shell metacharacters to be expanded before the shell runs and enabling command injection in privileged release jobs. 
- The goal is to eliminate pre-shell expression interpolation and validate inputs so only safe characters are used for generated filenames and tags.

### Description
- Add allowlist validation for the top-level `suffix` in `.github/workflows/release-image.yml` and for `runtime-tag-release` in `.github/workflows/srtool-build.yml` to permit only letters, numbers, dots, underscores, and hyphens. 
- Stop embedding `${{ ... }}` expressions directly inside `run:` scripts by exporting derived srtool WASM filenames into environment variables (`WASM_FILE`, `COMPACT_WASM_FILE`, `COMPRESSED_WASM_FILE`) and then referencing those shell variables inside the `run:` blocks. 
- Move `matrix.platform` usages into `env: PLATFORM: ${{ matrix.platform }}` and use `$PLATFORM` inside `run:` blocks so no `${{ ... }}` expressions appear in shell scripts. 
- Update checksum generation, artifact upload, and related steps to use the safe environment variables and preserve existing attestation/upload functionality.

### Testing
- Parsed both modified workflows with Ruby YAML (`YAML.load_file`) to ensure syntactic validity, which succeeded. 
- Ran a Python run-block scanner that verifies no `${{ ... }}` GitHub expressions remain inside `run:` blocks for the touched workflows, which succeeded. 
- Executed a Bash regex unit check confirming allowed example suffixes/tags are accepted and malicious payloads with shell metacharacters are rejected, which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded, and noted `actionlint` was not available in the environment so full linting could not be run locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b8c3627548333bf9bbcf36a7f10f8)