### PR TITLE
fix: harden archive-changes workflow checkout

### DIFF
--- a/.github/workflows/archive-changes.yml
+++ b/.github/workflows/archive-changes.yml
@@ -92,18 +92,30 @@ jobs:
       pull-requests: write
     env:
       FORCE_COLOR: 1
+    defaults:
+      run:
+        working-directory: release-tree
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
+          path: ci-assets
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Checkout release ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
+        with:
+          path: release-tree
+          persist-credentials: false
           submodules: true
           ref: ${{ inputs.ref }}
 
       - name: Install Season
-        uses: ./.github/actions/install-season
+        uses: ./ci-assets/.github/actions/install-season
         with:
           gh-token: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
-          config: ./.github/season.yml
+          config: ${{ github.workspace }}/ci-assets/.github/season.yml
 
       - name: Setup Env
         shell: bash
@@ -129,7 +141,9 @@ jobs:
         if: inputs.archive-changes == true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git fetch origin tag "$GIT_TAG_RELEASE"
+        run: >-
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer $GH_TOKEN"
+          fetch origin tag "$GIT_TAG_RELEASE"
 
       - name: Archive changes
         if: inputs.archive-changes == true


### PR DESCRIPTION
Quarantine the untrusted release ref to release-tree/ and source CI assets (install-season action, season.yml) from a separate default-branch checkout, so an arbitrary inputs.ref cannot execute code with the workflow's contents:write token. Disable credential persistence on both checkouts; the tag fetch authenticates explicitly via http.extraheader.

Assisted-by: Claude:claude-fable-5

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
