### PR TITLE
test(e2e): cross-chain bridge pool invariant suite (#1779)

### DIFF
--- a/changes/node/added/c2m-bridge-cross-chain-invariant-suite.md
+++ b/changes/node/added/c2m-bridge-cross-chain-invariant-suite.md
@@ -25,5 +25,5 @@ Requires the Part A cNIGHT genesis seeding (#1778) and a clean local-env (no pri
 cNIGHT minting). `reqwest` is now an unconditional dev-dependency of the e2e crate
 (also used by the kupo client).
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1781
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1779

--- a/changes/node/added/c2m-bridge-cross-chain-invariant-suite.md
+++ b/changes/node/added/c2m-bridge-cross-chain-invariant-suite.md
@@ -1,0 +1,29 @@
+#node
+# Add cross-chain bridge pool invariant e2e suite (state monitor + cooperative flood)
+
+Adds an independent cross-chain invariant suite for the cNIGHT<->NIGHT bridge
+(`tests/e2e/tests/c2m_bridge_invariants.rs`), serialized behind `C2M_BRIDGE_SERIAL`
+and local-env only. Invariants are state predicates over aggregate pool balances, so
+the monitor needs no per-transaction knowledge:
+
+- Midnight pools (M.R / M.L / M.U) via the toolkit's `night_pools()` genesis replay
+  (a new reusable `show_night_pools::read_night_pools`).
+- Cardano pools: C.L (ICS validator) and C.R (Reserve validator) via ogmios, and
+  `C.U = minted_total - C.L - C.R` with `minted_total` read from kupo (new
+  `KupoClient`). Adds `reserve_validator_address()` mirroring `ics_validator_address()`.
+
+`check_cross_chain_invariants` asserts the four relations — `M.U <= C.L`,
+`C.U <= M.L`, `C.R <= M.R`, `M.U + C.U <= S` — as continuous inequalities, with strict
+equalities at quiescence (accounting for the subminimal wait-pool). A cooperative,
+seeded flood spends pre-seeded circulating cNIGHT (no minting) into a diverse mix of
+approved / unapproved / invalid / subminimal transfers via a new
+`CardanoClient::make_cooperative_bridge_transfer`, asserting at genesis -> through the
+flood -> at quiescence. A manual `#[ignore]` negative control mints unmatched cNIGHT to
+prove the monitor catches a breach.
+
+Requires the Part A cNIGHT genesis seeding (#1778) and a clean local-env (no prior
+cNIGHT minting). `reqwest` is now an unconditional dev-dependency of the e2e crate
+(also used by the kupo client).
+
+PR:
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1779

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -14,7 +14,8 @@ qanet = []
 # assertions against a running indexer-api (default
 # http://127.0.0.1:8088/api/v3/graphql, override via INDEXER_GRAPHQL_URL).
 # When off, the tests behave exactly as before (node-side asserts only).
-indexer = ["dep:reqwest"]
+# (`reqwest` is an unconditional dep — also used by the kupo client.)
+indexer = []
 default = ["local-ci"]
 
 [dependencies]
@@ -34,7 +35,7 @@ blake2 = "0.10.6"
 tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true }
 midnight-node-e2e-macros = { path = "macros" }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 midnight-node-res = { workspace = true, features = ["test"] }

--- a/tests/e2e/src/api/cardano.rs
+++ b/tests/e2e/src/api/cardano.rs
@@ -1803,6 +1803,86 @@ impl CardanoClient {
         })
     }
 
+    /// Build and sign — but do not submit — a *cooperative* bridge transfer for the
+    /// invariant flood (#1779): lock `amount` cNight at the ICS validator spending
+    /// **already-minted** cNight from `self`'s own UTxO(s), change (cNight + ADA) back
+    /// to `self`. Unlike [`Self::make_bridge_transfer`] it does not mint and takes a
+    /// variable input set, so the change is a single UTxO that chains into the next
+    /// lock. The ICS output keeps only min-ADA so the change retains ADA for fees.
+    ///
+    /// No collateral input: sending to the ICS script address carries a datum but runs
+    /// no Plutus validator, so the tx needs none.
+    pub async fn make_cooperative_bridge_transfer(
+        &self,
+        inputs: &[OgmiosUtxo],
+        ics_address: &str,
+        amount: u64,
+        recipient: BridgeTransferRecipient,
+    ) -> Result<SignedBridgeTransaction, OgmiosClientError> {
+        const BRIDGE_METADATUM_LABEL: u64 = 6_500_973;
+        const ICS_MIN_LOVELACE: u64 = 1_500_000;
+        let policy_id = config::cnight_token_policy_id();
+        let network = Network::Custom(self.constants.cost_model.clone());
+        let self_addr = self.address_as_bech32();
+
+        let send_assets = vec![
+            Asset::new_from_str("lovelace", &ICS_MIN_LOVELACE.to_string()),
+            Asset::new_from_str(&policy_id, &amount.to_string()),
+        ];
+
+        let mut tx_builder = TxBuilder::new_core();
+        tx_builder
+            .network(network)
+            .set_evaluator(Box::new(OfflineTxEvaluator::new()));
+        for input in inputs {
+            tx_builder.tx_in(
+                &hex::encode(input.transaction.id),
+                input.index.into(),
+                &Self::build_asset_vector(input),
+                &self_addr,
+            );
+        }
+        let mut unsigned_tx_hex = tx_builder
+            .tx_out(ics_address, &send_assets)
+            .tx_out_inline_datum_value(&WData::JSON(
+                serde_json::json!({"constructor": 0, "fields": []}).to_string(),
+            ))
+            .metadata_value(
+                &BRIDGE_METADATUM_LABEL.to_string(),
+                BRIDGE_ADDRESS_METADATUM_PLACEHOLDER_JSON,
+            )
+            .change_address(&self_addr)
+            .complete_sync(None)
+            .unwrap()
+            .tx_hex();
+
+        if let BridgeTransferRecipient::Address(address) = &recipient {
+            unsigned_tx_hex = replace_with_bytes_metadatum(
+                &unsigned_tx_hex,
+                BRIDGE_METADATUM_LABEL,
+                address.as_slice(),
+            )
+            .expect("Failed to swap placeholder for bytes metadatum on cooperative bridge tx");
+        }
+
+        let signed_tx_hex = self
+            .wallet
+            .sign_tx(&unsigned_tx_hex)
+            .expect("Failed to sign cooperative bridge transfer tx");
+        let fixed_tx = whisky::csl::FixedTransaction::from_hex(&signed_tx_hex)
+            .expect("Failed to parse signed cooperative bridge transfer as FixedTransaction");
+        let tx_id: [u8; 32] = fixed_tx
+            .transaction_hash()
+            .to_bytes()
+            .try_into()
+            .expect("Cardano tx hash must be 32 bytes");
+        let signed_tx_bytes = hex::decode(&signed_tx_hex).expect("Failed to decode signed tx hex");
+        Ok(SignedBridgeTransaction {
+            tx_id,
+            signed_tx_bytes,
+        })
+    }
+
     /// Submit an already built and signed Cardano transaction (CBOR bytes) via Ogmios.
     pub async fn submit_tx(
         &self,

--- a/tests/e2e/src/api/cardano.rs
+++ b/tests/e2e/src/api/cardano.rs
@@ -1883,6 +1883,77 @@ impl CardanoClient {
         })
     }
 
+    /// Split `inputs` into `n` self-owned UTxOs, each holding `cnight_per` cNight +
+    /// `lovelace_per` lovelace (plus a change UTxO for the remainder). Submits and returns
+    /// the `n` freshly-created cNight UTxOs.
+    ///
+    /// Used by the invariant flood to give the wallet **independent per-deposit inputs**, so
+    /// every lock tx can be built up-front and all approved hashes batch-approved in a single
+    /// governance round-trip (instead of one round-trip per approved deposit). cNight stays
+    /// circulating (still `C.U`), so this doesn't perturb the pools.
+    pub async fn split_cnight_to_self(
+        &self,
+        inputs: &[OgmiosUtxo],
+        n: usize,
+        lovelace_per: u64,
+        cnight_per: u64,
+    ) -> Result<Vec<OgmiosUtxo>, OgmiosClientError> {
+        let policy_id = config::cnight_token_policy_id();
+        let network = Network::Custom(self.constants.cost_model.clone());
+        let self_addr = self.address_as_bech32();
+        let out_assets = vec![
+            Asset::new_from_str("lovelace", &lovelace_per.to_string()),
+            Asset::new_from_str(&policy_id, &cnight_per.to_string()),
+        ];
+
+        let mut tx_builder = TxBuilder::new_core();
+        tx_builder
+            .network(network)
+            .set_evaluator(Box::new(OfflineTxEvaluator::new()));
+        for input in inputs {
+            tx_builder.tx_in(
+                &hex::encode(input.transaction.id),
+                input.index.into(),
+                &Self::build_asset_vector(input),
+                &self_addr,
+            );
+        }
+        for _ in 0..n {
+            tx_builder.tx_out(&self_addr, &out_assets);
+        }
+        let tx_hex = tx_builder
+            .change_address(&self_addr)
+            .complete_sync(None)
+            .unwrap()
+            .tx_hex();
+        let signed_tx = self
+            .wallet
+            .sign_tx(&tx_hex)
+            .expect("Failed to sign split tx");
+        let tx_bytes = hex::decode(signed_tx).expect("Failed to decode split tx hex");
+        let response = self.submit_tx(tx_bytes).await?;
+
+        let outputs = self
+            .find_utxos_by_tx_id(&self_addr, hex::encode(response.transaction.id))
+            .await;
+        // The `n` flood outputs each hold exactly `cnight_per`; the change UTxO holds the
+        // (larger) remainder, so filtering on the exact cNight amount isolates them.
+        Ok(outputs
+            .into_iter()
+            .filter(|u| {
+                u.value
+                    .native_tokens
+                    .iter()
+                    .filter(|(pid, _)| hex::encode(pid) == policy_id)
+                    .flat_map(|(_, assets)| assets.iter())
+                    .map(|a| a.amount)
+                    .sum::<u64>()
+                    == cnight_per
+            })
+            .take(n)
+            .collect())
+    }
+
     /// Submit an already built and signed Cardano transaction (CBOR bytes) via Ogmios.
     pub async fn submit_tx(
         &self,

--- a/tests/e2e/src/api/kupo.rs
+++ b/tests/e2e/src/api/kupo.rs
@@ -1,0 +1,76 @@
+//! Thin HTTP client for [kupo](https://github.com/CardanoSolutions/kupo), the
+//! Cardano chain-indexer bundled in local-env.
+//!
+//! The cross-chain bridge invariant suite uses it to read the **total** cNIGHT in
+//! existence (summed across all unspent UTxOs by minting policy) — the
+//! `minted_total` from which the unlocked Cardano pool is derived:
+//! `C.U = minted_total - C.L - C.R`. Per-address pools (`C.L` at the ICS validator,
+//! `C.R` at the Reserve validator) are read via ogmios in `CardanoClient`.
+
+use std::time::Duration;
+
+pub type KupoResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Minimal kupo client over its REST `/matches` API.
+pub struct KupoClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl KupoClient {
+    /// Build a client for `base_url` (e.g. `http://127.0.0.1:1442`).
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("build reqwest::Client"),
+        }
+    }
+
+    /// Total unspent quantity of all assets under `policy_id` across the whole chain.
+    /// With no burning this equals the total minted supply (`minted_total`).
+    ///
+    /// Queries `GET /matches/{policy_id}.*?unspent` and sums every `value.assets`
+    /// entry whose key starts with `policy_id` (kupo keys assets as
+    /// `"<policy_id>.<asset_name_hex>"`).
+    pub async fn cnight_total(&self, policy_id: &str) -> KupoResult<u128> {
+        let url = format!("{}/matches/{}.*?unspent", self.base_url, policy_id);
+        self.sum_policy(&url, policy_id).await
+    }
+
+    async fn sum_policy(&self, url: &str, policy_id: &str) -> KupoResult<u128> {
+        let matches: Vec<serde_json::Value> = self
+            .http
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        let mut total: u128 = 0;
+        for m in &matches {
+            let Some(assets) = m
+                .get("value")
+                .and_then(|v| v.get("assets"))
+                .and_then(|a| a.as_object())
+            else {
+                continue;
+            };
+            for (unit, amount) in assets {
+                if unit.starts_with(policy_id) {
+                    // kupo emits native-token quantities as JSON integers; serde_json
+                    // keeps full u64 precision (no f64 rounding), and cNIGHT totals
+                    // (<= 24e15) sit well within u64.
+                    let qty = amount
+                        .as_u64()
+                        .ok_or_else(|| format!("kupo asset {unit} amount not a u64: {amount}"))?;
+                    total = total.saturating_add(qty as u128);
+                }
+            }
+        }
+        Ok(total)
+    }
+}

--- a/tests/e2e/src/api/midnight.rs
+++ b/tests/e2e/src/api/midnight.rs
@@ -771,6 +771,29 @@ impl MidnightClient {
         Ok(String::from_utf8(bytes)?)
     }
 
+    /// Reserve validator bech32 address from `Bridge::MainChainScriptsConfiguration`.
+    /// Mirror of [`Self::ics_validator_address`] — the cross-chain invariant suite reads
+    /// the aggregate cNIGHT held here as the Cardano reserve pool (C.R).
+    pub async fn reserve_validator_address(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let addr = mn_meta::storage()
+            .bridge()
+            .main_chain_scripts_configuration();
+
+        let scripts = self
+            .online_client()
+            .at_current_block()
+            .await?
+            .storage()
+            .try_fetch(addr, ())
+            .await?
+            .map(|v| v.decode())
+            .transpose()?
+            .ok_or("Bridge::MainChainScriptsConfiguration is not set in storage")?;
+
+        let bytes = scripts.reserve_validator_address.0.0;
+        Ok(String::from_utf8(bytes)?)
+    }
+
     /// Read the active `LedgerParameters` via the `get_ledger_parameters` runtime API.
     pub async fn get_ledger_parameters(
         &self,

--- a/tests/e2e/src/api/mod.rs
+++ b/tests/e2e/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod cardano;
 #[cfg(feature = "indexer")]
 pub mod indexer;
+pub mod kupo;
 pub mod midnight;

--- a/tests/e2e/src/config.rs
+++ b/tests/e2e/src/config.rs
@@ -85,6 +85,7 @@ fn read_plutus_compiled_code(title: &str) -> String {
 pub struct Settings {
     pub node_client: NodeClientSettings,
     pub ogmios_client: OgmiosClientSettings,
+    pub kupo_client: KupoClientSettings,
     pub constants: Constants,
     /// Timeout for waiting for a Midnight observation event *after* the
     /// underlying Cardano tx has reached stability. Generous on networks
@@ -120,6 +121,16 @@ impl Settings {
                     timeout_seconds: 180,
                     network: CardanoNetwork::Preview,
                     network_info,
+                },
+                kupo_client: KupoClientSettings {
+                    #[cfg(any(feature = "local", feature = "local-dev"))]
+                    base_url: "http://127.0.0.1:1442".into(),
+                    #[cfg(feature = "local-ci")]
+                    base_url: "http://172.17.0.1:1442".into(),
+                    // kupo is only consulted by the local-env invariant suite; this is an
+                    // unused placeholder on qanet so the field still compiles.
+                    #[cfg(feature = "qanet")]
+                    base_url: "http://127.0.0.1:1442".into(),
                 },
                 #[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
                 finality_timeout: Duration::from_secs(60),
@@ -216,6 +227,13 @@ pub struct OgmiosClientSettings {
     pub timeout_seconds: u64,
     pub network: CardanoNetwork,
     pub network_info: CardanoNetworkInfo,
+}
+
+#[derive(Clone)]
+pub struct KupoClientSettings {
+    /// kupo REST base URL (e.g. `http://127.0.0.1:1442`). Used by the cross-chain
+    /// bridge invariant suite (local-env only) to read total minted cNIGHT.
+    pub base_url: String,
 }
 
 #[derive(Clone)]

--- a/tests/e2e/tests/c2m_bridge.rs
+++ b/tests/e2e/tests/c2m_bridge.rs
@@ -31,7 +31,7 @@ const CLAIM_FUNDING_SEED_HEX: &str =
 // so can't run in parallel.
 static C2M_BRIDGE_SERIAL: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
-async fn lock_c2m_bridge_serial() -> MutexGuard<'static, ()> {
+pub(crate) async fn lock_c2m_bridge_serial() -> MutexGuard<'static, ()> {
     C2M_BRIDGE_SERIAL.lock().await
 }
 
@@ -919,7 +919,7 @@ const LOCAL_ENV_TC_KEYS: [&str; 3] = ["//One", "//Two", "//Three"];
 /// FederatedAuthority motion close → Root call) so it executes with Root
 /// origin. The call is built dynamically against the live metadata so callers
 /// don't depend on a generated subxt builder existing for the target pallet.
-async fn submit_via_governance(
+pub(crate) async fn submit_via_governance(
     midnight: &MidnightClient,
     pallet: &str,
     call: &str,
@@ -943,7 +943,7 @@ async fn submit_via_governance(
 }
 
 /// Pre-approve a single Cardano tx hash via `C2MBridge.add_approved_mc_tx_hashes`.
-async fn approve_mc_tx_hash_via_governance(
+pub(crate) async fn approve_mc_tx_hash_via_governance(
     midnight: &MidnightClient,
     mc_tx_hash: [u8; 32],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -964,7 +964,7 @@ async fn approve_mc_tx_hash_via_governance(
 /// Set the `SubminimalTransfersConfig.subminimal_transfers_flush_threshold` on
 /// the c2m-bridge pallet. Reaches `set_subminimal_transfers_config` with Root
 /// origin via governance.
-async fn set_subminimal_threshold_via_governance(
+pub(crate) async fn set_subminimal_threshold_via_governance(
     midnight: &MidnightClient,
     threshold: u64,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -987,7 +987,7 @@ async fn set_subminimal_threshold_via_governance(
 /// Read the c2m-bridge `SubminimalTransfersConfiguration` storage value and
 /// return its `subminimal_transfers_flush_threshold` field. Lets callers skip a
 /// no-op governance round-trip when the chain already holds the desired value.
-async fn read_subminimal_flush_threshold(
+pub(crate) async fn read_subminimal_flush_threshold(
     midnight: &MidnightClient,
 ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
     let storage_address = mn_meta::storage()

--- a/tests/e2e/tests/c2m_bridge.rs
+++ b/tests/e2e/tests/c2m_bridge.rs
@@ -947,11 +947,25 @@ pub(crate) async fn approve_mc_tx_hash_via_governance(
     midnight: &MidnightClient,
     mc_tx_hash: [u8; 32],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    approve_mc_tx_hashes_via_governance(midnight, &[mc_tx_hash]).await
+}
+
+/// Pre-approve several Cardano tx hashes in a **single** governance round-trip via
+/// `C2MBridge.add_approved_mc_tx_hashes` (which takes a `BoundedVec`). Batching matters
+/// for the invariant flood: governance is the dominant cost, so one round-trip for all
+/// approved deposits is far cheaper than one per deposit.
+pub(crate) async fn approve_mc_tx_hashes_via_governance(
+    midnight: &MidnightClient,
+    mc_tx_hashes: &[[u8; 32]],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // BoundedVec<McTxHash, _> SCALE-encodes identically to Vec<McTxHash>;
     // McTxHash is a single-field tuple struct around `[u8; 32]`.
-    let hashes_value = DynValue::unnamed_composite(vec![DynValue::unnamed_composite(vec![
-        DynValue::from_bytes(mc_tx_hash.as_slice()),
-    ])]);
+    let hashes_value = DynValue::unnamed_composite(
+        mc_tx_hashes
+            .iter()
+            .map(|h| DynValue::unnamed_composite(vec![DynValue::from_bytes(h.as_slice())]))
+            .collect::<Vec<_>>(),
+    );
     submit_via_governance(
         midnight,
         "C2MBridge",

--- a/tests/e2e/tests/c2m_bridge_invariants.rs
+++ b/tests/e2e/tests/c2m_bridge_invariants.rs
@@ -1,0 +1,537 @@
+//! E8 — cross-chain bridge pool invariants (#1773 / #1779).
+//!
+//! An independent **state monitor** + a **cooperative seeded flood** on local-env.
+//! Invariants are state predicates over the aggregate pool balances, so the monitor
+//! needs no per-transaction knowledge:
+//!
+//! * Midnight pools (`M.R` reserve / `M.L` locked / `M.U` unlocked) via the toolkit's
+//!   `night_pools()` genesis replay (`show-night-pools`).
+//! * Cardano pools: `C.L` = Σ cNIGHT at the ICS validator, `C.R` = Σ cNIGHT at the
+//!   Reserve validator (both via ogmios), and `C.U = minted_total − C.L − C.R` where
+//!   `minted_total` is read from kupo.
+//!
+//! Relations (from *Cross-Chain Token Invariants v2*), with the subminimal wait-pool
+//! `W` (cNIGHT locked on Cardano but not yet reflected on Midnight):
+//!   * continuous (Cardano leads, Midnight reflects after observation):
+//!     `M.U ≤ C.L`, `C.U ≤ M.L`, `C.R ≤ M.R`, `M.U + C.U ≤ S`;
+//!   * at quiescence (everything observed): `C.R == M.R`, `C.L == M.U + W`,
+//!     `C.U == M.L − W`.
+//!
+//! **Requires a clean local-env** (the Part A cNIGHT genesis seeding, #1778, with no
+//! prior cNIGHT *minting* activity): the mint-based functional flows in `c2m_bridge.rs`
+//! inflate `C.U` past `M.L` under the infinite-mint test policy, which permanently
+//! breaks the supply-bound invariants on a shared chain. Run this suite first / on a
+//! dedicated local-env. It is serialized behind `C2M_BRIDGE_SERIAL` so it never races
+//! the functional bridge tests. Local-env only (fast finality + fresh genesis).
+
+use midnight_node_e2e::api::cardano::{BridgeTransferRecipient, CardanoClient};
+use midnight_node_e2e::api::kupo::KupoClient;
+use midnight_node_e2e::api::midnight::MidnightClient;
+use midnight_node_e2e::config::{self, Settings};
+use midnight_node_e2e::e2e_test;
+use midnight_node_metadata::midnight_metadata_latest as mn_meta;
+use midnight_node_toolkit::commands::show_night_pools::read_night_pools;
+use midnight_node_toolkit::tx_generator::source::Source;
+use ogmios_client::types::OgmiosUtxo;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::c2m_bridge::{
+    approve_mc_tx_hash_via_governance, lock_c2m_bridge_serial, read_subminimal_flush_threshold,
+    set_subminimal_threshold_via_governance,
+};
+use crate::global_faucet_manager;
+
+/// Total NIGHT supply S, in STARS (1 NIGHT = 1_000_000 STARS).
+const S_STARS: u128 = 24_000_000_000 * 1_000_000;
+
+/// Subminimal flush threshold (STARS) we set for the flood, low enough that each
+/// subminimal deposit flushes promptly so the wait-pool returns to 0 at quiescence.
+const FLOOD_FLUSH_THRESHOLD_STARS: u64 = 500;
+
+/// A single subminimal deposit (< `c_to_m_bridge_min_amount` = 1000 STARS).
+const SUBMINIMAL_STARS: u64 = 999;
+
+/// Deterministic RNG seed for the flood (reproducibility).
+const FLOOD_RNG_SEED: u64 = 0xC2C_1779;
+
+/// ADA funded to the flood wallet for fees + per-lock min-UTxO. Each lock sends
+/// ~1.5 ADA to ICS plus a small fee, so this covers a few hundred locks.
+const FLOOD_WALLET_ADA: u64 = 900_000_000;
+
+/// The three pools of a single chain, in STARS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Pools {
+    /// Reserve.
+    r: u128,
+    /// Locked.
+    l: u128,
+    /// Unlocked / circulating.
+    u: u128,
+}
+
+/// A cross-chain snapshot: both chains' pools plus the subminimal wait-pool.
+#[derive(Debug, Clone, Copy)]
+struct Snapshot {
+    midnight: Pools,
+    cardano: Pools,
+    /// Subminimal cNIGHT locked on Cardano but not yet flushed/reflected on Midnight.
+    waitpool: u128,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Mid-flood: only the directional inequalities are guaranteed.
+    Continuous,
+    /// Settled: strict equalities (accounting for the wait-pool) also hold.
+    Quiescent,
+}
+
+/// Pure invariant check — returns `Err(reason)` on the first violated relation.
+/// Kept non-panicking so the quiescence poll can use it and the negative control
+/// can assert it reports a violation.
+fn check_cross_chain_invariants(s: &Snapshot, phase: Phase) -> Result<(), String> {
+    let (m, c, w) = (s.midnight, s.cardano, s.waitpool);
+
+    // Supply bound — always.
+    if m.u + c.u > S_STARS {
+        return Err(format!("M.U + C.U ({} + {}) > S ({})", m.u, c.u, S_STARS));
+    }
+    // Directional inequalities — always (Cardano leads, Midnight reflects later).
+    if m.u > c.l {
+        return Err(format!("M.U ({}) > C.L ({})", m.u, c.l));
+    }
+    if c.u > m.l {
+        return Err(format!("C.U ({}) > M.L ({})", c.u, m.l));
+    }
+    if c.r > m.r {
+        return Err(format!("C.R ({}) > M.R ({})", c.r, m.r));
+    }
+
+    if phase == Phase::Quiescent {
+        if c.r != m.r {
+            return Err(format!("quiescent: C.R ({}) != M.R ({})", c.r, m.r));
+        }
+        // C.L mirrors M.U plus whatever is still waiting in the subminimal pool.
+        if c.l != m.u + w {
+            return Err(format!(
+                "quiescent: C.L ({}) != M.U + W ({} + {})",
+                c.l, m.u, w
+            ));
+        }
+        if c.u + w != m.l {
+            return Err(format!(
+                "quiescent: C.U + W ({} + {}) != M.L ({})",
+                c.u, w, m.l
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[track_caller]
+fn assert_cross_chain_invariants(s: &Snapshot, phase: Phase) {
+    if let Err(reason) = check_cross_chain_invariants(s, phase) {
+        panic!("cross-chain invariant violated ({phase:?}): {reason}\n  snapshot = {s:?}");
+    }
+}
+
+/// Sum of cNIGHT (under `policy_id`) held across `utxos`.
+fn cnight_in_utxos(utxos: &[OgmiosUtxo], policy_id: &str) -> u128 {
+    utxos
+        .iter()
+        .map(|u| {
+            u.value
+                .native_tokens
+                .iter()
+                .filter(|(pid, _)| hex::encode(pid) == policy_id)
+                .flat_map(|(_, assets)| assets.iter())
+                .map(|a| a.amount as u128)
+                .sum::<u128>()
+        })
+        .sum()
+}
+
+/// Read both chains' pools + the subminimal wait-pool into a [`Snapshot`].
+#[allow(clippy::too_many_arguments)]
+async fn read_pools(
+    midnight: &MidnightClient,
+    cardano: &CardanoClient,
+    kupo: &KupoClient,
+    src_url: &str,
+    ledger_state_db: &str,
+    ics_address: &str,
+    reserve_address: &str,
+    policy_id: &str,
+) -> Snapshot {
+    // ----- Midnight (M.R / M.L / M.U) via genesis replay -----
+    let source = Source {
+        src_url: Some(src_url.to_string()),
+        fetch_concurrency: crate::fetch_concurrency(),
+        fetch_compute_concurrency: None,
+        src_files: None,
+        dust_warp: false,
+        ignore_block_context: false,
+        fetch_only_cached: false,
+        fetch_cache: crate::fetch_cache_config(),
+        ledger_state_db: ledger_state_db.to_string(),
+    };
+    let np = read_night_pools(source)
+        .await
+        .expect("read_night_pools (Midnight pool replay) failed");
+    let m_r = np.reserve;
+    let m_l = np.locked;
+    // Unlocked = everything that isn't reserved or locked (treasury + utxos + rewards + …).
+    let m_u = S_STARS
+        .checked_sub(m_r + m_l)
+        .expect("reserve + locked exceed total supply");
+
+    // ----- Cardano (C.L / C.R via ogmios, C.U via kupo) -----
+    let c_l = cnight_in_utxos(&cardano.query_utxos(ics_address).await, policy_id);
+    let c_r = cnight_in_utxos(&cardano.query_utxos(reserve_address).await, policy_id);
+    let minted_total = kupo
+        .cnight_total(policy_id)
+        .await
+        .expect("kupo cnight_total failed");
+    let c_u = minted_total
+        .checked_sub(c_l + c_r)
+        .expect("C.L + C.R exceed minted cNIGHT total");
+
+    let waitpool = read_waitpool(midnight)
+        .await
+        .expect("read subminimal wait-pool failed");
+
+    Snapshot {
+        midnight: Pools {
+            r: m_r,
+            l: m_l,
+            u: m_u,
+        },
+        cardano: Pools {
+            r: c_r,
+            l: c_l,
+            u: c_u,
+        },
+        waitpool,
+    }
+}
+
+/// Accumulated subminimal cNIGHT (STARS) sitting in `C2MBridge::SubminimalTransfers`.
+async fn read_waitpool(
+    midnight: &MidnightClient,
+) -> Result<u128, Box<dyn std::error::Error + Send + Sync>> {
+    let addr = mn_meta::storage().c2m_bridge().subminimal_transfers();
+    let sum = match midnight
+        .online_client()
+        .at_current_block()
+        .await?
+        .storage()
+        .try_fetch(&addr, ())
+        .await?
+    {
+        Some(value) => value.decode()?.sum as u128,
+        None => 0,
+    };
+    Ok(sum)
+}
+
+/// What disposition a flood deposit should get on Midnight.
+#[derive(Debug, Clone, Copy)]
+enum Disposition {
+    /// Valid recipient, hash pre-approved → `UserTransfer` → `DistributeNight`.
+    Approved,
+    /// Valid recipient, hash not approved → `UnapprovedTransfer` → `UnlockToTreasury`.
+    Unapproved,
+    /// Malformed recipient metadata → `InvalidTransfer` → `UnlockToTreasury`.
+    Invalid,
+    /// Below `c_to_m_bridge_min_amount` → accumulates, then flushes to Treasury.
+    Subminimal,
+}
+
+/// One planned flood deposit.
+struct FloodStep {
+    disposition: Disposition,
+    amount: u64,
+    recipient: [u8; 32],
+}
+
+/// Build the deterministic flood plan: a diverse mix of dispositions with seeded
+/// amounts and rotating recipients. Every disposition is represented.
+fn build_flood_plan() -> Vec<FloodStep> {
+    let mut rng = StdRng::seed_from_u64(FLOOD_RNG_SEED);
+    // A few distinct recipients (rotated) so the mix isn't single-target.
+    let recipients: [[u8; 32]; 3] = [[0x11; 32], [0x22; 32], [0x33; 32]];
+    let dispositions = [
+        Disposition::Approved,
+        Disposition::Unapproved,
+        Disposition::Subminimal,
+        Disposition::Invalid,
+        Disposition::Approved,
+        Disposition::Subminimal,
+    ];
+    dispositions
+        .into_iter()
+        .enumerate()
+        .map(|(i, disposition)| {
+            let amount = match disposition {
+                Disposition::Subminimal => SUBMINIMAL_STARS,
+                // Above the 1000-STAR minimum; varied per step.
+                _ => rng.random_range(40_000_000..100_000_000),
+            };
+            FloodStep {
+                disposition,
+                amount,
+                recipient: recipients[i % recipients.len()],
+            }
+        })
+        .collect()
+}
+
+/// Find the (single) UTxO at `client`'s address that carries cNIGHT — the chained
+/// input for the next cooperative lock.
+async fn find_cnight_utxo(client: &CardanoClient, policy_id: &str) -> OgmiosUtxo {
+    client
+        .utxos()
+        .await
+        .into_iter()
+        .find(|u| cnight_in_utxos(std::slice::from_ref(u), policy_id) > 0)
+        .expect("flood wallet holds no cNIGHT UTxO")
+}
+
+#[e2e_test]
+async fn cross_chain_invariants_hold_under_flood() {
+    let _serial = lock_c2m_bridge_serial().await;
+    let settings = Settings::default();
+    let midnight = MidnightClient::new(settings.node_client.clone()).await;
+    let funded =
+        CardanoClient::new_from_funded(settings.ogmios_client.clone(), settings.constants.clone())
+            .await;
+    let kupo = KupoClient::new(settings.kupo_client.base_url.clone());
+
+    let src_url = midnight.base_url().to_string();
+    let policy = config::cnight_token_policy_id();
+    let ics = midnight
+        .ics_validator_address()
+        .await
+        .expect("read ICS validator address");
+    let reserve = midnight
+        .reserve_validator_address()
+        .await
+        .expect("read reserve validator address");
+
+    // Per-suite ledger cache so repeated Midnight replays are incremental.
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let ledger_db = tmp
+        .path()
+        .join("invariant_ledger_cache")
+        .to_string_lossy()
+        .to_string();
+
+    let snapshot = |label: &'static str| {
+        let (m, c, k, u, db, i, r, p) = (
+            &midnight, &funded, &kupo, &src_url, &ledger_db, &ics, &reserve, &policy,
+        );
+        async move {
+            let s = read_pools(m, c, k, u, db, i, r, p).await;
+            tracing::info!(
+                "{label}: M(R={} L={} U={}) C(R={} L={} U={}) W={}",
+                s.midnight.r,
+                s.midnight.l,
+                s.midnight.u,
+                s.cardano.r,
+                s.cardano.l,
+                s.cardano.u,
+                s.waitpool,
+            );
+            s
+        }
+    };
+
+    // ----- assert @ genesis (clean seeded mirror) -----
+    let genesis = snapshot("genesis").await;
+    assert_cross_chain_invariants(&genesis, Phase::Quiescent);
+
+    // Lower the subminimal flush threshold so subminimal deposits flush promptly.
+    if read_subminimal_flush_threshold(&midnight)
+        .await
+        .expect("read subminimal flush threshold")
+        != FLOOD_FLUSH_THRESHOLD_STARS
+    {
+        set_subminimal_threshold_via_governance(&midnight, FLOOD_FLUSH_THRESHOLD_STARS)
+            .await
+            .expect("set subminimal flush threshold via governance");
+    }
+
+    // ----- set up the cooperative flood wallet -----
+    // A dedicated wallet W funded with ADA (fees) and a chunk of the seeded circulating
+    // cNIGHT. Moving cNIGHT to W keeps it circulating (C.U unchanged) and avoids any
+    // contention on the shared funded address (the faucet never touches the cNIGHT UTxO).
+    let flood =
+        CardanoClient::new(settings.ogmios_client.clone(), settings.constants.clone()).await;
+    let flood_addr = flood.address_as_bech32();
+    global_faucet_manager()
+        .await
+        .request_tokens(&flood_addr, FLOOD_WALLET_ADA)
+        .await;
+
+    let funded_cnight = find_cnight_utxo(&funded, &policy).await;
+    let move_tx = funded
+        .spend_cnight(&funded_cnight, &flood_addr)
+        .await
+        .expect("move seeded cNIGHT to flood wallet");
+    funded
+        .find_utxo_by_tx_id(&flood_addr, hex::encode(move_tx.transaction.id))
+        .await
+        .expect("flood wallet never received cNIGHT");
+    tracing::info!("flood wallet {flood_addr} funded with ADA + circulating cNIGHT");
+
+    // The first lock spends both the cNIGHT UTxO and the ADA UTxO; afterwards the single
+    // change UTxO (cNIGHT + ADA) chains into each subsequent lock.
+    let mut inputs: Vec<OgmiosUtxo> = flood.utxos().await;
+
+    let plan = build_flood_plan();
+    let wave_size = 3;
+    for (wave_idx, wave) in plan.chunks(wave_size).enumerate() {
+        for step in wave {
+            let recipient = match step.disposition {
+                Disposition::Invalid => BridgeTransferRecipient::Invalid,
+                _ => BridgeTransferRecipient::Address(step.recipient),
+            };
+            let prepared = flood
+                .make_cooperative_bridge_transfer(&inputs, &ics, step.amount, recipient)
+                .await
+                .expect("build cooperative bridge transfer");
+
+            if matches!(step.disposition, Disposition::Approved) {
+                approve_mc_tx_hash_via_governance(&midnight, prepared.tx_id)
+                    .await
+                    .expect("pre-approve bridge tx hash via governance");
+            }
+
+            funded
+                .submit_tx(prepared.signed_tx_bytes)
+                .await
+                .expect("submit cooperative bridge transfer");
+            tracing::info!(
+                "wave {wave_idx}: submitted {:?} amount={} tx={}",
+                step.disposition,
+                step.amount,
+                hex::encode(prepared.tx_id),
+            );
+
+            // Wait for the change to confirm, then chain it as the next input.
+            let change = funded
+                .find_utxos_by_tx_id(&flood_addr, hex::encode(prepared.tx_id))
+                .await;
+            inputs = vec![
+                change
+                    .into_iter()
+                    .find(|u| cnight_in_utxos(std::slice::from_ref(u), &policy) > 0)
+                    .expect("cooperative transfer produced no cNIGHT change"),
+            ];
+        }
+
+        // Mid-flood: only the directional inequalities are guaranteed (Cardano leads).
+        let s = snapshot("post-wave").await;
+        assert_cross_chain_invariants(&s, Phase::Continuous);
+    }
+
+    // ----- drive to quiescence -----
+    // Poll until the bridge has observed every deposit and the pools satisfy the strict
+    // quiescent relations (wait-pool accounted), stable across two consecutive reads.
+    let end = drive_to_quiescence(&snapshot).await;
+    assert_cross_chain_invariants(&end, Phase::Quiescent);
+    tracing::info!("cross-chain invariants hold at genesis, through the flood, and at quiescence");
+}
+
+/// Poll `snapshot` until the quiescent relations hold for two consecutive reads, or
+/// fail loudly after the budget. Returns the final (quiescent) snapshot.
+async fn drive_to_quiescence<F, Fut>(snapshot: &F) -> Snapshot
+where
+    F: Fn(&'static str) -> Fut,
+    Fut: std::future::Future<Output = Snapshot>,
+{
+    const POLL: Duration = Duration::from_secs(8);
+    const BUDGET: Duration = Duration::from_secs(240);
+    let start = std::time::Instant::now();
+    let mut consecutive_ok = 0;
+    let mut last = snapshot("quiescing").await;
+    loop {
+        let s = snapshot("quiescing").await;
+        last = s;
+        if check_cross_chain_invariants(&s, Phase::Quiescent).is_ok() {
+            consecutive_ok += 1;
+            if consecutive_ok >= 2 {
+                return s;
+            }
+        } else {
+            consecutive_ok = 0;
+        }
+        if start.elapsed() > BUDGET {
+            // Surface the precise unmet relation.
+            assert_cross_chain_invariants(&last, Phase::Quiescent);
+            return last;
+        }
+        sleep(POLL).await;
+    }
+}
+
+/// Negative control (manual): minting fresh cNIGHT with no matching lock inflates the
+/// circulating Cardano pool (C.U) beyond the Midnight locked pool (M.L), so the monitor
+/// must report a violation. Proves the monitor fails when it should.
+///
+/// `#[ignore]` — it irreversibly perturbs local-env state (extra cNIGHT in circulation),
+/// so it is run by hand on a dedicated/fresh instance, not as part of the suite.
+#[e2e_test]
+#[ignore = "manual: irreversibly mints extra cNIGHT to prove the monitor catches a breach"]
+async fn negative_control_extra_mint_breaks_invariants() {
+    let _serial = lock_c2m_bridge_serial().await;
+    let settings = Settings::default();
+    let midnight = MidnightClient::new(settings.node_client.clone()).await;
+    let cardano =
+        CardanoClient::new_from_funded(settings.ogmios_client.clone(), settings.constants.clone())
+            .await;
+    let kupo = KupoClient::new(settings.kupo_client.base_url.clone());
+
+    let src_url = midnight.base_url().to_string();
+    let policy = config::cnight_token_policy_id();
+    let ics = midnight.ics_validator_address().await.expect("ICS address");
+    let reserve = midnight
+        .reserve_validator_address()
+        .await
+        .expect("reserve address");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let ledger_db = tmp.path().join("neg_ledger").to_string_lossy().to_string();
+
+    let before = read_pools(
+        &midnight, &cardano, &kupo, &src_url, &ledger_db, &ics, &reserve, &policy,
+    )
+    .await;
+    assert_cross_chain_invariants(&before, Phase::Continuous);
+
+    // Mint a large slug of fresh cNIGHT (no lock) — pushes C.U above M.L.
+    let collateral = global_faucet_manager()
+        .await
+        .request_tokens(&cardano.address_as_bech32(), 5_000_000)
+        .await;
+    cardano
+        .mint_tokens(S_STARS as u64, &collateral)
+        .await
+        .expect("mint extra cNIGHT");
+    // Give kupo a moment to index the mint.
+    sleep(Duration::from_secs(10)).await;
+
+    let after = read_pools(
+        &midnight, &cardano, &kupo, &src_url, &ledger_db, &ics, &reserve, &policy,
+    )
+    .await;
+    tracing::info!(?after, "post-mint snapshot");
+    let result = check_cross_chain_invariants(&after, Phase::Continuous);
+    assert!(
+        result.is_err(),
+        "negative control: monitor should have reported a violation after an unmatched \
+         cNIGHT mint, but invariants still held: {after:?}"
+    );
+    tracing::info!("negative control: monitor correctly flagged the breach: {result:?}");
+}

--- a/tests/e2e/tests/c2m_bridge_invariants.rs
+++ b/tests/e2e/tests/c2m_bridge_invariants.rs
@@ -38,7 +38,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::c2m_bridge::{
-    approve_mc_tx_hash_via_governance, lock_c2m_bridge_serial, read_subminimal_flush_threshold,
+    approve_mc_tx_hashes_via_governance, lock_c2m_bridge_serial, read_subminimal_flush_threshold,
     set_subminimal_threshold_via_governance,
 };
 use crate::global_faucet_manager;
@@ -59,6 +59,13 @@ const FLOOD_RNG_SEED: u64 = 0xC2C_1779;
 /// ADA funded to the flood wallet for fees + per-lock min-UTxO. Each lock sends
 /// ~1.5 ADA to ICS plus a small fee, so this covers a few hundred locks.
 const FLOOD_WALLET_ADA: u64 = 900_000_000;
+
+/// Lovelace placed on each per-deposit flood input (covers the ICS min-UTxO + fee).
+const FLOOD_INPUT_LOVELACE: u64 = 4_000_000;
+
+/// cNIGHT placed on each per-deposit flood input — comfortably above the largest
+/// planned deposit so any disposition's amount fits.
+const FLOOD_INPUT_CNIGHT: u64 = 150_000_000;
 
 /// The three pools of a single chain, in STARS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -386,50 +393,65 @@ async fn cross_chain_invariants_hold_under_flood() {
         .expect("flood wallet never received cNIGHT");
     tracing::info!("flood wallet {flood_addr} funded with ADA + circulating cNIGHT");
 
-    // The first lock spends both the cNIGHT UTxO and the ADA UTxO; afterwards the single
-    // change UTxO (cNIGHT + ADA) chains into each subsequent lock.
-    let mut inputs: Vec<OgmiosUtxo> = flood.utxos().await;
-
+    // Give the wallet one independent (cNIGHT + ADA) UTxO per planned deposit, so every
+    // lock tx can be built up-front (no chaining) and all approved hashes batch-approved in
+    // a single governance round-trip.
     let plan = build_flood_plan();
+    let flood_inputs = flood
+        .split_cnight_to_self(
+            &flood.utxos().await,
+            plan.len(),
+            FLOOD_INPUT_LOVELACE,
+            FLOOD_INPUT_CNIGHT,
+        )
+        .await
+        .expect("split flood inputs");
+    assert_eq!(
+        flood_inputs.len(),
+        plan.len(),
+        "expected one flood input per planned deposit"
+    );
+
+    // Build every lock tx up-front and collect the hashes that need approval.
+    let mut prepared: Vec<(Disposition, u64, [u8; 32], Vec<u8>)> = Vec::with_capacity(plan.len());
+    let mut approved_hashes: Vec<[u8; 32]> = Vec::new();
+    for (step, input) in plan.iter().zip(flood_inputs.into_iter()) {
+        let recipient = match step.disposition {
+            Disposition::Invalid => BridgeTransferRecipient::Invalid,
+            _ => BridgeTransferRecipient::Address(step.recipient),
+        };
+        let tx = flood
+            .make_cooperative_bridge_transfer(&[input], &ics, step.amount, recipient)
+            .await
+            .expect("build cooperative bridge transfer");
+        if matches!(step.disposition, Disposition::Approved) {
+            approved_hashes.push(tx.tx_id);
+        }
+        prepared.push((step.disposition, step.amount, tx.tx_id, tx.signed_tx_bytes));
+    }
+
+    // One governance round-trip approves every approved deposit before any is submitted, so
+    // the bridge sees the approvals before it observes the locks.
+    if !approved_hashes.is_empty() {
+        approve_mc_tx_hashes_via_governance(&midnight, &approved_hashes)
+            .await
+            .expect("batch pre-approve bridge tx hashes via governance");
+    }
+
+    // Submit in waves; after each wave only the directional inequalities are guaranteed.
     let wave_size = 3;
-    for (wave_idx, wave) in plan.chunks(wave_size).enumerate() {
-        for step in wave {
-            let recipient = match step.disposition {
-                Disposition::Invalid => BridgeTransferRecipient::Invalid,
-                _ => BridgeTransferRecipient::Address(step.recipient),
-            };
-            let prepared = flood
-                .make_cooperative_bridge_transfer(&inputs, &ics, step.amount, recipient)
-                .await
-                .expect("build cooperative bridge transfer");
-
-            if matches!(step.disposition, Disposition::Approved) {
-                approve_mc_tx_hash_via_governance(&midnight, prepared.tx_id)
-                    .await
-                    .expect("pre-approve bridge tx hash via governance");
-            }
-
+    for (wave_idx, wave) in prepared.chunks(wave_size).enumerate() {
+        for (disposition, amount, tx_id, signed_tx_bytes) in wave {
             funded
-                .submit_tx(prepared.signed_tx_bytes)
+                .submit_tx(signed_tx_bytes.clone())
                 .await
                 .expect("submit cooperative bridge transfer");
             tracing::info!(
                 "wave {wave_idx}: submitted {:?} amount={} tx={}",
-                step.disposition,
-                step.amount,
-                hex::encode(prepared.tx_id),
+                disposition,
+                amount,
+                hex::encode(tx_id),
             );
-
-            // Wait for the change to confirm, then chain it as the next input.
-            let change = funded
-                .find_utxos_by_tx_id(&flood_addr, hex::encode(prepared.tx_id))
-                .await;
-            inputs = vec![
-                change
-                    .into_iter()
-                    .find(|u| cnight_in_utxos(std::slice::from_ref(u), &policy) > 0)
-                    .expect("cooperative transfer produced no cNIGHT change"),
-            ];
         }
 
         // Mid-flood: only the directional inequalities are guaranteed (Cardano leads).

--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -351,6 +351,7 @@ pub(crate) fn fetch_concurrency() -> usize {
 
 // -------- TEST MODULES --------
 mod c2m_bridge;
+mod c2m_bridge_invariants;
 mod cnight;
 mod contract_state;
 mod governance;

--- a/util/toolkit/src/commands/show_night_pools.rs
+++ b/util/toolkit/src/commands/show_night_pools.rs
@@ -48,13 +48,18 @@ fn night(stars: u128) -> String {
 	format!("{}.{:06} NIGHT", stars / STARS_PER_NIGHT, stars % STARS_PER_NIGHT)
 }
 
-pub async fn execute(
-	args: ShowNightPoolsArgs,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-	let ledger_state_db = args.source.ledger_state_db.clone();
-	let fetch_cache = args.source.fetch_cache.clone();
+/// Read the NIGHT pools from a network/source by replaying its `LedgerState`.
+///
+/// Shared by [`execute`] (which prints them) and external callers such as the
+/// cross-chain bridge invariant e2e suite, which compares these Midnight pools
+/// (M.R / M.L / M.U) against the Cardano cNIGHT pools.
+pub async fn read_night_pools(
+	source: Source,
+) -> Result<NightPools, Box<dyn std::error::Error + Send + Sync>> {
+	let ledger_state_db = source.ledger_state_db.clone();
+	let fetch_cache = source.fetch_cache.clone();
 
-	let src = TxGenerator::source(args.source, false).await?;
+	let src = TxGenerator::source(source, false).await?;
 	let source_txs = src.get_txs().await?;
 	let wallet_cache = create_file_wallet_cache(&ledger_state_db, &fetch_cache);
 
@@ -66,11 +71,17 @@ pub async fn execute(
 	let fork_ctx =
 		build_fork_aware_context_cached(&cache_seed, &source_txs, wallet_cache.as_deref()).await;
 
-	let night_pools = fork_ctx.dispatch(
+	fork_ctx.dispatch(
 		|ctx| ledger_7::night_pools::night_pools(&ctx),
 		|ctx| ledger_8::night_pools::night_pools(&ctx),
 		|ctx| ledger_9::night_pools::night_pools(&ctx),
-	)?;
+	)
+}
+
+pub async fn execute(
+	args: ShowNightPoolsArgs,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+	let night_pools = read_night_pools(args.source).await?;
 
 	let total = night_pools.reserve
 		+ night_pools.locked


### PR DESCRIPTION
# Overview

Part B of #1773 (tracked as #1779) — the cross-chain bridge pool **invariant suite**: an independent state monitor + a cooperative seeded flood on local-env. This is the bridge's core guarantee (locked cNIGHT on Cardano mirrored by NIGHT on Midnight), previously unasserted end-to-end (QA test plan E8).

Invariants are state predicates over aggregate pool balances, so the monitor needs no per-transaction knowledge:

- **Midnight** pools (`M.R`/`M.L`/`M.U`) via the toolkit `night_pools()` genesis replay — a new reusable `show_night_pools::read_night_pools`.
- **Cardano** pools: `C.L` (ICS validator) / `C.R` (Reserve validator) via ogmios; `C.U = minted_total − C.L − C.R` with `minted_total` from a new `KupoClient`. Adds `reserve_validator_address()` mirroring `ics_validator_address()`.

`check_cross_chain_invariants` asserts `M.U ≤ C.L`, `C.U ≤ M.L`, `C.R ≤ M.R`, `M.U + C.U ≤ S` as continuous inequalities (Cardano leads, Midnight reflects after observation), with strict equalities at quiescence — accounting for the subminimal wait-pool `W` (`C.L == M.U + W`, `C.U + W == M.L`). A **cooperative seeded flood** spends pre-seeded circulating cNIGHT (no minting) into a diverse mix (approved / unapproved / invalid / subminimal) via a new `CardanoClient::make_cooperative_bridge_transfer`, asserting at genesis → through the flood → at quiescence. A manual `#[ignore]` **negative control** mints unmatched cNIGHT to prove the monitor catches a breach.

> **Stacked on #1780 (Part A).** This PR targets the Part A branch so the diff is Part-B-only; it auto-retargets to `main` when #1780 merges. The suite **requires** Part A's cNIGHT genesis seeding and a clean local-env (no prior cNIGHT minting — the mint-based functional flows would inflate `C.U` past `M.L` under the infinite-mint test policy). It is serialized behind `C2M_BRIDGE_SERIAL` and is local-env only.

## 🗹 TODO before merging

- [ ] Ready
- [ ] Rebase / retarget onto `main` after #1780 merges
- [ ] Add this PR link to the change file (follow-up commit)
- [ ] (follow-up) CI lane to gate this suite on a dedicated local-env — #1775

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A: e2e test code only -->
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Ran on a fresh seeded local-env (Part A):

```
cargo test -p midnight-node-e2e --no-default-features --features local --test e2e_tests \
  c2m_bridge_invariants::cross_chain_invariants_hold_under_flood -- --nocapture --test-threads 1
```

`test result: ok. 1 passed; 0 failed` (580s). The flood drove all dispositions —
`DistributeNight(CardanoBridge)` for approved transfers and `UnlockToTreasury` for
unapproved / invalid / subminimal — and the monitor held at genesis, after every wave
(Cardano leading, e.g. `C.L=2200000132932426 > M.U=2200000000000000`), and at quiescence:

```
M(R=5000000000873988  L=16799999739121281  U=2200000260004731)
C(R=5000000000873988  L=2200000260004731    U=16799999739121281)  W=0
  => M.R==C.R,  M.U==C.L,  M.L==C.U,  M.U+C.U <= S
```

The negative control (`#[ignore]`) was exercised separately and the monitor flagged the breach as expected.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A <!-- e2e test tooling only; no node runtime/client change -->

## Links

Part of #1773 · Closes #1779 · Stacked on #1780 (Part A)
