### PR TITLE
fix: remove NIGHT token name from preview reserve-config (1.0.1)

### DIFF
--- a/res/preview/reserve-config.json
+++ b/res/preview/reserve-config.json
@@ -2,7 +2,7 @@
   "reserve_validator_address": "addr_test1wzdpdpyev08npr3ktyy9dskvh2v9wk3vphamd6kk60qmjtgftyu2n",
   "asset": {
     "policy_id": "0xd2dbff622e509dda256fedbd31ef6e9fd98ed49ad91d5c0e07f68af1",
-    "asset_name": "NIGHT"
+    "asset_name": ""
   },
   "utxos": [
     {


### PR DESCRIPTION
# Overview

Backport of #1730 to `release/node-1.0.1`, scoped to **preview**.

`res/preview/reserve-config.json` had `asset.asset_name` set to `"NIGHT"`, but it should be empty (`""`) — the same defect tracked for qanet (#1733) and preprod (#1734). On `main` this was fixed by #1730; this PR brings `release/node-1.0.1` into line (one-line change, byte-identical to #1730's preview diff).

Note: the bridge value #1733 is about (`bridge.mainChainScripts.token_asset_name`) is sourced from `ics-config.json` (already `""`) — not from `reserve-config.json` — so preview's chain-spec/on-chain bridge token was already correct. This is a source-consistency fix. The release team agreed preview can be reset.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: network resource config only; no product (node/toolkit/runtime) impact — mirrors #1730 (`skip-changes-check-all`)
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Verified with locally-built `release/node-1.0.1` binaries that the change does **not** alter any generated artifact:

- `generate-genesis --network preview` with `asset_name=""` vs `"NIGHT"` (same ledger-params/cnight/ics/reserve/cardano-tip inputs) → **byte-identical** `genesis_block_preview.mn` and `genesis_state_preview.mn`.
- `CFG_PRESET=preview build-spec` with `asset_name=""` vs `"NIGHT"` → **byte-identical** full chain-spec.

Conclusion: a pure source-consistency fix with no genesis/chain-spec/on-chain effect. (A full faucet-funded preview reset still needs the `preview-genesis-seeds.json` secret in CI; the byte-identical A/B result isolates the asset_name change as a no-op.)

## 🔱 Fork Strategy

- [x] N/A

## Links

Related: #1733, #1734
Backport of: #1730