### PR TITLE
test(e2e): add indexer-side assertions to c2m_bridge tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8009,6 +8009,7 @@ dependencies = [
  "midnight-node-toolkit",
  "ogmios-client",
  "rand 0.9.2",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "subxt 0.50.0",

--- a/changes/node/added/c2m-bridge-indexer-e2e-assertions.md
+++ b/changes/node/added/c2m-bridge-indexer-e2e-assertions.md
@@ -33,4 +33,5 @@ item on shieldedtech/midnight-c-to-m-protocol-bridge#4 for five
 of the six bridge flows (reserve transfer remains gated on the
 Cardano Reserve Validator upgrade).
 
+PR: https://github.com/midnightntwrk/midnight-node/pull/1718
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1714

--- a/changes/node/added/c2m-bridge-indexer-e2e-assertions.md
+++ b/changes/node/added/c2m-bridge-indexer-e2e-assertions.md
@@ -1,0 +1,36 @@
+#tests #c2m-bridge #indexer
+
+# Add indexer-side assertions to c2m_bridge e2e tests (opt-in)
+
+Adds a new `indexer` cargo feature in `tests/e2e/` and a thin
+GraphQL helper (`tests/e2e/src/api/indexer.rs`) so the four
+`c2m_bridge::*` e2e tests can cross-check the indexer's bridge
+surface in the same run. With the feature on, each test asserts
+its matching indexer row (`BridgeUserTransfer`,
+`BridgeUnapprovedTransfer`, `BridgeInvalidTransfer`,
+`BridgeSubminimalFlushTransfer`) and the happy-path test
+additionally pins `BridgeClaimTransaction` and the recipient's
+`bridgeBalance` (deposited / claimed / balance) before and after
+the claim. The `balance` field is asserted to be the post-fee
+outstanding claimable, not the gross `deposited - claimed`.
+
+When the feature is off, the suite behaves exactly as before
+(node-side assertions only; no `reqwest` link, no HTTP traffic,
+no indexer dependency). Run with:
+
+```bash
+cargo test --test e2e_tests --no-default-features --features local,indexer \
+    c2m_bridge::
+```
+
+Also bumps the `indexer` submodule pointer to pick up the
+post-fee `bridgeBalance.balance` semantics on the indexer side
+(the prior build returned `deposited - claimed`, which the new
+happy-path assertion rejects).
+
+Closes the "End-to-end test against a bridge-enabled chain"
+item on shieldedtech/midnight-c-to-m-protocol-bridge#4 for five
+of the six bridge flows (reserve transfer remains gated on the
+Cardano Reserve Validator upgrade).
+
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1714

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -10,6 +10,11 @@ local = []
 local-dev = []
 local-ci = []
 qanet = []
+# Opt-in flag: when on, the c2m_bridge e2e tests run extra GraphQL
+# assertions against a running indexer-api (default
+# http://127.0.0.1:8088/api/v3/graphql, override via INDEXER_GRAPHQL_URL).
+# When off, the tests behave exactly as before (node-side asserts only).
+indexer = ["dep:reqwest"]
 default = ["local-ci"]
 
 [dependencies]
@@ -29,6 +34,7 @@ blake2 = "0.10.6"
 tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true }
 midnight-node-e2e-macros = { path = "macros" }
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 midnight-node-res = { workspace = true, features = ["test"] }

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -209,6 +209,46 @@ error if Postgres is down or the DB doesn't exist.
 > contexts). Pass the exact name to filter to one test, or
 > `--test-threads 1` to serialise.
 
+## Indexer-side assertions (`indexer` feature)
+
+The `c2m_bridge::*` tests double up as cross-checks against a running
+`indexer-api`. Opt in with the `indexer` cargo feature:
+
+```bash
+cargo test --test e2e_tests --no-default-features --features local,indexer \
+    c2m_bridge:: -- --test-threads=1 --nocapture
+```
+
+When the feature is on, each test runs the existing node-side checks and
+then asserts on the corresponding indexer GraphQL surface:
+
+| Test                                                            | Indexer surface(s) asserted                                       |
+|-----------------------------------------------------------------|-------------------------------------------------------------------|
+| `bridge_transfer_cnight_to_midnight_address`                    | `BridgeUserTransfer` row, `bridgeBalance` (pre/post claim), `BridgeClaimTransaction` row |
+| `bridge_transfer_invalid_recipient_unlocks_to_treasury`         | `BridgeInvalidTransfer` row                                       |
+| `unapproved_cardano_tx_makes_transfer_that_unlocks_to_treasury` | `BridgeUnapprovedTransfer` row                                    |
+| `subminimal_transfers_accumulate_and_flush_on_threshold_breach` | `BridgeSubminimalFlushTransfer` row (asserts `amount` + `count`)  |
+
+`bridgeBalance.balance` is asserted to be the **post-fee outstanding
+claimable** (not the gross `deposited - claimed`). A regression that
+flipped the semantics back to the pre-fee figure would fail the
+pre-claim assertion in `bridge_transfer_cnight_to_midnight_address`.
+
+The endpoint defaults to `http://127.0.0.1:8088/api/v3/graphql` (local-env's
+indexer-api). Override with:
+
+```bash
+INDEXER_GRAPHQL_URL=http://my-indexer:8088/api/v3/graphql \
+    cargo test --test e2e_tests --features local,indexer ...
+```
+
+Each test calls the indexer's `/ready` endpoint before running its
+assertions, so a missing/unreachable indexer fails fast with a clear
+error instead of timing out mid-test.
+
+Without the `indexer` feature, the suite behaves exactly as before:
+node-side assertions only, no indexer dependency, no extra HTTP traffic.
+
 ## Layout
 
 Tests are grouped by topic across module files under `tests/`:

--- a/tests/e2e/src/api/indexer.rs
+++ b/tests/e2e/src/api/indexer.rs
@@ -1,0 +1,506 @@
+//! Thin GraphQL client for the Midnight indexer-api.
+//!
+//! Compiled only when the `indexer` cargo feature is on. The c2m_bridge e2e
+//! tests use it to assert on indexer-side `BridgeEvent` rows, the recipient's
+//! `bridgeBalance`, and `BridgeClaimTransaction` rows alongside the existing
+//! node-side assertions. See `tests/e2e/README.md` for the env-var override.
+
+use serde_json::json;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+const DEFAULT_GRAPHQL_URL: &str = "http://127.0.0.1:8088/api/v3/graphql";
+const READY_URL_FROM_GRAPHQL_DEFAULT: &str = "http://127.0.0.1:8088/ready";
+
+pub type IndexerResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// `bridgeBalance(address: ...)` row, with amounts decoded from the indexer's
+/// `HexEncoded` u256 scalar to `u128`. Amounts above u128::MAX would panic in
+/// `decode_u128_from_hex` — fine for tests, where bridge amounts stay well under
+/// that bound.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeBalance {
+    /// Gross amount bridged in (sum of deposit amounts hitting this recipient).
+    pub deposited: u128,
+    /// Cumulative amount claimed by the recipient via `ClaimRewards(CardanoBridge)`.
+    pub claimed: u128,
+    /// Outstanding claimable balance for this recipient. Post-fee: equals
+    /// `claimable_so_far - claimed`, NOT `deposited - claimed`. A wallet/UI can
+    /// surface this directly as "amount still claimable now".
+    pub balance: u128,
+}
+
+/// One row from the `bridgeEvents` query. Carries only the fields the c2m_bridge
+/// tests assert on; extend as needed.
+#[derive(Debug, Clone)]
+pub enum BridgeEvent {
+    UserTransfer {
+        id: i64,
+        block_height: u64,
+        amount: u128,
+        cardano_tx_hash: [u8; 32],
+        midnight_tx_hash: [u8; 32],
+        recipient: [u8; 32],
+    },
+    UnapprovedTransfer {
+        id: i64,
+        block_height: u64,
+        amount: u128,
+        cardano_tx_hash: [u8; 32],
+    },
+    InvalidTransfer {
+        id: i64,
+        block_height: u64,
+        amount: u128,
+        cardano_tx_hash: [u8; 32],
+    },
+    SubminimalFlushTransfer {
+        id: i64,
+        block_height: u64,
+        amount: u128,
+        count: i64,
+    },
+    ReserveTransfer {
+        id: i64,
+        block_height: u64,
+        amount: u128,
+    },
+}
+
+/// One `BridgeClaimTransaction` row from `block(...).transactions[]`, projecting
+/// just what the c2m_bridge tests look at.
+#[derive(Debug, Clone)]
+pub struct BridgeClaim {
+    pub block_height: u64,
+    pub hash: [u8; 32],
+    pub recipient: [u8; 32],
+    pub amount: u128,
+    /// Sum of NIGHT UTXO values in `unshieldedCreatedOutputs` going to `recipient`.
+    pub night_credited_to_recipient: u128,
+}
+
+pub struct IndexerClient {
+    graphql_url: String,
+    ready_url: String,
+    http: reqwest::Client,
+}
+
+impl IndexerClient {
+    /// Build a client from `INDEXER_GRAPHQL_URL` (and the matching `/ready` URL),
+    /// falling back to the local-env defaults.
+    pub fn from_env_or_default() -> Self {
+        let graphql_url = std::env::var("INDEXER_GRAPHQL_URL")
+            .unwrap_or_else(|_| DEFAULT_GRAPHQL_URL.to_string());
+        let ready_url = derive_ready_url(&graphql_url);
+        Self {
+            graphql_url,
+            ready_url,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("build reqwest::Client"),
+        }
+    }
+
+    pub fn graphql_url(&self) -> &str {
+        &self.graphql_url
+    }
+
+    /// Block until the indexer's `/ready` endpoint returns 200 with an empty body
+    /// (matches `scripts/tests/indexer-api-e2e.sh`), or fail after `timeout`.
+    pub async fn await_ready(&self, timeout: Duration) -> IndexerResult<()> {
+        let deadline = Instant::now() + timeout;
+        // Last HTTP status code we saw, if any — surfaced in the timeout error so
+        // a misconfigured URL ("404 across the board") reads differently from a
+        // down indexer ("never connected").
+        let mut last_status: Option<u16> = None;
+        loop {
+            if let Ok(resp) = self.http.get(&self.ready_url).send().await {
+                let status = resp.status();
+                last_status = Some(status.as_u16());
+                if status.is_success() && resp.text().await.unwrap_or_default().is_empty() {
+                    return Ok(());
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "indexer at {} not ready within {:?} (last status: {:?})",
+                    self.ready_url, timeout, last_status
+                )
+                .into());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Run a raw GraphQL POST and return the `data` object, panicking-style
+    /// (test harness) if the server replied with `errors`.
+    async fn graphql(&self, query: &str) -> IndexerResult<serde_json::Value> {
+        let body = json!({ "query": query });
+        let resp = self
+            .http
+            .post(&self.graphql_url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
+        let v: serde_json::Value = resp.json().await?;
+        if let Some(errors) = v.get("errors") {
+            return Err(format!("indexer GraphQL errors: {errors}").into());
+        }
+        v.get("data")
+            .cloned()
+            .ok_or_else(|| "indexer GraphQL response missing `data`".into())
+    }
+
+    pub async fn bridge_balance(&self, address: &[u8; 32]) -> IndexerResult<BridgeBalance> {
+        let q = format!(
+            r#"{{ bridgeBalance(address: "{addr}") {{ deposited claimed balance }} }}"#,
+            addr = hex::encode(address)
+        );
+        let data = self.graphql(&q).await?;
+        let row = data
+            .get("bridgeBalance")
+            .ok_or("indexer: bridgeBalance missing from response")?;
+        Ok(BridgeBalance {
+            deposited: decode_u128_from_hex(row, "deposited")?,
+            claimed: decode_u128_from_hex(row, "claimed")?,
+            balance: decode_u128_from_hex(row, "balance")?,
+        })
+    }
+
+    /// Repeatedly call `bridge_balance` until `pred` returns `true` or the deadline
+    /// expires. Indexer is a few hundred ms behind chain finalization, so callers
+    /// generally want this rather than a single read.
+    pub async fn await_bridge_balance_where<F>(
+        &self,
+        address: &[u8; 32],
+        mut pred: F,
+        timeout: Duration,
+    ) -> IndexerResult<BridgeBalance>
+    where
+        F: FnMut(&BridgeBalance) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        let mut last = self.bridge_balance(address).await?;
+        loop {
+            if pred(&last) {
+                return Ok(last);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "indexer bridgeBalance for {} did not satisfy predicate within {:?} \
+                     (last seen: deposited={}, claimed={}, balance={})",
+                    hex::encode(address),
+                    timeout,
+                    last.deposited,
+                    last.claimed,
+                    last.balance
+                )
+                .into());
+            }
+            sleep(Duration::from_millis(500)).await;
+            last = self.bridge_balance(address).await?;
+        }
+    }
+
+    /// Query `bridgeEvents` with optional recipient + variant filters.
+    pub async fn bridge_events(
+        &self,
+        recipient: Option<&[u8; 32]>,
+        variant: Option<BridgeEventVariant>,
+        limit: u32,
+    ) -> IndexerResult<Vec<BridgeEvent>> {
+        let mut args = vec![format!("limit: {limit}")];
+        if let Some(r) = recipient {
+            args.push(format!(r#"recipient: "{}""#, hex::encode(r)));
+        }
+        if let Some(v) = variant {
+            args.push(format!("variant: {}", v.as_graphql()));
+        }
+        let q = format!(
+            r#"{{ bridgeEvents({args}) {{
+                __typename
+                ... on BridgeUserTransfer {{ id blockHeight amount cardanoTxHash midnightTxHash recipient }}
+                ... on BridgeUnapprovedTransfer {{ id blockHeight amount cardanoTxHash }}
+                ... on BridgeInvalidTransfer {{ id blockHeight amount cardanoTxHash }}
+                ... on BridgeSubminimalFlushTransfer {{ id blockHeight amount count }}
+                ... on BridgeReserveTransfer {{ id blockHeight amount }}
+            }} }}"#,
+            args = args.join(", ")
+        );
+        let data = self.graphql(&q).await?;
+        let raw = data
+            .get("bridgeEvents")
+            .and_then(|v| v.as_array())
+            .ok_or("indexer: bridgeEvents missing or not an array")?;
+        raw.iter().map(parse_bridge_event).collect()
+    }
+
+    /// Poll `bridgeEvents` until at least one event matches `pred`, returning the
+    /// first match, or fail at `timeout`.
+    pub async fn await_bridge_event<F>(
+        &self,
+        recipient: Option<&[u8; 32]>,
+        variant: Option<BridgeEventVariant>,
+        mut pred: F,
+        timeout: Duration,
+    ) -> IndexerResult<BridgeEvent>
+    where
+        F: FnMut(&BridgeEvent) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let events = self.bridge_events(recipient, variant, 50).await?;
+            if let Some(hit) = events.into_iter().find(|e| pred(e)) {
+                return Ok(hit);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "no matching bridgeEvent surfaced within {:?} \
+                     (recipient: {:?}, variant: {:?})",
+                    timeout,
+                    recipient.map(hex::encode),
+                    variant,
+                )
+                .into());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Walk blocks from `from_height` forward (inclusive) up to `from_height + max_blocks`
+    /// looking for a `BridgeClaimTransaction` whose recipient matches. Returns the
+    /// first hit, or `Ok(None)` if none found within the window. Errors surface
+    /// transport / response-shape problems.
+    pub async fn find_bridge_claim_for_recipient(
+        &self,
+        recipient: &[u8; 32],
+        from_height: u64,
+        max_blocks: u64,
+    ) -> IndexerResult<Option<BridgeClaim>> {
+        for h in from_height..from_height.saturating_add(max_blocks) {
+            let q = format!(
+                r#"{{ block(offset: {{ height: {h} }}) {{
+                    height
+                    transactions {{
+                        __typename hash
+                        ... on BridgeClaimTransaction {{
+                            recipient amount
+                            unshieldedCreatedOutputs {{ tokenType owner value }}
+                        }}
+                    }}
+                }} }}"#
+            );
+            let data = self.graphql(&q).await?;
+            let block = match data.get("block") {
+                Some(b) if !b.is_null() => b,
+                _ => continue, // block not yet indexed
+            };
+            let txs = block
+                .get("transactions")
+                .and_then(|v| v.as_array())
+                .ok_or("indexer: block.transactions missing or not an array")?;
+            for tx in txs {
+                if tx.get("__typename").and_then(|v| v.as_str()) != Some("BridgeClaimTransaction") {
+                    continue;
+                }
+                let claim_recipient: [u8; 32] = decode_hex_bytes(tx, "recipient")?;
+                if &claim_recipient != recipient {
+                    continue;
+                }
+                let amount = decode_u128_from_hex(tx, "amount")?;
+                let hash: [u8; 32] = decode_hex_bytes(tx, "hash")?;
+                let night_credited = sum_night_outputs_to_recipient(tx, recipient).unwrap_or(0);
+                return Ok(Some(BridgeClaim {
+                    block_height: h,
+                    hash,
+                    recipient: claim_recipient,
+                    amount,
+                    night_credited_to_recipient: night_credited,
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Poll `find_bridge_claim_for_recipient` until a hit appears or `timeout` expires.
+    pub async fn await_bridge_claim_for_recipient(
+        &self,
+        recipient: &[u8; 32],
+        from_height: u64,
+        max_blocks: u64,
+        timeout: Duration,
+    ) -> IndexerResult<BridgeClaim> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(claim) = self
+                .find_bridge_claim_for_recipient(recipient, from_height, max_blocks)
+                .await?
+            {
+                return Ok(claim);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "no BridgeClaimTransaction for recipient {} found in blocks \
+                     [{}, {}) within {:?}",
+                    hex::encode(recipient),
+                    from_height,
+                    from_height + max_blocks,
+                    timeout,
+                )
+                .into());
+            }
+            sleep(Duration::from_millis(750)).await;
+        }
+    }
+}
+
+/// Mirrors the indexer's `BridgeEventVariant` enum at the call-site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeEventVariant {
+    UserTransfer,
+    UnapprovedTransfer,
+    InvalidTransfer,
+    SubminimalFlushTransfer,
+    ReserveTransfer,
+}
+
+impl BridgeEventVariant {
+    fn as_graphql(self) -> &'static str {
+        match self {
+            Self::UserTransfer => "USER_TRANSFER",
+            Self::UnapprovedTransfer => "UNAPPROVED_TRANSFER",
+            Self::InvalidTransfer => "INVALID_TRANSFER",
+            Self::SubminimalFlushTransfer => "SUBMINIMAL_FLUSH_TRANSFER",
+            Self::ReserveTransfer => "RESERVE_TRANSFER",
+        }
+    }
+}
+
+fn parse_bridge_event(v: &serde_json::Value) -> IndexerResult<BridgeEvent> {
+    let typename = v
+        .get("__typename")
+        .and_then(|v| v.as_str())
+        .ok_or("bridgeEvent row missing __typename")?;
+    let id = v
+        .get("id")
+        .and_then(|v| v.as_i64())
+        .ok_or("bridgeEvent row missing id")?;
+    let block_height = v
+        .get("blockHeight")
+        .and_then(|v| v.as_i64())
+        .ok_or("bridgeEvent row missing blockHeight")? as u64;
+    match typename {
+        "BridgeUserTransfer" => Ok(BridgeEvent::UserTransfer {
+            id,
+            block_height,
+            amount: decode_u128_from_hex(v, "amount")?,
+            cardano_tx_hash: decode_hex_bytes(v, "cardanoTxHash")?,
+            midnight_tx_hash: decode_hex_bytes(v, "midnightTxHash")?,
+            recipient: decode_hex_bytes(v, "recipient")?,
+        }),
+        "BridgeUnapprovedTransfer" => Ok(BridgeEvent::UnapprovedTransfer {
+            id,
+            block_height,
+            amount: decode_u128_from_hex(v, "amount")?,
+            cardano_tx_hash: decode_hex_bytes(v, "cardanoTxHash")?,
+        }),
+        "BridgeInvalidTransfer" => Ok(BridgeEvent::InvalidTransfer {
+            id,
+            block_height,
+            amount: decode_u128_from_hex(v, "amount")?,
+            cardano_tx_hash: decode_hex_bytes(v, "cardanoTxHash")?,
+        }),
+        "BridgeSubminimalFlushTransfer" => Ok(BridgeEvent::SubminimalFlushTransfer {
+            id,
+            block_height,
+            amount: decode_u128_from_hex(v, "amount")?,
+            count: v
+                .get("count")
+                .and_then(|v| v.as_i64())
+                .ok_or("BridgeSubminimalFlushTransfer missing count")?,
+        }),
+        "BridgeReserveTransfer" => Ok(BridgeEvent::ReserveTransfer {
+            id,
+            block_height,
+            amount: decode_u128_from_hex(v, "amount")?,
+        }),
+        other => Err(format!("unknown bridgeEvent __typename: {other}").into()),
+    }
+}
+
+fn sum_night_outputs_to_recipient(tx: &serde_json::Value, recipient: &[u8; 32]) -> Option<u128> {
+    // owner is bech32 (mn_addr_...), not hex; match on the hex-encoded 32-byte
+    // payload by decoding bech32 would pull in another dep. Instead we rely on
+    // the indexer surfacing tokenType=NIGHT (all-zero) outputs, and let the
+    // outer node-side assertion cover the per-byte recipient match. We still
+    // sum only NIGHT UTXOs here, so this matches `credited_to_recipient` for
+    // the happy path; multi-recipient claims aren't a thing today.
+    let _ = recipient; // reserved for future per-recipient tightening
+    let outputs = tx
+        .get("unshieldedCreatedOutputs")
+        .and_then(|v| v.as_array())?;
+    let mut total: u128 = 0;
+    for o in outputs {
+        let token_type = o
+            .get("tokenType")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if token_type != "0000000000000000000000000000000000000000000000000000000000000000" {
+            continue;
+        }
+        let value: u128 = o
+            .get("value")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        total = total.saturating_add(value);
+    }
+    Some(total)
+}
+
+fn decode_u128_from_hex(v: &serde_json::Value, field: &str) -> IndexerResult<u128> {
+    let s = v
+        .get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("field `{field}` missing or not a string"))?;
+    let bytes = hex::decode(s).map_err(|e| format!("field `{field}` not hex: {e}"))?;
+    if bytes.len() > 16 {
+        // u256 → u128 truncation: assert the upper bytes are zero.
+        let upper = &bytes[..bytes.len() - 16];
+        if upper.iter().any(|b| *b != 0) {
+            return Err(format!("field `{field}` exceeds u128 range (hex {s})").into());
+        }
+    }
+    let mut buf = [0u8; 16];
+    let off = buf.len().saturating_sub(bytes.len());
+    buf[off..].copy_from_slice(&bytes[bytes.len().saturating_sub(16)..]);
+    Ok(u128::from_be_bytes(buf))
+}
+
+fn decode_hex_bytes<const N: usize>(v: &serde_json::Value, field: &str) -> IndexerResult<[u8; N]> {
+    let s = v
+        .get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("field `{field}` missing or not a string"))?;
+    let bytes = hex::decode(s).map_err(|e| format!("field `{field}` not hex: {e}"))?;
+    if bytes.len() != N {
+        return Err(format!("field `{field}` expected {N} bytes, got {}", bytes.len()).into());
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn derive_ready_url(graphql_url: &str) -> String {
+    // Strip a trailing `/api/v3/graphql` (or `/graphql`) and append `/ready`.
+    // Falls back to a hand-picked default when the URL shape is unusual.
+    if let Some(prefix) = graphql_url.strip_suffix("/api/v3/graphql") {
+        format!("{prefix}/ready")
+    } else if let Some(prefix) = graphql_url.strip_suffix("/graphql") {
+        format!("{prefix}/ready")
+    } else {
+        READY_URL_FROM_GRAPHQL_DEFAULT.to_string()
+    }
+}

--- a/tests/e2e/src/api/mod.rs
+++ b/tests/e2e/src/api/mod.rs
@@ -1,2 +1,4 @@
 pub mod cardano;
+#[cfg(feature = "indexer")]
+pub mod indexer;
 pub mod midnight;

--- a/tests/e2e/tests/c2m_bridge.rs
+++ b/tests/e2e/tests/c2m_bridge.rs
@@ -1,6 +1,8 @@
 use midnight_node_e2e::api::cardano::{
     BridgeTransferRecipient, CardanoClient, SignedBridgeTransaction,
 };
+#[cfg(feature = "indexer")]
+use midnight_node_e2e::api::indexer::{BridgeEvent, BridgeEventVariant, IndexerClient};
 use midnight_node_e2e::api::midnight::{C2MBridgePalletCalls, MidnightClient};
 use midnight_node_e2e::config::Settings;
 use midnight_node_e2e::e2e_test;
@@ -41,6 +43,26 @@ const BRIDGE_AMOUNT_STARS: u64 = 49_000_000;
 /// Upper bound on how long the test waits for the bridge transfer to be observed
 /// by midnight and produce the user-transfer system tx.
 const BRIDGE_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Upper bound on how long the indexer-side assertions wait for the indexer to
+/// catch up to a finalized Midnight block. The indexer is typically a few
+/// hundred ms behind finalization on local-env; 60s is generous headroom.
+#[cfg(feature = "indexer")]
+const INDEXER_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Build a ready-to-use `IndexerClient`. Blocks until the indexer's `/ready`
+/// endpoint succeeds — fails fast with a clear error if the indexer isn't up
+/// rather than letting individual assertions time out mid-test.
+#[cfg(feature = "indexer")]
+async fn indexer_client_ready() -> IndexerClient {
+    let client = IndexerClient::from_env_or_default();
+    client
+        .await_ready(Duration::from_secs(30))
+        .await
+        .expect("indexer-api is not reachable; bring it up or unset --features indexer");
+    tracing::info!(indexer_url = client.graphql_url(), "indexer reachable");
+    client
+}
 
 #[e2e_test]
 async fn bridge_transfer_cnight_to_midnight_address() {
@@ -168,6 +190,76 @@ async fn bridge_transfer_cnight_to_midnight_address() {
         params.cardano_to_midnight_bridge_fee_basis_points,
         params.c_to_m_bridge_min_amount,
     );
+
+    // ----- Indexer: deposit-side surface -----
+    //
+    // Verify the indexer surfaces the just-finalized deposit before we issue the
+    // claim. Two assertions:
+    //   1. The `BridgeUserTransfer` row carries the right Cardano + Midnight tx
+    //      hashes and the right amount.
+    //   2. `bridgeBalance.balance == claimable` (post-fee). This pins the
+    //      semantics: `balance` is "still claimable now", NOT `deposited -
+    //      claimed`. A regression that switched `balance` back to the gross
+    //      pre-fee figure would surface here.
+    #[cfg(feature = "indexer")]
+    {
+        let indexer = indexer_client_ready().await;
+        let user_transfer = indexer
+            .await_bridge_event(
+                Some(&recipient_address),
+                Some(BridgeEventVariant::UserTransfer),
+                |ev| matches!(ev, BridgeEvent::UserTransfer { cardano_tx_hash, .. } if cardano_tx_hash == &bridge_tx),
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect("indexer never surfaced a matching BridgeUserTransfer");
+        match user_transfer {
+            BridgeEvent::UserTransfer {
+                amount,
+                cardano_tx_hash,
+                midnight_tx_hash,
+                recipient: ev_recipient,
+                ..
+            } => {
+                assert_eq!(
+                    amount, BRIDGE_AMOUNT_STARS as u128,
+                    "indexer BridgeUserTransfer.amount should equal the bridged STAR amount"
+                );
+                assert_eq!(
+                    cardano_tx_hash, bridge_tx,
+                    "indexer BridgeUserTransfer.cardanoTxHash should equal the Cardano bridge tx id"
+                );
+                assert_ne!(
+                    midnight_tx_hash, [0u8; 32],
+                    "indexer BridgeUserTransfer.midnightTxHash should be non-zero (the handle_transfers tx)"
+                );
+                assert_eq!(
+                    ev_recipient, recipient_address,
+                    "indexer BridgeUserTransfer.recipient should equal the dev-seed-derived recipient"
+                );
+            }
+            other => panic!("expected BridgeUserTransfer, got {other:?}"),
+        }
+        let balance_before_claim = indexer
+            .await_bridge_balance_where(
+                &recipient_address,
+                |bb| {
+                    bb.deposited == BRIDGE_AMOUNT_STARS as u128
+                        && bb.claimed == 0
+                        && bb.balance == claimable
+                },
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect(
+                "indexer bridgeBalance did not converge to expected pre-claim state \
+                 (deposited=gross, claimed=0, balance=claimable post-fee)",
+            );
+        tracing::info!(
+            ?balance_before_claim,
+            "indexer pre-claim bridgeBalance matches expected post-fee semantics"
+        );
+    }
     assert!(
         claimable > 0,
         "post-fee claimable must be positive (amount={}, fee_bps={}, min={})",
@@ -265,6 +357,62 @@ async fn bridge_transfer_cnight_to_midnight_address() {
         credited_to_recipient,
         "bridged mNIGHT successfully claimed; recipient credited the claimed amount"
     );
+
+    // ----- Indexer: claim-side surface -----
+    //
+    // Pin two things after the claim apply:
+    //   1. The `BridgeClaimTransaction` row is discoverable via `Block.transactions`
+    //      (the `Transaction` interface) with the right recipient and amount.
+    //   2. `bridgeBalance.claimed` advanced by exactly `claimable` and `balance`
+    //      dropped to 0 — i.e. the recipient has nothing left to claim.
+    #[cfg(feature = "indexer")]
+    {
+        let indexer = indexer_client_ready().await;
+        // We don't know the exact block the claim landed in (it post-dates
+        // `min_midnight_block` by an unknown number of blocks). Walk a window
+        // forward from there; on local-env the claim lands within ~5 blocks.
+        let claim = indexer
+            .await_bridge_claim_for_recipient(
+                &recipient_address,
+                min_midnight_block,
+                64,
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect("indexer never surfaced a BridgeClaimTransaction for the recipient");
+        assert_eq!(
+            claim.amount, claimable,
+            "indexer BridgeClaimTransaction.amount should equal the claimed (post-fee) amount"
+        );
+        assert_eq!(
+            claim.recipient, recipient_address,
+            "indexer BridgeClaimTransaction.recipient should equal the dev-seed-derived recipient"
+        );
+        assert_eq!(
+            claim.night_credited_to_recipient, claimable,
+            "indexer BridgeClaimTransaction.unshieldedCreatedOutputs should credit the recipient \
+             a NIGHT UTXO equal to the claim amount"
+        );
+        let balance_after_claim = indexer
+            .await_bridge_balance_where(
+                &recipient_address,
+                |bb| bb.claimed == claimable && bb.balance == 0,
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect(
+                "indexer bridgeBalance did not converge to post-claim state \
+                 (claimed=claimable, balance=0)",
+            );
+        assert_eq!(
+            balance_after_claim.deposited, BRIDGE_AMOUNT_STARS as u128,
+            "indexer bridgeBalance.deposited should remain at the gross deposit total post-claim"
+        );
+        tracing::info!(
+            ?balance_after_claim,
+            "indexer post-claim bridgeBalance drained as expected"
+        );
+    }
 }
 
 /// Bridge transfer whose Cardano-side metadatum is not valid Midnight address bytes.
@@ -358,6 +506,38 @@ async fn bridge_transfer_invalid_recipient_unlocks_to_treasury() {
         amount, BRIDGE_AMOUNT_STARS,
         "InvalidTransfer.amount should equal the STAR amount transferred"
     );
+
+    // ----- Indexer: BridgeInvalidTransfer row -----
+    #[cfg(feature = "indexer")]
+    {
+        let indexer = indexer_client_ready().await;
+        let event = indexer
+            .await_bridge_event(
+                None,
+                Some(BridgeEventVariant::InvalidTransfer),
+                |ev| matches!(ev, BridgeEvent::InvalidTransfer { cardano_tx_hash, .. } if cardano_tx_hash == &bridge_tx),
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect("indexer never surfaced a matching BridgeInvalidTransfer");
+        match event {
+            BridgeEvent::InvalidTransfer {
+                amount,
+                cardano_tx_hash,
+                ..
+            } => {
+                assert_eq!(
+                    amount, BRIDGE_AMOUNT_STARS as u128,
+                    "indexer BridgeInvalidTransfer.amount should equal the bridged STAR amount"
+                );
+                assert_eq!(
+                    cardano_tx_hash, bridge_tx,
+                    "indexer BridgeInvalidTransfer.cardanoTxHash should match the Cardano bridge tx id"
+                );
+            }
+            other => panic!("expected BridgeInvalidTransfer, got {other:?}"),
+        }
+    }
 }
 
 /// Unapproved Cardano Tx is accounted as transfer to Midnight Trasury
@@ -459,6 +639,38 @@ async fn unapproved_cardano_tx_makes_transfer_that_unlocks_to_treasury() {
         amount, BRIDGE_AMOUNT_STARS,
         "InvalidTransfer.amount should equal the STAR amount transferred"
     );
+
+    // ----- Indexer: BridgeUnapprovedTransfer row -----
+    #[cfg(feature = "indexer")]
+    {
+        let indexer = indexer_client_ready().await;
+        let event = indexer
+            .await_bridge_event(
+                None,
+                Some(BridgeEventVariant::UnapprovedTransfer),
+                |ev| matches!(ev, BridgeEvent::UnapprovedTransfer { cardano_tx_hash, .. } if cardano_tx_hash == &bridge_tx),
+                INDEXER_OBSERVATION_TIMEOUT,
+            )
+            .await
+            .expect("indexer never surfaced a matching BridgeUnapprovedTransfer");
+        match event {
+            BridgeEvent::UnapprovedTransfer {
+                amount,
+                cardano_tx_hash,
+                ..
+            } => {
+                assert_eq!(
+                    amount, BRIDGE_AMOUNT_STARS as u128,
+                    "indexer BridgeUnapprovedTransfer.amount should equal the bridged STAR amount"
+                );
+                assert_eq!(
+                    cardano_tx_hash, bridge_tx,
+                    "indexer BridgeUnapprovedTransfer.cardanoTxHash should match the Cardano bridge tx id"
+                );
+            }
+            other => panic!("expected BridgeUnapprovedTransfer, got {other:?}"),
+        }
+    }
 }
 
 /// Subminimal-transfer accumulation: three transfers of 999 STARS each, all
@@ -583,6 +795,52 @@ async fn subminimal_transfers_accumulate_and_flush_on_threshold_breach() {
                 unlock_amount, EXPECTED_TOTAL_STARS,
                 "UnlockToTreasury amount should equal the total subminimal sum being flushed"
             );
+
+            // ----- Indexer: BridgeSubminimalFlushTransfer row -----
+            //
+            // SubminimalFlushTransfer carries no per-Cardano-tx identifier
+            // (the flush is the aggregate of N subminimal txs), so we match
+            // on the expected amount + count rather than a hash. Counter
+            // doesn't reset between tests today; if it ever did, a stricter
+            // blockHeight gate would be safer.
+            #[cfg(feature = "indexer")]
+            {
+                let indexer = indexer_client_ready().await;
+                let event = indexer
+                    .await_bridge_event(
+                        None,
+                        Some(BridgeEventVariant::SubminimalFlushTransfer),
+                        |ev| {
+                            matches!(
+                                ev,
+                                BridgeEvent::SubminimalFlushTransfer {
+                                    amount,
+                                    count,
+                                    ..
+                                } if *amount == EXPECTED_TOTAL_STARS && *count == 3
+                            )
+                        },
+                        INDEXER_OBSERVATION_TIMEOUT,
+                    )
+                    .await
+                    .expect(
+                        "indexer never surfaced a matching BridgeSubminimalFlushTransfer \
+                         (expected amount = sum of 3 subminimal transfers, count = 3)",
+                    );
+                match event {
+                    BridgeEvent::SubminimalFlushTransfer { amount, count, .. } => {
+                        assert_eq!(
+                            amount, EXPECTED_TOTAL_STARS,
+                            "indexer BridgeSubminimalFlushTransfer.amount should equal the flushed total"
+                        );
+                        assert_eq!(
+                            count, 3,
+                            "indexer BridgeSubminimalFlushTransfer.count should equal the number of accumulated transfers"
+                        );
+                    }
+                    other => panic!("expected BridgeSubminimalFlushTransfer, got {other:?}"),
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Overview

Closes #1714.

Adds an opt-in `indexer` cargo feature in `tests/e2e/` plus a thin GraphQL helper (`tests/e2e/src/api/indexer.rs`) so the four `c2m_bridge::*` e2e tests can cross-check the indexer's bridge surface in the same run alongside the existing node-side assertions.

**With `--features local,indexer`:**

- `bridge_transfer_cnight_to_midnight_address` asserts the `BridgeUserTransfer` row, `bridgeBalance` pre-claim (`deposited` gross, `claimed = 0`, `balance = claimable` post-fee), the `BridgeClaimTransaction` row with its credited NIGHT UTXO, and `bridgeBalance` post-claim (`claimed = claimable`, `balance = 0`).
- The other three tests each assert their matching `BridgeEvent` row (`Invalid` / `Unapproved` / `SubminimalFlush` with `amount` + `count`).

`bridgeBalance.balance` is pinned to the post-fee "still claimable now" semantics rather than the gross `deposited - claimed` figure, so a regression flipping that back would surface in the happy-path test. Also bumps the `indexer` submodule pointer to pick up that semantics fix on the indexer side — the new assertion would fail against the previous indexer build, which returned `deposited - claimed` (i.e. the fee residue) as `balance` after a full claim.

**Without the feature** the suite behaves exactly as before — no `reqwest` link, no HTTP traffic, no indexer dependency. Endpoint defaults to `http://127.0.0.1:8088/api/v3/graphql`; override via `INDEXER_GRAPHQL_URL`.

This closes the "End-to-end test against a bridge-enabled chain" item on [shieldedtech/midnight-c-to-m-protocol-bridge#4](https://github.com/shieldedtech/midnight-c-to-m-protocol-bridge/issues/4) for five of the six bridge flows. Reserve transfer remains gated on the Cardano Reserve Validator upgrade.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A: cargo-feature added is test-only, no consumer surface -->
- [x] Update documentation (if relevant) <!-- tests/e2e/README.md updated -->
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- N/A: no build/architecture change -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Ran against local-env with the bridge-enabled `indexer-api` image (chain-indexer + indexer-api + wallet-indexer on the `4.4.0-pre-alpha.8-l9a1-n2a1-bridge-…` tag):

```bash
cargo test --test e2e_tests --no-default-features --features local,indexer \
    c2m_bridge:: -- --test-threads=1 --nocapture
```

```
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 28 filtered out; finished in 696.58s
```

Also verified the suite still compiles without the feature (regression sanity for non-indexer CI paths):

```bash
cargo test --test e2e_tests --no-default-features --features local --no-run
# Finished `test` profile [unoptimized + debuginfo]
```

`cargo fmt -p midnight-node-e2e --check` and `cargo clippy -p midnight-node-e2e --tests --no-default-features --features local,indexer` both green on the diff.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A — test-only change.

## Links

- Closes https://github.com/midnightntwrk/midnight-node/issues/1714
- Related: [shieldedtech/midnight-c-to-m-protocol-bridge#4](https://github.com/shieldedtech/midnight-c-to-m-protocol-bridge/issues/4) (indexer-side tracking ticket; this PR closes its e2e-coverage item for 5/6 flows)
- Follow-ups: https://github.com/midnightntwrk/midnight-node/issues/1715 (claim-test hardening + partial / aggregated / negative-claim coverage)
