### PR TITLE
fix(cnight-observation): chunk the bulk cache catch-up pull

### DIFF
--- a/changes/node/changed/chunk-cnight-catchup-pull.md
+++ b/changes/node/changed/chunk-cnight-catchup-pull.md
@@ -1,0 +1,8 @@
+#node #cnight-observation #performance
+# Chunk the cNIGHT observation cache catch-up pull
+
+The bulk cNIGHT observation cache warms/slides its in-memory window in a background `refresh`, which pulled the whole `[from_block, target_end]` range in a single `bulk_pull` with `LARGE_LIMIT`. In steady state that range is small, but when a node is far behind tip (cold start, or after a lag) the span can be hundreds of thousands of Cardano blocks, and one query over it is a multi-minute db-sync scan that stalls block import.
+
+The refresh now pulls the range in bounded block-span chunks (`REFRESH_CHUNK_BLOCKS`, 5000 blocks), committing `snapshot_end_block` after each chunk so an interrupted catch-up resumes from the last committed block. This is a cache-warming change only: the union of chunks covers exactly the same range, so the consensus inherent payload is unaffected (the per-block inherent path in `get_utxos_up_to_capacity` still queries through tip, unchanged).
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1889

--- a/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation_bulk.rs
@@ -51,6 +51,16 @@ pub const DEFAULT_WINDOW_SIZE: u32 = 100_000;
 /// forward.
 const REFRESH_THRESHOLD: u32 = 10_000;
 
+/// Maximum Cardano block span pulled per `bulk_pull` while warming or sliding
+/// the cache forward. A far-behind node (cold start, or after a lag) would
+/// otherwise pull `[from_block, target_end]` (up to the whole `window_size`)
+/// in a single query: a multi-minute db-sync scan that stalls block import.
+/// Splitting the range into chunks of this many blocks bounds each query's
+/// span and lets the catch-up make committed, resumable progress. This is a
+/// cache-warming detail only; the union of chunks covers the same range, so
+/// it never changes what a consensus inherent observes.
+const REFRESH_CHUNK_BLOCKS: u32 = 5_000;
+
 /// Errors that can arise while bulk-pulling cNIGHT observation events.
 #[derive(thiserror::Error, Debug)]
 pub enum BulkPullError {
@@ -417,27 +427,50 @@ impl RefreshContext {
 			"refresh kicked off: pulling [{from_block}, {target_end}] (was end={old_end}); trim behind {new_window_start}"
 		);
 		let t0 = std::time::Instant::now();
-		let (start, end) = (
-			CardanoPosition::min_for_block(from_block),
-			CardanoPosition::max_for_block(target_end),
-		);
-		// Warming the cache means pulling a whole multi-block window, so the per-query
-		// limit is the wide `LARGE_LIMIT` rather than the per-block over-fetch bound.
-		let extension =
-			bulk_pull(&self.pool, &self.cnight_addresses, &start, &end, LARGE_LIMIT).await?;
-		{
-			let mut events_guard =
-				self.all_events.write().map_err(|e| format!("all_events write poisoned: {e}"))?;
-			slide_events(&mut events_guard, extension, new_window_start);
+		// Pull the range in bounded block-span chunks instead of one giant query.
+		// When a node is far behind tip (cold start, or after a lag) the span
+		// `[from_block, target_end]` can be hundreds of thousands of blocks, and a
+		// single `bulk_pull` over it is a multi-minute db-sync scan that stalls
+		// block import. Chunking bounds each query's span (and so its duration) and
+		// commits progress after every chunk, so an interrupted catch-up resumes
+		// from the last committed block. Cache-warming only: the union of chunks
+		// covers the same range, so no inherent payload changes.
+		let mut chunk_from = from_block;
+		loop {
+			let chunk_end = chunk_from
+				.saturating_add(REFRESH_CHUNK_BLOCKS.saturating_sub(1))
+				.min(target_end);
+			let (start, end) = (
+				CardanoPosition::min_for_block(chunk_from),
+				CardanoPosition::max_for_block(chunk_end),
+			);
+			// Warming the cache means pulling a whole multi-block window, so the per-query
+			// limit is the wide `LARGE_LIMIT` rather than the per-block over-fetch bound.
+			let extension =
+				bulk_pull(&self.pool, &self.cnight_addresses, &start, &end, LARGE_LIMIT).await?;
+			{
+				let mut events_guard = self
+					.all_events
+					.write()
+					.map_err(|e| format!("all_events write poisoned: {e}"))?;
+				slide_events(&mut events_guard, extension, new_window_start);
+			}
+			// Commit progress after each chunk. The window start's final value is
+			// known up front; the end advances chunk by chunk so a failure mid
+			// catch-up resumes from here on the next refresh.
+			*self
+				.snapshot_start_block
+				.write()
+				.map_err(|e| format!("snapshot_start_block write poisoned: {e}"))? = Some(new_window_start);
+			*self
+				.snapshot_end_block
+				.write()
+				.map_err(|e| format!("snapshot_end_block write poisoned: {e}"))? = Some(chunk_end);
+			if chunk_end >= target_end {
+				break;
+			}
+			chunk_from = chunk_end.saturating_add(1);
 		}
-		*self
-			.snapshot_start_block
-			.write()
-			.map_err(|e| format!("snapshot_start_block write poisoned: {e}"))? = Some(new_window_start);
-		*self
-			.snapshot_end_block
-			.write()
-			.map_err(|e| format!("snapshot_end_block write poisoned: {e}"))? = Some(target_end);
 		log::info!(
 			target: "cnight::sliding-window",
 			"refresh done: window now [{new_window_start}, {target_end}] (took {:?})",


### PR DESCRIPTION
# Overview

Investigating the "slow db-sync query" spikes on devnet/stagenet (node 2.0.x) traced the load to the **cNIGHT observation** path, not to db-sync resourcing. Two facts pin it to the node code, not the DB:

- devnet (2.0.x) and qanet (1.0.0) read the **same** shared Aurora; only the 2.0.x one is slow. stagenet (2.0.x) has its **own dedicated** Aurora and is slow too. The variable that tracks the symptom is the node version, not the database.
- An `EXPLAIN ANALYZE` of the cNIGHT observation join shape ran **~53 s on an otherwise idle DB**. The plan is sensible (index scans, accurate estimates) — the cost is the *range width* scanned, not a missing index or contention.

This PR fixes one concrete driver of that width: the bulk cache's **catch-up pull**.

## Change

`RefreshContext::refresh` warms/slides the in-memory cNIGHT window in the background. It pulled the whole `[from_block, target_end]` range in a single `bulk_pull` with `LARGE_LIMIT`. In steady state that range is small (`[old_end + 1, target_end]`), but when a node is **far behind tip** (cold start, or after a lag) the span can be hundreds of thousands of Cardano blocks, and one query over it is a multi-minute db-sync scan that stalls block import.

The refresh now pulls the range in **bounded block-span chunks** (`REFRESH_CHUNK_BLOCKS = 5000`), committing `snapshot_end_block` after each chunk so an interrupted catch-up resumes from the last committed block instead of restarting the giant query.

**Consensus-safe / scope:** this is a cache-warming detail only. The union of chunks covers exactly the same range, so no inherent payload changes. The per-block consensus path (`MidnightCNightObservationDataSourceImpl::get_utxos_up_to_capacity`) is untouched and still queries through tip — deliberately, per its existing replay-semantics comment.

## Relationship to other PRs

- Supersedes the approach in **#1432** (which clamped the *inherent* query upper bound — no longer viable, since the surviving path documents that clipping the SQL range changes the inherent payload and breaks import of already-authored blocks). #1432 should be closed as superseded; its root-cause writeup remains accurate.
- Complements **#1836** (re-anchor the window near tip): #1836 reduces *how often* a node ends up far behind / oversized; this PR bounds the query cost *when* a catch-up does happen. They stack.

## Testing Evidence

- `rustfmt --edition 2024` clean.
- Not compiled locally (dev-machine build policy); relying on CI for `cargo check`/`clippy`/tests.
- **Follow-up wanted:** a unit test around the chunk boundary in `refresh` (chunk_end clamping, resume via committed `snapshot_end_block`). Happy to add once a reviewer confirms the approach.

## Submission Checklist

- [x] Changes are backward-compatible
- [x] PR description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] Included a change file
- [ ] Bump node minor version (n/a — behavior-preserving perf fix)
- [ ] Additional tests (see follow-up above)
