### PR TITLE
fix(node): backport #1767 to release/node-2.0.0 (accept --no-hardware-benchmarks & --rpc-max-finality-subscriptions)

### DIFF
--- a/node/src/cfg/substrate_cfg/mod.rs
+++ b/node/src/cfg/substrate_cfg/mod.rs
@@ -56,12 +56,19 @@ impl SubstrateCfg {
 	// Ignore here - the large Result is inherited from Substrate
 	#[allow(clippy::result_large_err)]
 	pub fn into_run_cmd(self, safe_read_opts: &SafeReadOpts) -> sc_cli::Result<RunCmd> {
+		let run_cmd = RunCmd::parse_from(self.argv());
+		self.apply_overrides_to_run_cmd(run_cmd, safe_read_opts)
+	}
+
+	// Ignore here - the large Result is inherited from Substrate
+	#[allow(clippy::result_large_err)]
+	pub fn apply_overrides_to_run_cmd(
+		self,
+		mut run_cmd: RunCmd,
+		safe_read_opts: &SafeReadOpts,
+	) -> sc_cli::Result<RunCmd> {
 		let default_run_cmd = RunCmd::parse_from(&["midnight-node".to_string()]);
 
-		let argv: Vec<String> =
-			self.argv().into_iter().filter(|e| e != "--filter-deploy-txs").collect();
-
-		let mut run_cmd = RunCmd::parse_from(argv);
 		if run_cmd.shared_params.base_path.is_none() && self.base_path.is_some() {
 			run_cmd.shared_params.base_path = self.base_path.map(|p| p.into());
 		}

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -171,12 +171,12 @@ fn decode_genesis_state(
 
 fn run_node(cfg: Cfg) -> sc_cli::Result<()> {
 	bail_if_runtime_benchmarks("running a node");
-	let run_cmd: RunCmd = cfg
-		.substrate_cfg
-		.clone()
-		.into_run_cmd(&Cfg::safe_read_opts().map_err(|e| sc_cli::Error::Input(e.to_string()))?)?;
 	let run_midnight = RunMidnight::try_parse_from(cfg.substrate_cfg.clone().argv())
 		.map_err(|e| sc_cli::Error::Input(format!("invalid node run arguments: {e}")))?;
+	let run_cmd: RunCmd = cfg.substrate_cfg.clone().apply_overrides_to_run_cmd(
+		run_midnight.run.clone(),
+		&Cfg::safe_read_opts().map_err(|e| sc_cli::Error::Input(e.to_string()))?,
+	)?;
 	let tx_filter_config = if run_midnight.filter_deploy_txs {
 		TxFilterConfig::enabled()
 	} else {


### PR DESCRIPTION
# Overview

Backports #1767 (merged to `main` as `88eafaff`) to `release/node-2.0.0`.

The fix repairs node startup argument parsing so the custom `RunMidnight` wrapper
flags are accepted. Previously `into_run_cmd()` stripped only `--filter-deploy-txs`
before re-parsing argv with `sc_cli::RunCmd`, so the other two custom flags leaked
through and `RunCmd::parse_from` aborted the process before the node could start:

- `--no-hardware-benchmarks`
- `--rpc-max-finality-subscriptions <value>`

The fix parses `RunMidnight` first, then applies the config overrides to the already
parsed `run_midnight.run` via the new `apply_overrides_to_run_cmd()`.

This is the QA blocker reported on #1395 (the `--no-hardware-benchmarks` disable flag
is an acceptance criterion of that issue). Without this backport, `node-2.0.0-rc.3`
cut from this release branch would still ship the bug.

This is a pure cherry-pick of `88eafaff` (`-x` traceability line included); no code
was modified for the backport.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: pure cherry-pick of #1767, which carried no change file; `skip-changes-check-all` applied
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Retested on `release/node-2.0.0` with the cherry-pick applied, release build (`cargo build --release`).

**Baseline (pre-fix binary)** — both flags abort at arg parsing with exit 2:
```
$ midnight-node --no-hardware-benchmarks --tmp --dev --no-prometheus
error: unexpected argument '--no-hardware-benchmarks' found
$ midnight-node --rpc-max-finality-subscriptions 256 --tmp --dev --no-prometheus
error: unexpected argument '--rpc-max-finality-subscriptions' found
```

**With fix** — node boots past arg parsing and produces blocks in all cases:

| Test | `unexpected argument`? | Boots & produces blocks? | Benchmark runs? |
|---|---|---|---|
| `--no-hardware-benchmarks` | No | Yes (consensus + block #1) | No (0 lines) — flag suppresses it |
| `--rpc-max-finality-subscriptions 256` | No | Yes (best #4 / finalized #1) | Yes (expected) |
| control (plain `--dev`) | No | Yes (best #3 / finalized #1) | Yes (expected) |

`--no-hardware-benchmarks` was also confirmed functional, not merely accepted: 0 benchmark
log lines vs 4 in the control run.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] Node Client Update

## Links

Related issue (QA blocker): https://github.com/midnightntwrk/midnight-node/issues/1395
Original PR: https://github.com/midnightntwrk/midnight-node/pull/1767

Assisted-by: Claude:claude-opus-4-8
