### PR TITLE
fix(toolkit): do not allow to create genesis state with more than max supply of tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8114,6 +8114,7 @@ dependencies = [
 name = "midnight-node-toolkit"
 version = "2.0.0"
 dependencies = [
+ "assert_matches",
  "async-channel 2.5.0",
  "async-trait",
  "backoff",

--- a/util/toolkit/Cargo.toml
+++ b/util/toolkit/Cargo.toml
@@ -58,6 +58,7 @@ stacker.workspace = true
 semver.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 test-case = "3.3.1"
 hex-literal.workspace = true
 trycmd = "1.2.0"

--- a/util/toolkit/src/genesis_generator.rs
+++ b/util/toolkit/src/genesis_generator.rs
@@ -59,8 +59,8 @@ pub enum GenesisGeneratorError<D: DB> {
 	SerializationError(#[from] std::io::Error),
 	#[error("Missing verifying key for wallet")]
 	MissingVerifyingKey,
-	#[error("Ledger {0} pool is empty")]
-	EmptyPool(String),
+	#[error("Ledger pools amounts are invalid: {0}")]
+	InvalidPoolsAmounts(String),
 }
 
 /// Common arguments for funding wallets (shielded, unshielded, dust)
@@ -136,7 +136,9 @@ impl GenesisGenerator {
 			log::error!(
 				"Treasury pool is empty. Run with --allow-empty-pools to allow such configuration"
 			);
-			return Err(GenesisGeneratorError::EmptyPool("Treasury".to_string()));
+			return Err(GenesisGeneratorError::InvalidPoolsAmounts(
+				"Treasury is empty".to_string(),
+			));
 		}
 
 		let reserve_pool = reserve_config.as_ref().map(|c| c.total_amount).unwrap_or_else(|| {
@@ -148,15 +150,26 @@ impl GenesisGenerator {
 			log::error!(
 				"Reserve pool is empty. Run with --allow-empty-pools to allow such configuration"
 			);
-			return Err(GenesisGeneratorError::EmptyPool("Reserve".to_string()));
+			return Err(GenesisGeneratorError::InvalidPoolsAmounts("Reserve is empty".to_string()));
 		}
 
-		let locked_pool = MAX_SUPPLY - reserve_pool - treasury;
+		let locked_pool = MAX_SUPPLY
+			.checked_sub(reserve_pool)
+			.and_then(|x| x.checked_sub(treasury))
+			.ok_or_else(|| {
+				log::error!(
+					"Treasury = {treasury} and Reserve = {reserve_pool} exceed MAX_SUPPLY = {MAX_SUPPLY}!"
+				);
+				GenesisGeneratorError::InvalidPoolsAmounts(
+					"Tresury and Reserve exceed MAX_SUPPLY".to_string(),
+				)
+			})?;
+
 		if locked_pool == 0 && !allow_empty_pools {
 			log::error!(
 				"Locked pool is empty. Run with --allow-empty-pools to allow such configuration"
 			);
-			return Err(GenesisGeneratorError::EmptyPool("Locked".to_string()));
+			return Err(GenesisGeneratorError::InvalidPoolsAmounts("Locked is empty".to_string()));
 		}
 
 		// If custom ledger parameters are provided, apply them first
@@ -931,8 +944,12 @@ mod test {
 		.await;
 
 		match result {
-			Err(GenesisGeneratorError::EmptyPool(pool)) if pool.to_string() == "Reserve" => (),
-			_ => panic!("Expected EmptyPool(Reserve) error"),
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
+				if pool.to_string() == "Reserve is empty" =>
+			{
+				()
+			},
+			_ => panic!("Expected InvalidPoolsAmounts(Reserve is empty) error"),
 		}
 
 		let result = GenesisGenerator::new(
@@ -967,8 +984,12 @@ mod test {
 		.await;
 
 		match result {
-			Err(GenesisGeneratorError::EmptyPool(pool)) if pool.to_string() == "Treasury" => (),
-			_ => panic!("Expected EmptyPool(Treasury) error"),
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
+				if pool.to_string() == "Treasury is empty" =>
+			{
+				()
+			},
+			_ => panic!("Expected InvalidPoolsAmounts(Treasury is empty) error"),
 		}
 
 		let result = GenesisGenerator::new(
@@ -1004,8 +1025,12 @@ mod test {
 		.await;
 
 		match result {
-			Err(GenesisGeneratorError::EmptyPool(pool)) if pool.to_string() == "Locked" => (),
-			_ => panic!("Expected EmptyPool(Locked) error"),
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
+				if pool.to_string() == "Locked is empty" =>
+			{
+				()
+			},
+			_ => panic!("Expected InvalidPoolsAmounts(Locked is empty) error"),
 		}
 
 		let result = GenesisGenerator::new(
@@ -1023,6 +1048,73 @@ mod test {
 		)
 		.await;
 		assert!(result.is_ok())
+	}
+
+	#[tokio::test]
+	async fn do_not_allow_pools_to_exceed_max_supply() {
+		let funding = empty_funding_args();
+
+		let seed = hex::decode(GENESIS_NONCE_SEED).unwrap().try_into().unwrap();
+		let network_id = "undeployed";
+		let proof_server = None;
+
+		let reserve_config = ReserveConfig {
+			reserve_validator_address: "addr_test1qz_reserve".to_string(),
+			asset: midnight_primitives_reserve_observation::ReserveAsset {
+				policy_id: midnight_primitives_reserve_observation::PolicyId([0u8; 28]),
+				asset_name: "NIGHT".to_string(),
+			},
+			utxos: vec![midnight_primitives_reserve_observation::ReserveUtxo {
+				tx_hash: "def456".to_string(),
+				output_index: 1,
+				amount: MAX_SUPPLY as u64,
+			}],
+			total_amount: MAX_SUPPLY,
+		};
+		// ICS config determines the treasury pool amount.
+		let ics_config = IcsConfig {
+			illiquid_circulation_supply_validator_address:
+				"addr_test1wqgdspp2cnethukgvrve6wnue8adjjzz5ty9x3z4t5s8c8cnck7xz".to_string(),
+			asset: IcsAsset {
+				policy_id: PolicyId::from_str(
+					"d2dbff622e509dda256fedbd31ef6e9fd98ed49ad91d5c0e07f68af1",
+				)
+				.expect("valid policy ID"),
+				asset_name: "".to_string(),
+			},
+			utxos: vec![IcsUtxo {
+				tx_hash: "abc123".to_string(),
+				output_index: 0,
+				amount: 1_000_000_000_000_000,
+			}],
+			total_amount: 10_000_000_000_000_000,
+		};
+
+		let result = GenesisGenerator::new(
+			seed,
+			network_id,
+			proof_server.clone(),
+			funding.clone(),
+			None,
+			None,
+			Some(ics_config),
+			Some(reserve_config),
+			None, // no custom ledger parameters
+			None, // use default genesis timestamp
+			false,
+		)
+		.await;
+
+		match result {
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg))
+				if msg.to_string() == "Tresury and Reserve exceed MAX_SUPPLY" =>
+			{
+				()
+			},
+			_ => {
+				panic!("Expected InvalidPoolsAmounts(Tresury and Reserve exceed MAX_SUPPLY) error")
+			},
+		}
 	}
 
 	fn empty_funding_args() -> FundingArgs {

--- a/util/toolkit/src/genesis_generator.rs
+++ b/util/toolkit/src/genesis_generator.rs
@@ -102,6 +102,7 @@ pub struct FundingArgs {
 	unshielded_alt_token_types: Vec<UnshieldedTokenType>,
 }
 
+#[derive(Debug)]
 pub struct GenesisGenerator {
 	pub state: LedgerState<DefaultDB>,
 	pub txs: SerializedTxBatches,
@@ -679,6 +680,7 @@ fn without_fees(params: &LedgerParameters) -> LedgerParameters {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use assert_matches::assert_matches;
 	use midnight_primitives_ics_observation::PolicyId;
 	use std::{collections::HashMap, str::FromStr};
 
@@ -943,14 +945,10 @@ mod test {
 		)
 		.await;
 
-		match result {
-			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
-				if pool.to_string() == "Reserve is empty" =>
-			{
-				()
-			},
-			_ => panic!("Expected InvalidPoolsAmounts(Reserve is empty) error"),
-		}
+		assert_matches!(
+			result,
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg)) if msg.to_string() == "Reserve is empty"
+		);
 
 		let result = GenesisGenerator::new(
 			seed,
@@ -983,14 +981,10 @@ mod test {
 		)
 		.await;
 
-		match result {
-			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
-				if pool.to_string() == "Treasury is empty" =>
-			{
-				()
-			},
-			_ => panic!("Expected InvalidPoolsAmounts(Treasury is empty) error"),
-		}
+		assert_matches!(
+			result,
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg)) if msg.to_string() == "Treasury is empty"
+		);
 
 		let result = GenesisGenerator::new(
 			seed,
@@ -1024,14 +1018,10 @@ mod test {
 		)
 		.await;
 
-		match result {
-			Err(GenesisGeneratorError::InvalidPoolsAmounts(pool))
-				if pool.to_string() == "Locked is empty" =>
-			{
-				()
-			},
-			_ => panic!("Expected InvalidPoolsAmounts(Locked is empty) error"),
-		}
+		assert_matches!(
+			result,
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg)) if msg.to_string() == "Locked is empty"
+		);
 
 		let result = GenesisGenerator::new(
 			seed,
@@ -1105,16 +1095,10 @@ mod test {
 		)
 		.await;
 
-		match result {
-			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg))
-				if msg.to_string() == "Tresury and Reserve exceed MAX_SUPPLY" =>
-			{
-				()
-			},
-			_ => {
-				panic!("Expected InvalidPoolsAmounts(Tresury and Reserve exceed MAX_SUPPLY) error")
-			},
-		}
+		assert_matches!(
+			result,
+			Err(GenesisGeneratorError::InvalidPoolsAmounts(msg)) if msg.to_string() == "Tresury and Reserve exceed MAX_SUPPLY"
+		);
 	}
 
 	fn empty_funding_args() -> FundingArgs {


### PR DESCRIPTION
# Overview

It was possible to create genesis states with more than MAX SUPPLY of tokens, therefore creating unsound genesis state.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
