### PR TITLE
fix: use apply_post_block_update in place of post_block_update to avoid id block fullness check

### DIFF
--- a/changes/runtime/changed/apply-post-block-update.md
+++ b/changes/runtime/changed/apply-post-block-update.md
@@ -1,0 +1,6 @@
+#runtime
+
+# Use `apply_post_block_update` in `pallet_midnight` `on_finalize`
+
+This change makes `on_finalize` use function that has theoretically one way less to fail.
+In practice the error couldn't happen becase block fullness is checked for each included transaction.

--- a/ledger/src/host_api/ledger_7.rs
+++ b/ledger/src/host_api/ledger_7.rs
@@ -102,7 +102,11 @@ pub trait LedgerBridge {
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
 		} else {
-			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(
+				*self,
+				state_key,
+				block_context,
+			)
 		}
 	}
 

--- a/ledger/src/host_api/ledger_7.rs
+++ b/ledger/src/host_api/ledger_7.rs
@@ -94,6 +94,18 @@ pub trait LedgerBridge {
 		}
 	}
 
+	fn apply_post_block_update(
+		&mut self,
+		state_key: PassFatPointerAndRead<&[u8]>,
+		block_context: PassFatPointerAndDecode<BlockContext>,
+	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		if is_unified(*self) {
+			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
+		} else {
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+		}
+	}
+
 	// Current Enabled Version
 	fn get_version(&mut self) -> AllocateAndReturnFatPointer<Vec<u8>> {
 		// Dispatch on storage mode even though `get_version` doesn't read storage today —

--- a/ledger/src/host_api/ledger_8.rs
+++ b/ledger/src/host_api/ledger_8.rs
@@ -83,7 +83,11 @@ pub trait Ledger8Bridge {
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
 		} else {
-			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(
+				*self,
+				state_key,
+				block_context,
+			)
 		}
 	}
 

--- a/ledger/src/host_api/ledger_8.rs
+++ b/ledger/src/host_api/ledger_8.rs
@@ -75,6 +75,18 @@ pub trait Ledger8Bridge {
 		}
 	}
 
+	fn apply_post_block_update(
+		&mut self,
+		state_key: PassFatPointerAndRead<&[u8]>,
+		block_context: PassFatPointerAndDecode<BlockContext>,
+	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		if is_unified(*self) {
+			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
+		} else {
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+		}
+	}
+
 	// Current Enabled Version
 	fn get_version(&mut self) -> AllocateAndReturnFatPointer<Vec<u8>> {
 		// Dispatch on storage mode even though `get_version` doesn't read storage today —

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -75,6 +75,18 @@ pub trait Ledger9Bridge {
 		}
 	}
 
+	fn apply_post_block_update(
+		&mut self,
+		state_key: PassFatPointerAndRead<&[u8]>,
+		block_context: PassFatPointerAndDecode<BlockContext>,
+	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		if is_unified(*self) {
+			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
+		} else {
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+		}
+	}
+
 	// Current Enabled Version
 	fn get_version(&mut self) -> AllocateAndReturnFatPointer<Vec<u8>> {
 		// Dispatch on storage mode even though `get_version` doesn't read storage today —

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -83,7 +83,11 @@ pub trait Ledger9Bridge {
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(*self, state_key, block_context)
 		} else {
-			Bridge::<Signature, DbSeparate>::apply_post_block_update(*self, state_key, block_context)
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(
+				*self,
+				state_key,
+				block_context,
+			)
 		}
 	}
 

--- a/ledger/src/versions/common/api/ledger.rs
+++ b/ledger/src/versions/common/api/ledger.rs
@@ -202,7 +202,10 @@ impl<D: DB> Ledger<D> {
 	/// [`apply_system_tx`]), and the accumulated `block_fullness` is clamped to the block limits
 	/// here before being applied, so the underlying update cannot fail on block limits. Suitable
 	/// for `on_finalize`, which cannot propagate an error.
-	pub(crate) fn apply_post_block_update(sp: Sp<Self, D>, block_context: BlockContext) -> Sp<Self, D> {
+	pub(crate) fn apply_post_block_update(
+		sp: Sp<Self, D>,
+		block_context: BlockContext,
+	) -> Sp<Self, D> {
 		let block_fullness: SyntheticCost = sp.block_fullness.clone().into();
 		let block_limits = sp.state.parameters.limits.block_limits;
 		let normalized_fullness = helpers_local::clamp_and_normalize(
@@ -229,17 +232,18 @@ impl<D: DB> Ledger<D> {
 	) -> Result<Sp<Self, D>, LedgerApiError> {
 		let tx_cost = tx.cost(&sp.state.parameters);
 		let next_block_fullness = tx_cost + sp.block_fullness.clone().into();
-		post_block_update::prevalidate_post_block_update(
-			&sp.state,
-			&next_block_fullness,
-			&sp.state.parameters.limits.block_limits,
-			"apply_system_tx",
-		)?;
-
 		let (next_state, _) = sp.state.apply_system_tx(tx, tblock).map_err(|e| {
 			log::error!(target: LOG_TARGET, "Error applying System Transaction: {e:?}");
 			LedgerApiError::Transaction(TransactionError::SystemTransaction(e.into()))
 		})?;
+		// SystemTransaction::OverwriteParameters can change cost model and block limit.
+		// Cost is computed with old parameters but block fullness is checked against updated limits.
+		post_block_update::prevalidate_post_block_update(
+			&next_state,
+			&next_block_fullness,
+			&next_state.parameters.limits.block_limits,
+			"apply_system_tx",
+		)?;
 		Ok(default_storage::<D>()
 			.arena
 			.alloc(Ledger { state: next_state, block_fullness: next_block_fullness.into() }))

--- a/ledger/src/versions/common/api/ledger.rs
+++ b/ledger/src/versions/common/api/ledger.rs
@@ -194,6 +194,34 @@ impl<D: DB> Ledger<D> {
 		Ok(new_sp)
 	}
 
+	/// Infallible counterpart to [`post_block_update`](Self::post_block_update): applies the
+	/// end-of-block ledger update without the block-limit check.
+	///
+	/// The limit check is performed per-transaction via
+	/// `post_block_update::prevalidate_post_block_update` (see [`apply_verified_transaction`] and
+	/// [`apply_system_tx`]), and the accumulated `block_fullness` is clamped to the block limits
+	/// here before being applied, so the underlying update cannot fail on block limits. Suitable
+	/// for `on_finalize`, which cannot propagate an error.
+	pub(crate) fn apply_post_block_update(sp: Sp<Self, D>, block_context: BlockContext) -> Sp<Self, D> {
+		let block_fullness: SyntheticCost = sp.block_fullness.clone().into();
+		let block_limits = sp.state.parameters.limits.block_limits;
+		let normalized_fullness = helpers_local::clamp_and_normalize(
+			&block_fullness,
+			&block_limits,
+			"apply_post_block_update",
+		);
+		let overall_fullness = compute_overall_fullness(&normalized_fullness);
+		let next_state = post_block_update::apply_post_block_update(
+			&sp.state,
+			Timestamp::from_secs(block_context.tblock),
+			normalized_fullness,
+			overall_fullness,
+		);
+		default_storage::<D>()
+			.arena
+			.alloc(Ledger { state: next_state, block_fullness: SyntheticCost::ZERO.into() })
+	}
+
 	pub(crate) fn apply_system_tx(
 		sp: Sp<Self, D>,
 		tx: &SystemTransaction,

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -260,12 +260,11 @@ where
 			"⏱️  Post block update start (elapsed_ms={})",
 			start_tx_processing_time.elapsed().as_millis()
 		);
-		let mut ledger = Ledger::post_block_update(ledger, block_context).map_err(|e| {
+		let mut ledger = Ledger::post_block_update(ledger, block_context).inspect_err(|e| {
 			log::error!(
 				target: LOG_TARGET,
 				"Post Block Update error: {e:?}"
 			);
-			LedgerApiError::NoLedgerState
 		})?;
 		log::trace!(
 			target: LOG_TARGET,
@@ -288,6 +287,23 @@ where
 			start_tx_processing_time.elapsed().as_millis()
 		);
 
+		Ok(state_root)
+	}
+
+	/// The end-of-block ledger transition cannot fail on block limits (the limit check runs
+	/// per-transaction via prevalidation, and fullness is clamped before applying), so this is
+	/// suitable for `on_finalize`. Loading the ledger state and serializing the resulting key
+	/// remain fallible — those represent genuine bugs rather than block-content conditions.
+	pub fn apply_post_block_update(
+		mut _externalities: &mut dyn Externalities,
+		state_key: &[u8],
+		block_context: BlockContext,
+	) -> Result<Vec<u8>, LedgerApiError> {
+		let api = api::new();
+		let ledger = Self::get_ledger(&api, state_key)?;
+		let mut ledger = Ledger::apply_post_block_update(ledger, block_context);
+		let state_root = api.tagged_serialize(&ledger.as_typed_key())?;
+		ledger.persist();
 		Ok(state_root)
 	}
 

--- a/ledger/src/versions/post_block_update/ledger_7.rs
+++ b/ledger/src/versions/post_block_update/ledger_7.rs
@@ -17,13 +17,37 @@
 
 #![cfg(feature = "std")]
 
-use super::{common::types::LedgerApiError, ledger_storage_local::db::DB};
+use super::{
+	base_crypto_local::{
+		cost_model::{FixedPoint, NormalizedCost},
+		time::Timestamp,
+	},
+	common::types::LedgerApiError,
+	ledger_storage_local::db::DB,
+	mn_ledger_local::structure::LedgerState,
+};
 
 pub fn prevalidate_post_block_update<D: DB>(
-	_state: &super::mn_ledger_local::structure::LedgerState<D>,
+	_state: &LedgerState<D>,
 	_block_fullness: &super::base_crypto_local::cost_model::SyntheticCost,
 	_block_limits: &super::base_crypto_local::cost_model::SyntheticCost,
 	_context: &str,
 ) -> Result<(), LedgerApiError> {
 	Ok(())
+}
+
+/// Applies the end-of-block ledger update. Ledger 7 exposes only the fallible combined
+/// `post_block_update`; the caller has already clamped fullness to the block limits, so its
+/// internal limit check cannot fail here.
+pub fn apply_post_block_update<D: DB>(
+	state: &LedgerState<D>,
+	tblock: Timestamp,
+	detailed_block_fullness: NormalizedCost,
+	overall_block_fullness: FixedPoint,
+) -> LedgerState<D> {
+	state
+		.post_block_update(tblock, detailed_block_fullness, overall_block_fullness)
+		.unwrap_or_else(|_| {
+			panic!("apply_post_block_update: post_block_update failed despite clamped fullness")
+		})
 }

--- a/ledger/src/versions/post_block_update/ledger_8.rs
+++ b/ledger/src/versions/post_block_update/ledger_8.rs
@@ -17,13 +17,37 @@
 
 #![cfg(feature = "std")]
 
-use super::{common::types::LedgerApiError, ledger_storage_local::db::DB};
+use super::{
+	base_crypto_local::{
+		cost_model::{FixedPoint, NormalizedCost},
+		time::Timestamp,
+	},
+	common::types::LedgerApiError,
+	ledger_storage_local::db::DB,
+	mn_ledger_local::structure::LedgerState,
+};
 
 pub fn prevalidate_post_block_update<D: DB>(
-	_state: &super::mn_ledger_local::structure::LedgerState<D>,
+	_state: &LedgerState<D>,
 	_block_fullness: &super::base_crypto_local::cost_model::SyntheticCost,
 	_block_limits: &super::base_crypto_local::cost_model::SyntheticCost,
 	_context: &str,
 ) -> Result<(), LedgerApiError> {
 	Ok(())
+}
+
+/// Applies the end-of-block ledger update. Ledger 8 exposes only the fallible combined
+/// `post_block_update`; the caller has already clamped fullness to the block limits, so its
+/// internal limit check cannot fail here.
+pub fn apply_post_block_update<D: DB>(
+	state: &LedgerState<D>,
+	tblock: Timestamp,
+	detailed_block_fullness: NormalizedCost,
+	overall_block_fullness: FixedPoint,
+) -> LedgerState<D> {
+	state
+		.post_block_update(tblock, detailed_block_fullness, overall_block_fullness)
+		.unwrap_or_else(|_| {
+			panic!("apply_post_block_update: post_block_update failed despite clamped fullness")
+		})
 }

--- a/ledger/src/versions/post_block_update/ledger_9.rs
+++ b/ledger/src/versions/post_block_update/ledger_9.rs
@@ -19,7 +19,10 @@
 #![cfg(feature = "std")]
 
 use super::{
-	base_crypto_local::cost_model::SyntheticCost,
+	base_crypto_local::{
+		cost_model::{FixedPoint, NormalizedCost, SyntheticCost},
+		time::Timestamp,
+	},
 	common::{LOG_TARGET, types::LedgerApiError},
 	helpers_local::compute_overall_fullness,
 	ledger_storage_local::db::DB,
@@ -43,4 +46,17 @@ pub fn prevalidate_post_block_update<D: DB>(
 	state
 		.prevalidate_post_block_update(normalized_fullness, overall_fullness)
 		.map_err(|_err: BlockLimitExceeded| LedgerApiError::BlockLimitExceededError)
+}
+
+/// Applies the end-of-block ledger update. Infallible on ledger 9: the only fallible step (the
+/// block-limit check) is factored out into [`prevalidate_post_block_update`], which runs after
+/// every transaction. The caller must pass fullness that has already been clamped to the block
+/// limits (see `clamp_and_normalize`).
+pub fn apply_post_block_update<D: DB>(
+	state: &LedgerState<D>,
+	tblock: Timestamp,
+	detailed_block_fullness: NormalizedCost,
+	overall_block_fullness: FixedPoint,
+) -> LedgerState<D> {
+	state.apply_post_block_update(tblock, detailed_block_fullness, overall_block_fullness)
 }

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -341,8 +341,8 @@ pub mod pallet {
 			let state_key = StateKey::<T>::get();
 			let block_context = Self::get_block_context();
 
-			let state_root = LedgerApi::post_block_update(&state_key, block_context.clone())
-				.expect("Post block update failed");
+			let state_root = LedgerApi::apply_post_block_update(&state_key, block_context.clone())
+				.expect("FATAL: Apply post block update failed");
 
 			StateKey::<T>::put(state_root);
 


### PR DESCRIPTION
# Overview

Adds a lot of code to not check block weight in `on_finalize`, because we know it was checked before.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [x] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
