### PR TITLE
fix(toolkit): return errors instead of panicking in single-tx and fetcher

### DIFF
--- a/changes/toolkit/changed/single-tx-graceful-errors.md
+++ b/changes/toolkit/changed/single-tx-graceful-errors.md
@@ -1,0 +1,14 @@
+#toolkit
+# Return errors instead of panicking in single-tx and fetcher
+
+`generate-txs single-tx` panicked when the source wallet had insufficient
+shielded coins or unshielded UTXOs. These are expected runtime conditions for
+a CLI, so they now surface as structured errors (`SingleTxError`, mirroring
+`BatchSingleTxError`) with a clean non-zero exit; proving failures and empty
+transactions are converted the same way. Also saturate two subtractions in the
+`fetch_from_rpc` summary log that underflowed (debug-build panic) when the
+queried node's finalized height was below the cached minimum. Found by
+Antithesis fault testing.
+
+Closes: #1821
+PR: https://github.com/midnightntwrk/midnight-node/pull/1822

--- a/changes/toolkit/changed/single-tx-graceful-errors.md
+++ b/changes/toolkit/changed/single-tx-graceful-errors.md
@@ -5,10 +5,10 @@
 shielded coins or unshielded UTXOs. These are expected runtime conditions for
 a CLI, so they now surface as structured errors (`SingleTxError`, mirroring
 `BatchSingleTxError`) with a clean non-zero exit; proving failures and empty
-transactions are converted the same way. Also saturate two subtractions in the
-`fetch_from_rpc` summary log that underflowed (debug-build panic) when the
-queried node's finalized height was below the cached minimum. Found by
-Antithesis fault testing.
+transactions are converted the same way. Also saturate the height-span
+arithmetic in `fetch_from_rpc` (job sizing, progress log, and summary log),
+which underflowed (debug-build panic) when the queried node's finalized height
+was below the cached watermark. Found by Antithesis fault testing.
 
 Closes: #1821
 PR: https://github.com/midnightntwrk/midnight-node/pull/1822

--- a/util/toolkit/src/fetcher.rs
+++ b/util/toolkit/src/fetcher.rs
@@ -162,14 +162,18 @@ pub async fn fetch_from_rpc(
 	let max_height = finalized_height + 1;
 	let min_height = fetch_storage.get_highest_verified_block(chain_id).await.unwrap_or(0);
 
-	let blocks_per_job = if (max_height - min_height) < BLOCKS_PER_JOB * num_workers as u64 {
-		(max_height - min_height).div_ceil(num_workers as u64).max(5)
+	// The cache watermark can be ahead of this node's finalized height (e.g. the
+	// node lags behind the node the cache was built from); saturate to zero so we
+	// serve from cache instead of underflowing.
+	let fetch_span = max_height.saturating_sub(min_height);
+	let blocks_per_job = if fetch_span < BLOCKS_PER_JOB * num_workers as u64 {
+		fetch_span.div_ceil(num_workers as u64).max(5)
 	} else {
 		BLOCKS_PER_JOB
 	};
 
 	// Cap workers to the number of jobs to avoid unnecessary connections.
-	let num_jobs = (max_height - min_height).div_ceil(blocks_per_job);
+	let num_jobs = fetch_span.div_ceil(blocks_per_job);
 	let num_workers = num_workers.min(num_jobs as usize).max(1);
 
 	let mut join_set: JoinSet<Result<TaskResult, FetchError>> = JoinSet::new();
@@ -284,7 +288,7 @@ pub async fn fetch_from_rpc(
 
 	log::debug!("final verify step");
 	// Receive final jobs
-	let num_jobs = (max_height - min_height).div_ceil(blocks_per_job);
+	let num_jobs = fetch_span.div_ceil(blocks_per_job);
 	let mut jobs = Vec::with_capacity(num_jobs as usize);
 	let mut received = 0;
 	let mut fetch_workers_exited = 0;
@@ -316,7 +320,7 @@ pub async fn fetch_from_rpc(
 			job = final_jobs_rx.recv() => {
 				jobs.push(job.expect("..."));
 				received += 1;
-				log::info!("fetch progress: {:.1}% of {} blocks complete", (received as f64 / num_jobs as f64) * 100f64, max_height - min_height);
+				log::info!("fetch progress: {:.1}% of {} blocks complete", (received as f64 / num_jobs as f64) * 100f64, fetch_span);
 			}
 		}
 	}

--- a/util/toolkit/src/fetcher.rs
+++ b/util/toolkit/src/fetcher.rs
@@ -353,10 +353,14 @@ pub async fn fetch_from_rpc(
 	let blocks = read_blocks_from_cache(chain_id, fetch_storage).await?;
 	log::debug!("[perf] fetch_from_rpc read_blocks_from_cache took {:?}", t.elapsed());
 
+	// The queried node can report a finalized height below the cached minimum
+	// (e.g. it lags behind the node the cache was built from), so saturate to
+	// avoid underflow.
+	let fetched_blocks = finalized_height.saturating_sub(min_height);
 	log::info!(
 		"fetched {} blocks, read {} blocks from cache, total transactions: {}",
-		finalized_height - min_height,
-		blocks.len() - (finalized_height - min_height) as usize,
+		fetched_blocks,
+		blocks.len().saturating_sub(fetched_blocks as usize),
 		blocks.iter().fold(0, |acc, b| acc + b.transactions.len()),
 	);
 

--- a/util/toolkit/src/fetcher.rs
+++ b/util/toolkit/src/fetcher.rs
@@ -351,20 +351,21 @@ pub async fn fetch_from_rpc(
 
 	log::debug!("[perf] fetch_from_rpc RPC pipeline took {:?}", t_rpc_total.elapsed());
 
-	// Set highest verified height for quicker fetch next time
-	fetch_storage.set_highest_verified_block(chain_id, finalized_height).await;
+	// Set highest verified height for quicker fetch next time. Never lower it:
+	// when the queried node lags the cache, blocks beyond its finalized height
+	// are already verified, and read_blocks_from_cache bases its read range on
+	// this value — lowering it would hide them.
+	if finalized_height > min_height {
+		fetch_storage.set_highest_verified_block(chain_id, finalized_height).await;
+	}
 	let t = std::time::Instant::now();
 	let blocks = read_blocks_from_cache(chain_id, fetch_storage).await?;
 	log::debug!("[perf] fetch_from_rpc read_blocks_from_cache took {:?}", t.elapsed());
 
-	// The queried node can report a finalized height below the cached minimum
-	// (e.g. it lags behind the node the cache was built from), so saturate to
-	// avoid underflow.
-	let fetched_blocks = finalized_height.saturating_sub(min_height);
 	log::info!(
 		"fetched {} blocks, read {} blocks from cache, total transactions: {}",
-		fetched_blocks,
-		blocks.len().saturating_sub(fetched_blocks as usize),
+		fetch_span,
+		blocks.len().saturating_sub(fetch_span as usize),
 		blocks.iter().fold(0, |acc, b| acc + b.transactions.len()),
 	);
 

--- a/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
@@ -13,7 +13,6 @@
 
 use std::{
 	collections::{HashMap, HashSet},
-	convert::Infallible,
 	sync::Arc,
 };
 
@@ -39,6 +38,18 @@ use midnight_node_ledger_helpers::fork::raw_block_data::SerializedTxBatches;
 
 pub(crate) const MAX_GUARANTEED_OUTPUTS: usize = 2;
 const MAX_GUARANTEED_INPUTS_OUTPUTS: usize = 3;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SingleTxError {
+	#[error("failed to select unshielded UTXOs for transfer: {0}")]
+	UtxoSelection(#[from] UtxoSelectionError),
+	#[error("insufficient shielded coins for transfer: {0}")]
+	ShieldedCoinSelection(#[from] ShieldedCoinSelectionError),
+	#[error("proving failed: {0}")]
+	ProvingFailed(String),
+	#[error("transaction is empty: no valid destination addresses were resolved into outputs")]
+	EmptyTransaction,
+}
 
 pub struct SingleTxBuilder<C: BuilderContext<DefaultDB>> {
 	context: Arc<C>,
@@ -115,7 +126,7 @@ impl<C: BuilderContext<DefaultDB>> SingleTxBuilder<C> {
 
 #[async_trait]
 impl<C: BuilderContext<DefaultDB>> BuildTxs for SingleTxBuilder<C> {
-	type Error = Infallible;
+	type Error = SingleTxError;
 
 	async fn build_txs_from(
 		&self,
@@ -139,8 +150,7 @@ impl<C: BuilderContext<DefaultDB>> BuildTxs for SingleTxBuilder<C> {
 				self.source_seed.clone(),
 				self.shielded_outputs.iter().map(clone_shielded_spec).collect(),
 				self.coin_selection,
-			)
-			.expect("insufficient shielded coins for transfer");
+			)?;
 			if offer.outputs.len() > MAX_GUARANTEED_OUTPUTS {
 				tx_info.set_fallible_offers(HashMap::from([(1, offer)]));
 			} else {
@@ -156,10 +166,7 @@ impl<C: BuilderContext<DefaultDB>> BuildTxs for SingleTxBuilder<C> {
 				&self.input_utxos,
 				self.coin_selection,
 			)
-			.await
-			.unwrap_or_else(|error| {
-				panic!("failed to select unshielded UTXOs for transfer: {error}")
-			});
+			.await?;
 			tx_info.set_intents(intents);
 		}
 
@@ -170,10 +177,13 @@ impl<C: BuilderContext<DefaultDB>> BuildTxs for SingleTxBuilder<C> {
 			log::error!(
 				"transaction is empty! No valid destination_addresses were resolved into outputs"
 			);
-			panic!("transaction empty");
+			return Err(SingleTxError::EmptyTransaction);
 		}
 
-		let tx = tx_info.prove().await.expect("Balancing TX failed");
+		let tx = tx_info
+			.prove()
+			.await
+			.map_err(|e| SingleTxError::ProvingFailed(format!("{e}")))?;
 
 		let tx_with_context = TransactionWithContext::new(tx, None);
 


### PR DESCRIPTION
# Overview

During Antithesis fault-injection runs (shielded QA), `midnight-node-toolkit` failed the 'No Rust Panics' property with three distinct panics (#1821):

1. `single_tx.rs:161` — `panic!` when the source wallet has insufficient unshielded UTXOs
2. `single_tx.rs:143` — `.expect()` when the source wallet has insufficient shielded coins
3. `fetcher.rs:358` — `attempt to subtract with overflow` in the `fetch_from_rpc` summary log when the queried node's finalized height is below the cached minimum (debug builds only)
4. `fetcher.rs:165` — same underflow in the job-sizing arithmetic, hit in a follow-up validation run when the queried node lagged the cache watermark by more than one block (the line-358 case only covered a lag of exactly one)

Insufficient funds is an expected runtime condition for a CLI, not a programming error. `SingleTxBuilder` now uses a `SingleTxError` thiserror enum (mirroring the existing `BatchSingleTxError` pattern) instead of `type Error = Infallible`: shielded/unshielded coin-selection failures propagate via `#[from]`, proving failures map to `ProvingFailed`, and the empty-transaction case returns `EmptyTransaction`. Errors reach the CLI as a message + non-zero exit through the existing `DynamicError` wrapper. Since the file lives in `builders/common/`, the fix covers the v7/v8/v9 builder instantiations.

All height-span arithmetic in `fetch_from_rpc` (job sizing, receive-loop job count, progress log, summary log) now computes the span once via `saturating_sub`; a zero span degrades to the existing 0-jobs path, which serves blocks from cache.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file
- [ ] If the changes introduce a new feature, I have bumped the node minor version — N/A, bugfix only
- [ ] Update documentation (if relevant) — N/A
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed — N/A
- [x] No new todos introduced

## 🧪 Testing Evidence

- `cargo check -p midnight-node-toolkit` clean
- `cargo test -p midnight-node-toolkit --lib`: 109 passed, 0 failed (includes `test_generation::single_tx` and `test_batch_single_tx`)
- Panics originally reproduced by the Antithesis tx-spammer workload driving `generate-txs single-tx` against a 5-node network under fault injection
- A follow-up Antithesis run with the first commit confirmed panics 1–3 no longer occur, and surfaced panic 4 (fixed in the second commit)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other
- [x] N/A — toolkit CLI only

## Links

Closes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
