### PR TITLE
fix(node): re-anchor cNIGHT observation window near tip on from-genesis sync

### DIFF
--- a/changes/node/changed/cnight-observation-window-lookback.md
+++ b/changes/node/changed/cnight-observation-window-lookback.md
@@ -1,34 +1,31 @@
 #node
-# Shrink the cNIGHT observation sliding-window default so from-genesis syncs stay narrow
+# Re-anchor the cNIGHT observation window near tip instead of a fixed lookback
 
-Lower `DEFAULT_WINDOW_SIZE` for the cNIGHT observation sliding window from
-100 000 to 10 000 Cardano blocks.
+The cNIGHT observation sliding window trims to a lookback behind the follower in
+steady state. That lookback was a large fixed window, and a node syncing from
+genesis advances the follower contiguously and never takes the narrow re-anchor
+a restart-with-state node does — so it trailed the tip by the whole window
+forever instead of tracking it. A from-genesis validator ended up holding a
+~100k-block in-memory window (hundreds of MB) where a restarted peer holds a few
+thousand, with the retained width depending on how the node happened to sync
+rather than on the chain.
 
-`plan_refresh` trims the window to `follower - window_size` during steady
-operation, so `window_size` is really a reorg-safety *lookback* behind the
-follower, not a general cache size. A validator that syncs **from genesis**
-advances the follower contiguously the whole way, so it never hits the narrow
-"jump" re-anchor that a restart-with-state node takes — it stays in the
-contiguous branch and keeps `window_size` blocks behind the follower forever.
-At the old 100 000 default (100× the runtime's own observation window of 1000)
-that meant a permanent ~100k-wide window: every refresh queried a Cardano range
-many times wider than a healthy peer's, heavy enough to overrun the 6s slot and
-starve block authoring (`Discarding proposal … block production took too long`),
-silently degrading the authority until a manual restart.
+Re-anchor the window to a small reorg-safety margin (the Cardano security
+parameter plus stability margin) behind the follower instead. The runtime only
+ever reads at or ahead of the follower, so anything further back is never served
+from cache — the only reason to keep any is a reorg, which can't run deeper than
+that margin, and deeper re-reads fall back to the live source. A from-genesis
+node now converges to the same near-tip window as a restart-with-state one.
 
-The lookback is never read from cache — the runtime only queries
-`[start_position, tip]`, at or ahead of the follower, so forward sync never
-misses regardless of the value; the window only needs to cover backward-going
-reads (Cardano reorgs, block re-imports). 10 000 is 10× the runtime window and
-comfortably above Cardano's security parameter k (~2160), covering the deepest
-possible reorg with headroom while cutting the steady-state window (and its
-memory) ~10×. This makes a from-genesis node converge to roughly the same
-narrow window a restart-with-state node already gets. No consensus impact — the
-window is a node-local, in-memory artifact; out-of-window reads fall back to the
-live db source.
+The fixed-size window knob (`cnight_observation_window_size`) and its default are
+removed: the reorg margin the node already tracks is the right lookback, so there
+is nothing to tune. Existing configs that still carry the key keep loading (it is
+ignored). No consensus impact — the window is node-local.
 
-Operators can still tune this per node via `cnight_observation_window_size`
-(env `CNIGHT_OBSERVATION_WINDOW_SIZE`).
+Note: the per-refresh db-sync pull is already incremental, so the oversized
+window cost memory rather than steady-state query time; the slow refreshes
+reported in the issue were during a concurrent db-sync incident, not a
+window-only effect.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1836
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1835

--- a/changes/node/changed/cnight-observation-window-lookback.md
+++ b/changes/node/changed/cnight-observation-window-lookback.md
@@ -1,0 +1,34 @@
+#node
+# Shrink the cNIGHT observation sliding-window default so from-genesis syncs stay narrow
+
+Lower `DEFAULT_WINDOW_SIZE` for the cNIGHT observation sliding window from
+100 000 to 10 000 Cardano blocks.
+
+`plan_refresh` trims the window to `follower - window_size` during steady
+operation, so `window_size` is really a reorg-safety *lookback* behind the
+follower, not a general cache size. A validator that syncs **from genesis**
+advances the follower contiguously the whole way, so it never hits the narrow
+"jump" re-anchor that a restart-with-state node takes — it stays in the
+contiguous branch and keeps `window_size` blocks behind the follower forever.
+At the old 100 000 default (100× the runtime's own observation window of 1000)
+that meant a permanent ~100k-wide window: every refresh queried a Cardano range
+many times wider than a healthy peer's, heavy enough to overrun the 6s slot and
+starve block authoring (`Discarding proposal … block production took too long`),
+silently degrading the authority until a manual restart.
+
+The lookback is never read from cache — the runtime only queries
+`[start_position, tip]`, at or ahead of the follower, so forward sync never
+misses regardless of the value; the window only needs to cover backward-going
+reads (Cardano reorgs, block re-imports). 10 000 is 10× the runtime window and
+comfortably above Cardano's security parameter k (~2160), covering the deepest
+possible reorg with headroom while cutting the steady-state window (and its
+memory) ~10×. This makes a from-genesis node converge to roughly the same
+narrow window a restart-with-state node already gets. No consensus impact — the
+window is a node-local, in-memory artifact; out-of-window reads fall back to the
+live db source.
+
+Operators can still tune this per node via `cnight_observation_window_size`
+(env `CNIGHT_OBSERVATION_WINDOW_SIZE`).
+
+PR:
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1835

--- a/changes/node/changed/cnight-observation-window-lookback.md
+++ b/changes/node/changed/cnight-observation-window-lookback.md
@@ -1,31 +1,20 @@
 #node
-# Re-anchor the cNIGHT observation window near tip instead of a fixed lookback
+# Re-anchor the cNIGHT observation window near tip
 
-The cNIGHT observation sliding window trims to a lookback behind the follower in
-steady state. That lookback was a large fixed window, and a node syncing from
-genesis advances the follower contiguously and never takes the narrow re-anchor
-a restart-with-state node does — so it trailed the tip by the whole window
-forever instead of tracking it. A from-genesis validator ended up holding a
-~100k-block in-memory window (hundreds of MB) where a restarted peer holds a few
-thousand, with the retained width depending on how the node happened to sync
-rather than on the chain.
+A validator that syncs from genesis kept its cNIGHT observation cache window at
+full width behind the tip forever, instead of tracking the tip the way a
+restarted-with-state node does — holding ~100k Cardano blocks in memory where a
+restarted peer holds a few thousand.
 
-Re-anchor the window to a small reorg-safety margin (the Cardano security
-parameter plus stability margin) behind the follower instead. The runtime only
-ever reads at or ahead of the follower, so anything further back is never served
-from cache — the only reason to keep any is a reorg, which can't run deeper than
-that margin, and deeper re-reads fall back to the live source. A from-genesis
-node now converges to the same near-tip window as a restart-with-state one.
+The window now keeps only a reorg-safety margin (`cardano_security_parameter +
+block_stability_margin`, the deepest a Cardano reorg can go) behind the follower.
+The runtime never reads further back, and deeper re-reads fall back to the live
+source, so caching more is pointless. From-genesis and restarted nodes converge
+to the same window.
 
-The fixed-size window knob (`cnight_observation_window_size`) and its default are
-removed: the reorg margin the node already tracks is the right lookback, so there
-is nothing to tune. Existing configs that still carry the key keep loading (it is
-ignored). No consensus impact — the window is node-local.
-
-Note: the per-refresh db-sync pull is already incremental, so the oversized
-window cost memory rather than steady-state query time; the slow refreshes
-reported in the issue were during a concurrent db-sync incident, not a
-window-only effect.
+This removes the `cnight_observation_window_size` config knob and its default as
+redundant; configs that still set it keep loading (the key is ignored).
+Node-local, no consensus impact.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1836
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1835

--- a/changes/node/changed/cnight-observation-window-lookback.md
+++ b/changes/node/changed/cnight-observation-window-lookback.md
@@ -30,5 +30,5 @@ live db source.
 Operators can still tune this per node via `cnight_observation_window_size`
 (env `CNIGHT_OBSERVATION_WINDOW_SIZE`).
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1836
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1835

--- a/node/src/cfg/midnight_cfg/mod.rs
+++ b/node/src/cfg/midnight_cfg/mod.rs
@@ -29,13 +29,6 @@ pub enum StorageSeparation {
 	Unified,
 }
 
-/// Default for `cnight_observation_window_size` when not present in config.
-/// Applied by serde on deserialization (the path that builds a live config);
-/// the derived `Default` is only used by a key-enumeration test helper.
-fn default_cnight_observation_window_size() -> u32 {
-	midnight_primitives_mainchain_follower::data_source::DEFAULT_WINDOW_SIZE
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Validate, Documented)]
 #[validate(custom = main_chain_follower_vars)]
 #[validate(custom = mainchain_epoch_invariants)]
@@ -98,18 +91,6 @@ pub struct MidnightCfg {
 	/// Path to federated authority config file (contains council and technical committee addresses and policy IDs)
 	#[validate(custom = |s| maybe(s, path_exists))]
 	pub federated_authority_config_file: Option<String>,
-
-	/// Cardano blocks the cNIGHT observation sliding window retains *behind* the
-	/// follower — a reorg-safety lookback, not a general cache size. Bigger =
-	/// more backward-going reads (Cardano reorgs, block re-imports) hit the
-	/// in-memory cache instead of db-sync, at the cost of memory and a
-	/// proportionally heavier refresh query; smaller = less memory and lighter
-	/// refreshes but more db-fallback calls on reorgs. Forward sync never misses
-	/// regardless. Directly bounds the steady-state window width, so keep it a
-	/// modest multiple of the runtime observation window rather than oversizing
-	/// it. Defaults to `DEFAULT_WINDOW_SIZE` when unset.
-	#[serde(default = "default_cnight_observation_window_size")]
-	pub cnight_observation_window_size: u32,
 
 	/// Size of ledger storage cache (number of nodes)
 	pub storage_cache_size: usize,

--- a/node/src/cfg/midnight_cfg/mod.rs
+++ b/node/src/cfg/midnight_cfg/mod.rs
@@ -99,10 +99,15 @@ pub struct MidnightCfg {
 	#[validate(custom = |s| maybe(s, path_exists))]
 	pub federated_authority_config_file: Option<String>,
 
-	/// Cardano blocks to keep in the cNIGHT observation sliding window.
-	/// Bigger = fewer cache misses during sync but more memory; smaller =
-	/// less memory but more db-fallback calls. Defaults to
-	/// `DEFAULT_WINDOW_SIZE` (100k) when unset.
+	/// Cardano blocks the cNIGHT observation sliding window retains *behind* the
+	/// follower — a reorg-safety lookback, not a general cache size. Bigger =
+	/// more backward-going reads (Cardano reorgs, block re-imports) hit the
+	/// in-memory cache instead of db-sync, at the cost of memory and a
+	/// proportionally heavier refresh query; smaller = less memory and lighter
+	/// refreshes but more db-fallback calls on reorgs. Forward sync never misses
+	/// regardless. Directly bounds the steady-state window width, so keep it a
+	/// modest multiple of the runtime observation window rather than oversizing
+	/// it. Defaults to `DEFAULT_WINDOW_SIZE` when unset.
 	#[serde(default = "default_cnight_observation_window_size")]
 	pub cnight_observation_window_size: u32,
 

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -285,7 +285,6 @@ pub fn cnight_follower_genesis_from_storage(
 /// resolve the cNIGHT addresses we query db-sync for. Falls back to the per-call
 /// db-backed source otherwise; sync is significantly slower in that case.
 async fn build_cnight_observation_data_source(
-	cnight_observation_window_size: u32,
 	cnight_follower_genesis: Option<(CNightAddresses, CardanoPosition)>,
 	cnight_observation_pool: Pool<Postgres>,
 	db_sync_block_data_source_config: &DbSyncBlockDataSourceConfig,
@@ -309,7 +308,12 @@ async fn build_cnight_observation_data_source(
 			// history is not re-pulled.
 			let next_pos: u32 = next_cardano_position.block_number;
 			let init_horizon = next_pos.saturating_sub(1);
-			let window_size: u32 = cnight_observation_window_size;
+			// The window keeps a reorg-margin lookback behind the follower, so it
+			// tracks the tip once caught up rather than trailing it by a fixed
+			// width (see `plan_refresh`).
+			let stability_margin = db_sync_block_data_source_config
+				.cardano_security_parameter
+				.saturating_add(db_sync_block_data_source_config.block_stability_margin);
 
 			// Empty initial cache so the node starts up immediately. The
 			// first follower call will see `tip_pos > horizon`, delegate
@@ -317,11 +321,8 @@ async fn build_cnight_observation_data_source(
 			// refresh that populates the window. Subsequent calls hit
 			// the cache.
 			log::info!(
-				"cNIGHT observation: sliding window cache (anchor = Cardano block {next_pos}, window = {window_size})"
+				"cNIGHT observation: sliding window cache (anchor = Cardano block {next_pos}, lookback = {stability_margin})"
 			);
-			let stability_margin = db_sync_block_data_source_config
-				.cardano_security_parameter
-				.saturating_add(db_sync_block_data_source_config.block_stability_margin);
 			let db_fallback = Arc::new(MidnightCNightObservationDataSourceImpl::new(
 				cnight_observation_pool.clone(),
 				midnight_metrics_opt.clone(),
@@ -332,7 +333,6 @@ async fn build_cnight_observation_data_source(
 				BulkCacheConfig {
 					window_start_block: init_horizon,
 					window_end_block: init_horizon,
-					window_size,
 					stability_margin,
 					pool: cnight_observation_pool,
 					db_fallback,
@@ -461,7 +461,6 @@ pub async fn create_cached_data_sources(
 				e
 			})?;
 	let cnight_observation = build_cnight_observation_data_source(
-		cfg.cnight_observation_window_size,
 		cnight_follower_genesis,
 		cnight_observation_pool,
 		&db_sync_block_data_source_config,

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
@@ -41,10 +41,31 @@ use std::sync::{Arc, Mutex};
 /// one shot.
 const LARGE_LIMIT: usize = 5_000_000;
 
-/// Default number of cardano blocks to keep in the sliding window when the
-/// node config doesn't override it. Memory cost ≈ 5 KB × events-per-block,
-/// so 100k blocks ≈ a few hundred MB on a busy chain.
-pub const DEFAULT_WINDOW_SIZE: u32 = 100_000;
+/// Default number of Cardano blocks the sliding window retains *behind* the
+/// follower when the node config doesn't override it.
+///
+/// This is a reorg-safety **lookback**, not a general cache size. Steady-state
+/// refreshes trim the window to `follower - window_size` (see [`plan_refresh`]),
+/// so `window_size` directly bounds how wide the window stays once the node has
+/// caught up. Forward sync never misses regardless of its value — the runtime
+/// only ever reads `[start_position, tip]`, i.e. at or ahead of the follower, so
+/// blocks behind the follower are never served from cache. A larger value only
+/// lets more *backward*-going reads (Cardano reorgs, block re-imports) hit the
+/// in-memory cache instead of falling back to db-sync.
+///
+/// Sized at 10× the runtime's own observation window
+/// (`CNightObservationApi::get_cardano_block_window_size` = 1000) and comfortably
+/// above Cardano's security parameter k (~2160), so it covers the deepest
+/// possible reorg with headroom. Memory cost ≈ 5 KB × events-per-block × window
+/// blocks, so 10k blocks ≈ tens of MB on a busy chain.
+///
+/// The previous default of 100_000 (100× the runtime window) pinned validators
+/// that synced from genesis at a ~100k-wide window: such a node advances the
+/// follower contiguously the whole way, never hits `plan_refresh`'s narrow jump
+/// re-anchor, and so keeps a 100k-block lookback permanently. Every refresh then
+/// queried a Cardano range far wider than a healthy peer's, overrunning the 6s
+/// slot and starving block authoring. See issue #1835.
+pub const DEFAULT_WINDOW_SIZE: u32 = 10_000;
 
 /// If the next-needed cardano position (`start_position`) is within this many
 /// blocks of the cache's `end`, kick an async refresh that slides the window
@@ -770,6 +791,43 @@ mod tests {
 		// behind the jump target (which would claim coverage over a gap).
 		let (from, start) = plan_refresh(99, 570_000, 0, Some(50), 100_000);
 		assert_eq!((from, start), (570_000, 570_000));
+	}
+
+	#[test]
+	fn plan_refresh_from_genesis_steady_state_tracks_follower_not_genesis() {
+		// Regression for #1835. A node that syncs from genesis advances the
+		// follower contiguously, so once it has caught up it is still in the
+		// contiguous branch (never the narrow jump re-anchor). The window must
+		// then trim to a bounded lookback behind the follower — NOT stay pinned
+		// at the genesis observation position (0), which is what produced the
+		// permanent ~100k-wide window.
+		let window_size = DEFAULT_WINDOW_SIZE;
+		let follower = 5_000_000;
+		let old_end = follower + 5; // cache prefetched slightly ahead → contiguous, no jump
+		let existing_start = 0; // worst case: window start still at genesis
+		let (from, start) =
+			plan_refresh(old_end, follower, existing_start, Some(follower), window_size);
+		// Contiguous: extend from just past the cached end.
+		assert_eq!(from, old_end + 1);
+		// Trim to a bounded lookback behind the follower, well past genesis.
+		assert_eq!(start, follower - window_size);
+		assert!(start > 0, "window must re-anchor near the follower, not stay at genesis");
+		// The retained lookback is exactly `window_size`, independent of how far
+		// the follower has travelled from genesis — the window width is bounded.
+		assert_eq!(follower - start, window_size);
+	}
+
+	#[test]
+	fn default_window_size_is_a_modest_reorg_lookback() {
+		// Regression guard for #1835. `DEFAULT_WINDOW_SIZE` is the steady-state
+		// lookback (see `plan_refresh`), so it must stay a modest multiple of the
+		// runtime's own observation window (1000) and above Cardano's security
+		// parameter k (~2160) — not the old 100_000, which pinned from-genesis
+		// validators at a ~100k-wide window and starved block authoring.
+		assert!(
+			(2_160..=20_000).contains(&DEFAULT_WINDOW_SIZE),
+			"DEFAULT_WINDOW_SIZE={DEFAULT_WINDOW_SIZE} is outside the sane reorg-safety lookback range"
+		);
 	}
 
 	#[test]

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
@@ -41,32 +41,6 @@ use std::sync::{Arc, Mutex};
 /// one shot.
 const LARGE_LIMIT: usize = 5_000_000;
 
-/// Default number of Cardano blocks the sliding window retains *behind* the
-/// follower when the node config doesn't override it.
-///
-/// This is a reorg-safety **lookback**, not a general cache size. Steady-state
-/// refreshes trim the window to `follower - window_size` (see [`plan_refresh`]),
-/// so `window_size` directly bounds how wide the window stays once the node has
-/// caught up. Forward sync never misses regardless of its value — the runtime
-/// only ever reads `[start_position, tip]`, i.e. at or ahead of the follower, so
-/// blocks behind the follower are never served from cache. A larger value only
-/// lets more *backward*-going reads (Cardano reorgs, block re-imports) hit the
-/// in-memory cache instead of falling back to db-sync.
-///
-/// Sized at 10× the runtime's own observation window
-/// (`CNightObservationApi::get_cardano_block_window_size` = 1000) and comfortably
-/// above Cardano's security parameter k (~2160), so it covers the deepest
-/// possible reorg with headroom. Memory cost ≈ 5 KB × events-per-block × window
-/// blocks, so 10k blocks ≈ tens of MB on a busy chain.
-///
-/// The previous default of 100_000 (100× the runtime window) pinned validators
-/// that synced from genesis at a ~100k-wide window: such a node advances the
-/// follower contiguously the whole way, never hits `plan_refresh`'s narrow jump
-/// re-anchor, and so keeps a 100k-block lookback permanently. Every refresh then
-/// queried a Cardano range far wider than a healthy peer's, overrunning the 6s
-/// slot and starving block authoring. See issue #1835.
-pub const DEFAULT_WINDOW_SIZE: u32 = 10_000;
-
 /// If the next-needed cardano position (`start_position`) is within this many
 /// blocks of the cache's `end`, kick an async refresh that slides the window
 /// forward.
@@ -261,11 +235,11 @@ pub struct BulkCachedCNightObservationDataSource {
 	/// cNIGHT addresses cached so the sliding-window refresh can re-run the
 	/// observation queries without re-reading the chainspec JSON.
 	cnight_addresses: CNightAddresses,
-	/// Cardano blocks to leave un-fetched past the requested target
-	/// (re-org safety). Equals `cardano_security_parameter + block_stability_margin`.
+	/// Cardano blocks to leave un-fetched past the requested target (re-org
+	/// safety), and the lookback the window keeps behind the follower so
+	/// reorg-depth re-reads stay in cache rather than hitting `db_fallback`.
+	/// Equals `cardano_security_parameter + block_stability_margin`.
 	stability_margin: u32,
-	/// Cardano blocks to keep in the sliding window.
-	window_size: u32,
 	/// Single-flight gate for sliding-window refreshes. The owned lock guard is
 	/// held by the in-flight refresh task; `try_lock_owned` failing means a
 	/// refresh is already running, so a new trigger is a no-op.
@@ -283,10 +257,9 @@ pub struct BulkCacheConfig {
 	/// Cardano block range the initial events cover: `[window_start_block, window_end_block]`.
 	pub window_start_block: u32,
 	pub window_end_block: u32,
-	/// Cardano blocks to keep in the sliding window.
-	pub window_size: u32,
 	/// Cardano blocks to leave un-fetched past the requested target (re-org
-	/// safety). Equals `cardano_security_parameter + block_stability_margin`.
+	/// safety), and the lookback the window keeps behind the follower. Equals
+	/// `cardano_security_parameter + block_stability_margin`.
 	pub stability_margin: u32,
 	/// db-sync connection used by the refresh and per-call block lookups.
 	pub pool: PgPool,
@@ -306,7 +279,6 @@ impl BulkCachedCNightObservationDataSource {
 		let BulkCacheConfig {
 			window_start_block,
 			window_end_block,
-			window_size,
 			stability_margin,
 			pool,
 			db_fallback,
@@ -323,7 +295,6 @@ impl BulkCachedCNightObservationDataSource {
 			db_fallback,
 			cnight_addresses,
 			stability_margin,
-			window_size,
 			refresh_in_flight: Arc::new(tokio::sync::Mutex::new(())),
 			metrics_opt,
 		}
@@ -350,7 +321,6 @@ impl BulkCachedCNightObservationDataSource {
 			last_observation: Arc::clone(&self.last_observation),
 			snapshot_start_block: Arc::clone(&self.snapshot_start_block),
 			snapshot_end_block: Arc::clone(&self.snapshot_end_block),
-			window_size: self.window_size,
 			stability_margin: self.stability_margin,
 		};
 
@@ -378,7 +348,6 @@ struct RefreshContext {
 	last_observation: Arc<Mutex<Option<LastObservation>>>,
 	snapshot_start_block: Arc<std::sync::RwLock<Option<u32>>>,
 	snapshot_end_block: Arc<std::sync::RwLock<Option<u32>>>,
-	window_size: u32,
 	stability_margin: u32,
 }
 
@@ -426,8 +395,13 @@ impl RefreshContext {
 			.lock()
 			.ok()
 			.and_then(|g| g.as_ref().map(|last| last.start_position.block_number));
-		let (from_block, new_window_start) =
-			plan_refresh(old_end, follower_anchor, existing_start, trim_anchor, self.window_size);
+		let (from_block, new_window_start) = plan_refresh(
+			old_end,
+			follower_anchor,
+			existing_start,
+			trim_anchor,
+			self.stability_margin,
+		);
 		// The stable clamp above can land below a jumped-forward `from_block`
 		// when db-sync lags; nothing useful to pull yet.
 		if target_end < from_block {
@@ -472,36 +446,38 @@ impl RefreshContext {
 /// `(from_block, new_window_start)`.
 ///
 /// Contiguous case (`follower_anchor <= old_end + 1`): extend from
-/// `old_end + 1`. The trim point is anchored on the follower's last-seen
-/// position, keeping `window_size` blocks behind it — during catchup the
-/// follower can be hundreds of thousands of blocks behind tip and still
-/// needs that history, so trimming behind `target_end - window_size` would
-/// silently drop required events. With no follower call observed yet
-/// (`trim_anchor` is `None`), keep the existing start — never move it
-/// backward, otherwise we'd lie about coverage.
+/// `old_end + 1` and trim the window to `reorg_margin` blocks behind the
+/// follower. The runtime only ever reads at or ahead of the follower, so
+/// anything further back is never served from cache; the only reason to keep
+/// any is a Cardano reorg, which can't run deeper than `reorg_margin` (deeper
+/// re-reads fall back to `db_fallback`). Trimming this close keeps a node that
+/// synced from genesis tracking the tip rather than trailing it by a whole
+/// window (#1835). With no follower call observed yet (`trim_anchor` is
+/// `None`), keep the existing start — never move it backward, or we'd lie
+/// about coverage.
 ///
 /// Jump case (`follower_anchor > old_end + 1`): the runtime has already
 /// processed past the window's end, so extending contiguously would re-pull
 /// history nobody needs — e.g. a node restarting after a full sync, where
 /// the window is still anchored at the genesis observation position.
-/// Restart the window at the follower's position instead; queries older than
-/// that (competing forks) are served by `db_fallback`. The window start must
-/// equal the pull start here: retaining the old (pre-gap) events while
-/// claiming coverage from an older `new_window_start` would leave a hole in
+/// Restart the window at the follower's position instead; older queries
+/// (competing forks) are served by `db_fallback`. The window start must equal
+/// the pull start here: the pre-gap events sit below the follower, so claiming
+/// coverage from an older `new_window_start` would leave a hole in
 /// `(old_end, follower_anchor)` that cache reads would silently miss.
 fn plan_refresh(
 	old_end: u32,
 	follower_anchor: u32,
 	existing_start: u32,
 	trim_anchor: Option<u32>,
-	window_size: u32,
+	reorg_margin: u32,
 ) -> (u32, u32) {
 	let contiguous_from = old_end.saturating_add(1);
 	if follower_anchor > contiguous_from {
 		return (follower_anchor, follower_anchor);
 	}
 	let new_window_start = match trim_anchor {
-		Some(anchor) => existing_start.max(anchor.saturating_sub(window_size)),
+		Some(anchor) => existing_start.max(anchor.saturating_sub(reorg_margin)),
 		None => existing_start,
 	};
 	(contiguous_from, new_window_start)
@@ -757,14 +733,14 @@ mod tests {
 	#[test]
 	fn plan_refresh_contiguous_extends_and_trims_behind_follower() {
 		// Window ends at 100, follower at 90: extend from 101, keep
-		// window_size=30 blocks behind the follower.
+		// reorg_margin=30 blocks behind the follower.
 		let (from, start) = plan_refresh(100, 90, 50, Some(90), 30);
 		assert_eq!((from, start), (101, 60));
 	}
 
 	#[test]
 	fn plan_refresh_contiguous_never_moves_start_backward() {
-		// Existing start (80) is already ahead of follower - window_size (60).
+		// Existing start (80) is already ahead of follower - reorg_margin (60).
 		let (from, start) = plan_refresh(100, 90, 80, Some(90), 30);
 		assert_eq!((from, start), (101, 80));
 	}
@@ -781,7 +757,7 @@ mod tests {
 		// Restart after a full sync: window still anchored at genesis
 		// (old_end=99) while the runtime has processed up to block 570_000.
 		// Pull and window both restart at the follower, not at genesis.
-		let (from, start) = plan_refresh(99, 570_000, 0, None, 100_000);
+		let (from, start) = plan_refresh(99, 570_000, 0, None, 2_160);
 		assert_eq!((from, start), (570_000, 570_000));
 	}
 
@@ -789,45 +765,27 @@ mod tests {
 	fn plan_refresh_jump_ignores_stale_trim_anchor() {
 		// A stale last_observation must not pull the window start back
 		// behind the jump target (which would claim coverage over a gap).
-		let (from, start) = plan_refresh(99, 570_000, 0, Some(50), 100_000);
+		let (from, start) = plan_refresh(99, 570_000, 0, Some(50), 2_160);
 		assert_eq!((from, start), (570_000, 570_000));
 	}
 
 	#[test]
 	fn plan_refresh_from_genesis_steady_state_tracks_follower_not_genesis() {
-		// Regression for #1835. A node that syncs from genesis advances the
-		// follower contiguously, so once it has caught up it is still in the
-		// contiguous branch (never the narrow jump re-anchor). The window must
-		// then trim to a bounded lookback behind the follower — NOT stay pinned
-		// at the genesis observation position (0), which is what produced the
-		// permanent ~100k-wide window.
-		let window_size = DEFAULT_WINDOW_SIZE;
+		// A from-genesis node stays in the contiguous branch even once caught up,
+		// so it must trim to the reorg-margin lookback behind the follower, not
+		// stay pinned at genesis (the old cause of the permanent wide window,
+		// #1835).
+		let reorg_margin = 2_160;
 		let follower = 5_000_000;
-		let old_end = follower + 5; // cache prefetched slightly ahead → contiguous, no jump
-		let existing_start = 0; // worst case: window start still at genesis
+		let old_end = follower + 5; // cache slightly ahead → contiguous, not a jump
+		let existing_start = 0; // worst case: still at genesis
 		let (from, start) =
-			plan_refresh(old_end, follower, existing_start, Some(follower), window_size);
-		// Contiguous: extend from just past the cached end.
+			plan_refresh(old_end, follower, existing_start, Some(follower), reorg_margin);
 		assert_eq!(from, old_end + 1);
-		// Trim to a bounded lookback behind the follower, well past genesis.
-		assert_eq!(start, follower - window_size);
-		assert!(start > 0, "window must re-anchor near the follower, not stay at genesis");
-		// The retained lookback is exactly `window_size`, independent of how far
-		// the follower has travelled from genesis — the window width is bounded.
-		assert_eq!(follower - start, window_size);
-	}
-
-	#[test]
-	fn default_window_size_is_a_modest_reorg_lookback() {
-		// Regression guard for #1835. `DEFAULT_WINDOW_SIZE` is the steady-state
-		// lookback (see `plan_refresh`), so it must stay a modest multiple of the
-		// runtime's own observation window (1000) and above Cardano's security
-		// parameter k (~2160) — not the old 100_000, which pinned from-genesis
-		// validators at a ~100k-wide window and starved block authoring.
-		assert!(
-			(2_160..=20_000).contains(&DEFAULT_WINDOW_SIZE),
-			"DEFAULT_WINDOW_SIZE={DEFAULT_WINDOW_SIZE} is outside the sane reorg-safety lookback range"
-		);
+		assert_eq!(start, follower - reorg_margin);
+		assert!(start > 0, "window must track the follower, not stay at genesis");
+		// Lookback is exactly the reorg margin, independent of distance travelled.
+		assert_eq!(follower - start, reorg_margin);
 	}
 
 	#[test]

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
@@ -235,10 +235,11 @@ pub struct BulkCachedCNightObservationDataSource {
 	/// cNIGHT addresses cached so the sliding-window refresh can re-run the
 	/// observation queries without re-reading the chainspec JSON.
 	cnight_addresses: CNightAddresses,
-	/// Cardano blocks to leave un-fetched past the requested target (re-org
-	/// safety), and the lookback the window keeps behind the follower so
-	/// reorg-depth re-reads stay in cache rather than hitting `db_fallback`.
-	/// Equals `cardano_security_parameter + block_stability_margin`.
+	/// Cardano reorg depth (`cardano_security_parameter + block_stability_margin`).
+	/// Used two ways: the margin left un-fetched past a refresh's target (so
+	/// proactive look-ahead never caches rollback-prone blocks), and the lookback
+	/// kept behind the follower (so a reorg that rewinds the follower is still
+	/// served from cache instead of `db_fallback`).
 	stability_margin: u32,
 	/// Single-flight gate for sliding-window refreshes. The owned lock guard is
 	/// held by the in-flight refresh task; `try_lock_owned` failing means a
@@ -257,9 +258,9 @@ pub struct BulkCacheConfig {
 	/// Cardano block range the initial events cover: `[window_start_block, window_end_block]`.
 	pub window_start_block: u32,
 	pub window_end_block: u32,
-	/// Cardano blocks to leave un-fetched past the requested target (re-org
-	/// safety), and the lookback the window keeps behind the follower. Equals
-	/// `cardano_security_parameter + block_stability_margin`.
+	/// Cardano reorg depth (`cardano_security_parameter + block_stability_margin`).
+	/// Bounds both the refresh look-ahead and the window's lookback behind the
+	/// follower.
 	pub stability_margin: u32,
 	/// db-sync connection used by the refresh and per-call block lookups.
 	pub pool: PgPool,
@@ -446,25 +447,26 @@ impl RefreshContext {
 /// `(from_block, new_window_start)`.
 ///
 /// Contiguous case (`follower_anchor <= old_end + 1`): extend from
-/// `old_end + 1` and trim the window to `reorg_margin` blocks behind the
-/// follower. The runtime only ever reads at or ahead of the follower, so
-/// anything further back is never served from cache; the only reason to keep
-/// any is a Cardano reorg, which can't run deeper than `reorg_margin` (deeper
-/// re-reads fall back to `db_fallback`). Trimming this close keeps a node that
-/// synced from genesis tracking the tip rather than trailing it by a whole
-/// window (#1835). With no follower call observed yet (`trim_anchor` is
-/// `None`), keep the existing start — never move it backward, or we'd lie
-/// about coverage.
+/// `old_end + 1`, and trim the window's start to `reorg_margin` blocks behind
+/// the follower. The runtime only ever reads at or ahead of the follower, so
+/// blocks further back are never served from the cache — the one thing that
+/// could need them is a reorg, which can't rewind deeper than `reorg_margin`
+/// (a deeper re-read just falls back to `db_fallback`). Trimming this close is
+/// what keeps a node that synced from genesis tracking the tip instead of
+/// trailing it by a whole window (#1835). The start only ever moves forward:
+/// `existing_start.max(..)` never rewinds it — that would claim coverage the
+/// cache has already dropped — and with no follower position observed yet
+/// (`trim_anchor` is `None`) it stays put.
 ///
-/// Jump case (`follower_anchor > old_end + 1`): the runtime has already
-/// processed past the window's end, so extending contiguously would re-pull
-/// history nobody needs — e.g. a node restarting after a full sync, where
-/// the window is still anchored at the genesis observation position.
-/// Restart the window at the follower's position instead; older queries
-/// (competing forks) are served by `db_fallback`. The window start must equal
-/// the pull start here: the pre-gap events sit below the follower, so claiming
-/// coverage from an older `new_window_start` would leave a hole in
-/// `(old_end, follower_anchor)` that cache reads would silently miss.
+/// Jump case (`follower_anchor > old_end + 1`): the runtime is already past the
+/// window's end, so extending contiguously would re-pull history nobody needs
+/// — e.g. a node restarting after a full sync with its window still anchored at
+/// the genesis observation position. Restart the window at the follower
+/// instead; older queries (competing forks) fall back to `db_fallback`. Here
+/// the window start must equal the pull start: the retained events sit below
+/// the gap, so a smaller `new_window_start` would claim `(old_end,
+/// follower_anchor)` while holding nothing there — a hole cache reads would
+/// silently miss.
 fn plan_refresh(
 	old_end: u32,
 	follower_anchor: u32,

--- a/primitives/mainchain-follower/src/data_source/mod.rs
+++ b/primitives/mainchain-follower/src/data_source/mod.rs
@@ -31,7 +31,7 @@ pub use cnight_observation::{
 	TxPosition,
 };
 pub use cnight_observation_bulk::{
-	BulkCacheConfig, BulkCachedCNightObservationDataSource, DEFAULT_WINDOW_SIZE, bulk_pull,
+	BulkCacheConfig, BulkCachedCNightObservationDataSource, bulk_pull,
 };
 pub use cnight_observation_mock::CNightObservationDataSourceMock;
 pub use federated_authority_observation::FederatedAuthorityObservationDataSourceImpl;

--- a/primitives/mainchain-follower/tests/cnight_equivalence.rs
+++ b/primitives/mainchain-follower/tests/cnight_equivalence.rs
@@ -50,7 +50,7 @@ use midnight_primitives_cnight_observation::{
 	CNightAddresses, CardanoPosition, TimestampUnixMillis,
 };
 use midnight_primitives_mainchain_follower::data_source::{
-	BulkCacheConfig, BulkCachedCNightObservationDataSource, DEFAULT_WINDOW_SIZE,
+	BulkCacheConfig, BulkCachedCNightObservationDataSource,
 	MidnightCNightObservationDataSourceImpl, bulk_pull,
 };
 use midnight_primitives_mainchain_follower::inherent_provider::MidnightCNightObservationDataSource;
@@ -162,7 +162,6 @@ async fn bulk_source_matches_standard_over_block_range() {
 		BulkCacheConfig {
 			window_start_block: window_from,
 			window_end_block: window_to,
-			window_size: DEFAULT_WINDOW_SIZE,
 			stability_margin: 0, // irrelevant for a pre-populated, static window
 			pool: pool.clone(),
 			db_fallback,


### PR DESCRIPTION
# Overview

A validator that syncs from genesis ends up holding an oversized in-memory cNIGHT observation window that never narrows, unlike a restart-with-state node.

The observation sliding window trims to a lookback behind the follower in steady state. That lookback was a large fixed window. On a restart with state the cache starts behind the runtime and re-anchors narrowly near tip; but a from-genesis node advances the follower contiguously the whole way, never takes that narrow re-anchor, and so trails the tip by the entire window forever. It ends up holding a ~100k-block window (hundreds of MB) where a restarted peer holds a few thousand, with the retained width depending on how the node happened to sync rather than on the chain.

## Fix

Re-anchor the window to a small reorg-safety margin behind the follower — the Cardano security parameter plus stability margin (the maximum reorg depth), which the node already computes. The runtime only ever reads at or ahead of the follower, so anything further back is never served from cache; the only reason to keep any is a reorg, and reorgs can't run deeper than that margin (deeper re-reads fall back to the live source). A from-genesis node now converges to the same near-tip window as a restart-with-state one.

This makes the fixed-size window knob redundant, so `cnight_observation_window_size` (and `DEFAULT_WINDOW_SIZE`) are removed — the reorg margin the node already tracks is the right lookback, and there's nothing to tune. Existing configs that still carry the key keep loading (it's ignored; no `deny_unknown_fields`).

No consensus/correctness impact: the window is node-local and out-of-window reads fall back to the live db-sync source.

## Scope / note on the latency figures in #1835

The per-refresh db-sync pull is already incremental (`[old_end + 1, target_end]`, clamped to the stable tip), so the oversized window cost memory, not steady-state query time — a caught-up node already queries only a few blocks near tip. The wide/slow refreshes in the issue were captured during a concurrent db-sync incident (the issue disclaims those numbers). So this change fixes the window-tracking and memory behavior and makes from-genesis match restart; it is not, on its own, a steady-state latency fix.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

`cargo test -p midnight-primitives-mainchain-follower --lib` passes, including a regression test (`plan_refresh_from_genesis_steady_state_tracks_follower_not_genesis`) that a caught-up from-genesis node trims to the reorg-margin lookback rather than staying anchored at genesis. `cargo check -p midnight-node`, `cargo fmt --check`, and `cargo clippy --tests` on both changed crates are clean.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other:
- [ ] N/A

## Links

Closes #1835