### PR TITLE
chore: bump default storage_cache_size to 200000

### DIFF
--- a/changes/node/changed/bump-storage-cache-size.md
+++ b/changes/node/changed/bump-storage-cache-size.md
@@ -1,0 +1,7 @@
+#node
+# Increase default storage_cache_size to 200000
+
+Bumped the default `storage_cache_size` in `res/cfg/default.toml` from 100000 to
+200000 storage nodes to improve cache hit rates at the cost of higher memory use.
+
+PR:

--- a/changes/node/changed/bump-storage-cache-size.md
+++ b/changes/node/changed/bump-storage-cache-size.md
@@ -4,4 +4,4 @@
 Bumped the default `storage_cache_size` in `res/cfg/default.toml` from 100000 to
 200000 storage nodes to improve cache hit rates at the cost of higher memory use.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1729

--- a/res/cfg/default.toml
+++ b/res/cfg/default.toml
@@ -43,7 +43,7 @@ polling_period = 5
 
 # Setting to a non-default value derived from the DEFAULT_CACHE_SIZE of the midnight-ledger crate:
 # https://github.com/midnightntwrk/midnight-ledger/blob/ledger-7.0.0-rc.2/storage/src/storage.rs#L54
-storage_cache_size = 100000
+storage_cache_size = 200000
 storage_separation = "separate"
 
 # Set to default: 1024 * 1024 * 1024


### PR DESCRIPTION
# Overview

Bumps the default `storage_cache_size` in `res/cfg/default.toml` from 100000 to 200000 storage nodes. The larger cache improves storage cache hit rates at the cost of somewhat higher memory usage.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Config-only change; value validated against the config schema. No additional testing.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] Node Client Update
- [ ] N/A

## Links

N/A