### PR TITLE
ci(security): hardnen caching

### DIFF
--- a/.github/actions/tree-cache-guard/action.yml
+++ b/.github/actions/tree-cache-guard/action.yml
@@ -10,6 +10,13 @@ inputs:
     description: Extra key suffix for matrix jobs
     required: false
     default: ''
+  hmac-key:
+    description: >-
+      HMAC key authenticating cache keys (pass secrets.TREE_GUARD_HMAC).
+      Runs without secrets access (fork PRs) can neither forge nor hit
+      entries; when empty the guard always reports a miss.
+    required: false
+    default: ''
 
 outputs:
   hit:
@@ -40,6 +47,13 @@ runs:
           exit 0
         fi
 
+        if [[ -z "$HMAC_KEY" ]]; then
+          echo "::notice::hmac-key not provided (fork PR?) — skipping cache"
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+          echo "key=no-cache-no-hmac-key" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         workflow="${WORKFLOW_NAME// /-}"
         job="${CHECK_NAME// /-}"
         arch="${RUNNER_ARCH// /-}"
@@ -49,7 +63,14 @@ runs:
           matrix="${MATRIX_KEY// /-}"
           check="${check}-${matrix}"
         fi
-        key="passed-${check}-${tree}"
+        # `gh cache list` sees entries from every branch scope, so a fork PR
+        # (which can write caches scoped to its own ref) could otherwise mint
+        # a "passed" key and make trusted runs skip checks. Forks don't get
+        # secrets, so they can't compute the signature. Never put the raw
+        # secret in the key — keys are readable via the cache API. 16 hex
+        # chars (64 bits) is ample forgery resistance.
+        sig=$(printf '%s' "${check}-${tree}" | openssl dgst -sha256 -hmac "$HMAC_KEY" | awk '{print $NF}')
+        key="passed-${check}-${tree}-${sig:0:16}"
 
         echo "key=${key}" >> "$GITHUB_OUTPUT"
 
@@ -65,5 +86,6 @@ runs:
         COMMIT_SHA: ${{ github.sha }}
         CHECK_NAME: ${{ inputs.check-name }}
         MATRIX_KEY: ${{ inputs.matrix-key }}
+        HMAC_KEY: ${{ inputs.hmac-key }}
         RUNNER_ARCH: ${{ runner.arch }}
         WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/actions/tree-cache-guard/save/action.yml
+++ b/.github/actions/tree-cache-guard/save/action.yml
@@ -9,10 +9,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
+    # `no-cache-*` sentinel keys mean the guard opted out (workflow override
+    # or no hmac-key) — saving them would just create junk entries.
+    - if: ${{ !startsWith(inputs.key, 'no-cache') }}
+      shell: bash
       run: mkdir -p /tmp/ci-sentinel && touch /tmp/ci-sentinel/ok
 
-    - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v4
+    - if: ${{ !startsWith(inputs.key, 'no-cache') }}
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v4
       with:
         key: ${{ inputs.key }}
         path: /tmp/ci-sentinel

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,6 +28,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - name: Run actionlint
         if: steps.guard.outputs.hit != 'true'

--- a/.github/workflows/continuous-integration-checks.yml
+++ b/.github/workflows/continuous-integration-checks.yml
@@ -30,6 +30,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - name: Merge Conflict Finder
         if: steps.guard.outputs.hit != 'true'
@@ -79,6 +81,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - name: Login to GHCR
         if: steps.guard.outputs.hit != 'true'

--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -34,6 +34,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -401,6 +401,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
@@ -442,6 +444,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
@@ -503,6 +507,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
@@ -556,6 +562,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
@@ -673,6 +681,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       - uses: ./.github/actions/reusable-e2e-tests
         if: steps.guard.outputs.hit != 'true'
         with:
@@ -699,6 +709,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       - uses: ./.github/actions/reusable-e2e-tests
         if: steps.guard.outputs.hit != 'true'
         with:
@@ -725,6 +737,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       # "LEDGER9-TOOLKIT-JS: toolkit-js v9 / compact-js with intent[v7] serializer not yet vendored"
       # - uses: ./.github/actions/reusable-e2e-tests
       #   if: steps.guard.outputs.hit != 'true'
@@ -752,6 +766,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       #"LEDGER9-TOOLKIT-JS: toolkit-js v9 / compact-js with intent[v7] serializer not yet vendored"
       # - uses: ./.github/actions/reusable-e2e-tests
       #   if: steps.guard.outputs.hit != 'true'
@@ -779,6 +795,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       # "LEDGER9-TOOLKIT-JS: toolkit-js v9 / compact-js with intent[v7] serializer not yet vendored"
       # - uses: ./.github/actions/reusable-e2e-tests
       #   if: steps.guard.outputs.hit != 'true'
@@ -806,6 +824,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
         with:
@@ -902,6 +922,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       # "LEDGER9-TOOLKIT-JS: toolkit-js v9 / compact-js with intent[v7] serializer not yet vendored"
       # - uses: ./.github/actions/reusable-e2e-tests
       #   if: steps.guard.outputs.hit != 'true'
@@ -929,6 +951,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       - uses: ./.github/actions/reusable-e2e-tests
         if: steps.guard.outputs.hit != 'true'
         with:
@@ -976,6 +1000,8 @@ jobs:
           submodules: true
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
       - uses: ./.github/actions/reusable-e2e-tests
         if: steps.guard.outputs.hit != 'true'
         with:
@@ -1134,6 +1160,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       # Isolate docker config per job — see the matching step in the `run` job.
       # This job runs concurrently, so per-job isolation matters: multiple

--- a/.github/workflows/security-audit-scan.yml
+++ b/.github/workflows/security-audit-scan.yml
@@ -32,6 +32,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'
@@ -84,6 +86,8 @@ jobs:
 
       - id: guard
         uses: ./.github/actions/tree-cache-guard
+        with:
+          hmac-key: ${{ secrets.TREE_GUARD_HMAC }}
 
       - uses: EarthBuild/actions-setup@cae2d9ab68894d8402751fe42e07c7cca0272f7f
         if: steps.guard.outputs.hit != 'true'

--- a/changes/node/changed/hmac-authenticate-tree-guard-cache-keys.md
+++ b/changes/node/changed/hmac-authenticate-tree-guard-cache-keys.md
@@ -9,4 +9,4 @@ carry an HMAC-SHA256 signature over the check name and tree hash, keyed
 by the `TREE_GUARD_HMAC` repo secret. Runs without secrets access always
 miss and never save; `no-cache-*` sentinel keys are no longer saved.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1811

--- a/changes/node/changed/hmac-authenticate-tree-guard-cache-keys.md
+++ b/changes/node/changed/hmac-authenticate-tree-guard-cache-keys.md
@@ -1,0 +1,12 @@
+#ci #security
+# HMAC-authenticate tree-cache-guard cache keys
+
+The tree-cache-guard skip check used `gh cache list`, which sees cache
+entries from every branch scope — so a fork PR (which can write caches
+scoped to its own ref, but never sees repo secrets) could mint a
+`passed-...` key and make trusted runs skip their checks. Cache keys now
+carry an HMAC-SHA256 signature over the check name and tree hash, keyed
+by the `TREE_GUARD_HMAC` repo secret. Runs without secrets access always
+miss and never save; `no-cache-*` sentinel keys are no longer saved.
+
+PR:


### PR DESCRIPTION
# Overview

Authenticate `tree-cache-guard` cache keys with an HMAC so forks cannot forge a "passed" marker.

The guard skips a CI job when a `passed-<check>-<tree>` cache entry exists, but the existence check uses `gh cache list`, which sees entries from **every** branch scope. A fork PR can write cache entries scoped to its own ref (no secrets needed), and the list API surfaces them repo-wide — so an attacker could mint a key for an arbitrary tree hash and make trusted runs skip their checks.

Fix: the key now embeds a signature — `passed-<check>-<tree>-<sig>` where `sig` is the first 16 hex chars (64 bits) of `HMAC-SHA256(TREE_GUARD_HMAC, "<check>-<tree>")`:

- Fork PRs don't receive secrets, so they can't compute a valid signature for any new tree. Replaying a visible key is harmless — it only asserts a tree that genuinely passed, passed.
- The raw secret never appears in the key (keys are world-readable via the cache API); it travels input → `env`, never interpolated into `run:`.
- Runs without the secret (fork PRs) always report a miss and never save: full CI runs, no skips, no forgeable writes.
- `save` now skips `no-cache-*` sentinel keys, so opt-out paths (workflow override, missing secret) no longer create junk cache entries.

All 20 guard call sites across 5 workflows now pass `hmac-key: ${{ secrets.TREE_GUARD_HMAC }}`; save sites need no change (the signature rides inside the key output).

Residual trust boundary (intended): anyone who can execute a workflow *with* secrets access — same-repo branches, merged code — can still compute valid keys. Rotating the secret invalidates all existing guard entries at the cost of one full rerun per tree.

## 🗹 TODO before merging

- [x] `TREE_GUARD_HMAC` secret added to the repo
- [ ] Follow-up commit: add PR link to the change file
- [ ] Ready

## 📌 Submission Checklist

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking) — existing `passed-*` entries no longer match, so every tree reruns CI once after merge; behaviour is otherwise unchanged
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- All 7 touched YAML files parse cleanly (`yq`).
- HMAC derivation snippet smoke-tested locally: key format `passed-<check>-<tree>-<sig16>`, length 104 ≪ the 512-char cache-key limit; different secret ⇒ different signature.
- This PR's own CI exercises the guard end-to-end (including the actionlint job over the edited workflows).

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A — CI-only; no node/runtime artefacts change

## Links

<!-- none — CI hardening, no tracking issue -->
