### PR TITLE
fix(envrc): rename git hook friendly-name to avoid event collision

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,8 +10,8 @@ git_version=$(git --version | awk '{print $3}')
 git_major=${git_version%%.*}
 git_minor=${git_version#*.}; git_minor=${git_minor%%.*}
 if [[ "$git_major" -gt 2 ]] || [[ "$git_major" -eq 2 && "$git_minor" -ge 54 ]]; then
-  git config --local hook.commit-msg.event commit-msg
-  git config --local hook.commit-msg.command "$PWD/.githooks/commit-msg"
+  git config --local hook.dco.event commit-msg
+  git config --local hook.dco.command "$PWD/.githooks/commit-msg"
 else
   git config --local core.hooksPath .githooks
 fi


### PR DESCRIPTION
# Overview

`.envrc` configured the `commit-msg` hook using the `[hook "<friendly-name>"]` config syntax (introduced in Git 2.54), but used `commit-msg` as the friendly-name — identical to the known event name. Git 2.55.0 rejects this (verified locally) with:

```
fatal: hook friendly-name 'commit-msg' collides with a known event name; please choose a different friendly-name
```

Because `direnv` re-sources `.envrc` on every `cd` into the repo, the broken entry was regenerated constantly, breaking `git hook list` and clients that call it (e.g. lazygit).

This renames the friendly-name to `dco`, which accurately describes the hook (`.githooks/commit-msg` enforces the DCO `Signed-off-by:` line) and no longer collides with an event name.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: dev-env/tooling only, does not affect node/toolkit/runtime
- [x] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

On Git 2.55.0, before the fix `git hook list commit-msg` exited 128 with the collision error. After renaming the friendly-name to `dco` (and clearing the stale local config), `git hook list commit-msg` exits 0 and prints `dco`.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A

## Links

N/A