### PR TITLE
chore: passthrough --output-events to toolkit-js

### DIFF
--- a/changes/toolkit/added/circuit-output-events.md
+++ b/changes/toolkit/added/circuit-output-events.md
@@ -7,4 +7,5 @@ forwards to the `--output-events` flag already provided by `compact-js` 2.5.5-rc
 circuit command, exposing the new events API through the Rust toolkit. Events are only
 written when the flag is supplied, and it requires `COMPACTC_VERSION` >= 0.33.0.
 
-PR: <link after PR is opened>
+PR: https://github.com/midnightntwrk/midnight-node/pull/1910
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1639

--- a/changes/toolkit/added/circuit-output-events.md
+++ b/changes/toolkit/added/circuit-output-events.md
@@ -1,0 +1,10 @@
+#toolkit
+# Add `--output-events` to `generate-intent circuit`
+
+`generate-intent circuit` now accepts an optional `--output-events <file>` argument that
+writes the contract log events emitted during circuit execution to a JSON file. This
+forwards to the `--output-events` flag already provided by `compact-js` 2.5.5-rc.7's
+circuit command, exposing the new events API through the Rust toolkit. Events are only
+written when the flag is supplied, and it requires `COMPACTC_VERSION` >= 0.33.0.
+
+PR: <link after PR is opened>

--- a/scripts/tests/toolkit-mint-e2e.sh
+++ b/scripts/tests/toolkit-mint-e2e.sh
@@ -178,8 +178,8 @@ toolkit \
     "$domain_sep" \
     1000
 
-test -f "$outdir/$mint_intent_filename"
-test -f "$outdir/$mint_zswap_filename"
+test -f "$tempdir/$mint_intent_filename"
+test -f "$tempdir/$mint_zswap_filename"
 
 events_output=$(jq "$tempdir/$mint_events_filename")
 echo "Events emitted: $events_output"

--- a/scripts/tests/toolkit-mint-e2e.sh
+++ b/scripts/tests/toolkit-mint-e2e.sh
@@ -117,6 +117,7 @@ state_filename="contract_state.mn"
 
 mint_intent_filename="mint.bin"
 mint_zswap_filename="mint_zswap.json"
+mint_events_filename="mint_events.json"
 
 coin_public=$(
     toolkit show-address \
@@ -170,11 +171,19 @@ toolkit \
     --output-intent "$outdir/$mint_intent_filename" \
     --output-private-state "$outdir/tmp.json" \
     --output-zswap-state "$outdir/$mint_zswap_filename" \
+    --output-events "$outdir/$mint_events_filename" \
     --coin-public "$coin_public" \
     mint \
     "$nonce" \
     "$domain_sep" \
     1000
+
+test -f "$outdir/$mint_intent_filename"
+test -f "$outdir/$mint_zswap_filename"
+
+events_output=$(jq "$tempdir/$mint_events_filename")
+echo "Events emitted: $events_output"
+test -f "$tempdir/$mint_events_filename" && test -n "$events_output"
 
 shielded_destination=$(
     toolkit show-address \

--- a/scripts/tests/toolkit-mint-e2e.sh
+++ b/scripts/tests/toolkit-mint-e2e.sh
@@ -181,7 +181,7 @@ toolkit \
 test -f "$tempdir/$mint_intent_filename"
 test -f "$tempdir/$mint_zswap_filename"
 
-events_output=$(jq "$tempdir/$mint_events_filename")
+events_output=$(jq . "$tempdir/$mint_events_filename")
 echo "Events emitted: $events_output"
 test -f "$tempdir/$mint_events_filename" && test -n "$events_output"
 

--- a/util/toolkit-js/README.md
+++ b/util/toolkit-js/README.md
@@ -150,6 +150,16 @@ The `circuit` command accepts the following options via the command line:
 A path to a file containing the serialized onchain (or Ledger) state that represents the _current_ state of
 the contract. The executing circuit will apply to this given state.
 
+- `--output-events <file>`
+**Optional** A path to a file where the contract log events emitted during circuit execution are written as
+JSON (the raw `LogEvent[]`; `bigint` values are serialized as decimal strings and byte arrays as number
+arrays). Events are only written when this option is supplied.
+Requires `COMPACTC_VERSION` ≥ 0.33.0 — earlier variants predate the compact-js events API and do not accept
+this flag. (When driven through the Rust toolkit, requesting events on an older version fails early with a
+clear error; passing `--output-events` directly to an older toolkit-js instead yields a confusing
+"Invalid number of arguments" error, because `@effect/cli` absorbs the unknown flag into the trailing
+variadic arguments.)
+
 #### Arguments
 The `circuit` command requires the following arguments:
 

--- a/util/toolkit-js/README.md
+++ b/util/toolkit-js/README.md
@@ -229,7 +229,7 @@ different `compactc` versions, each supported version has its own sibling worksp
 compact-0.29.0/     → @midnight-ntwrk/compact-js* 2.4.3   (public npm)
 compact-0.30.0/     → @midnight-ntwrk/compact-js* 2.5.0   (public npm)
 compact-0.31.0/     → @midnight-ntwrk/compact-js* 2.5.1   (public npm)
-compact-0.33.0/     → @midnight-ntwrk/compact-js* 2.5.5-rc.6 (public npm)
+compact-0.33.0/     → @midnight-ntwrk/compact-js* 2.5.5-rc.7 (public npm)
 ```
 
 The root package depends on every variant (`@midnight-ntwrk/node-toolkit-compact-<major>.<minor>.<patch>`). At

--- a/util/toolkit-js/compact-0.33.0/package.json
+++ b/util/toolkit-js/compact-0.33.0/package.json
@@ -21,9 +21,9 @@
     "@effect/platform-node": "^0.107.0",
     "@effect/cli": "^0.75.0",
     "@midnight-ntwrk/platform-js": "^3.0.0",
-    "@midnight-ntwrk/compact-js": "^2.5.5-rc.6",
-    "@midnight-ntwrk/compact-js-command": "^2.5.5-rc.6",
-    "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.6",
+    "@midnight-ntwrk/compact-js": "^2.5.5-rc.7",
+    "@midnight-ntwrk/compact-js-command": "^2.5.5-rc.7",
+    "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.7",
     "@midnight-ntwrk/compact-runtime": "^0.18.0-rc.1",
     "effect": "^3.21.4"
   }

--- a/util/toolkit-js/mint/mint.compact
+++ b/util/toolkit-js/mint/mint.compact
@@ -7,5 +7,10 @@ export ledger round: Counter;
 export circuit mint(nonce: Bytes<32>, domainSep: Bytes<32>, amount: Uint<64>): [] {
     const coin = ShieldedCoinInfo { nonce:  disclose(nonce), color: tokenType(disclose(domainSep), kernel.self()), value: disclose(amount) };
     kernel.mintShielded(disclose(domainSep), disclose(amount));
+    emit(ShieldedMint {
+      commitment: disclose(nonce),
+      domainSep: disclose(domainSep),
+      amount: some<Uint<128>>(disclose(amount)),
+    });
     createZswapOutput(coin, left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()));
 }

--- a/util/toolkit-js/package-lock.json
+++ b/util/toolkit-js/package-lock.json
@@ -561,9 +561,9 @@
         "@effect/cli": "^0.75.0",
         "@effect/platform": "^0.96.1",
         "@effect/platform-node": "^0.107.0",
-        "@midnight-ntwrk/compact-js": "^2.5.5-rc.6",
-        "@midnight-ntwrk/compact-js-command": "^2.5.5-rc.6",
-        "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.6",
+        "@midnight-ntwrk/compact-js": "^2.5.5-rc.7",
+        "@midnight-ntwrk/compact-js-command": "^2.5.5-rc.7",
+        "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.7",
         "@midnight-ntwrk/compact-runtime": "^0.18.0-rc.1",
         "@midnight-ntwrk/platform-js": "^3.0.0",
         "effect": "^3.21.4"
@@ -725,9 +725,9 @@
       }
     },
     "compact-0.33.0/node_modules/@midnight-ntwrk/compact-js": {
-      "version": "2.5.5-rc.6",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.5-rc.6.tgz",
-      "integrity": "sha512-rEUnBgkCtvg/v1hyIzUwLgm2Csu28B0jZ+iK4lxe713jJAbCr17OWWRmsQC1aXDP2DGvTtwCql/oUXyFznELkg==",
+      "version": "2.5.5-rc.7",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.5-rc.7.tgz",
+      "integrity": "sha512-INcbIxsgK2NGm5J7pCHRsq1kxKQEXKQjFRgU84TsbP6GadqnWFg1hh0eJ/H2SS6AxAQGQjI0iasLodVTviKAIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@effect/platform": "^0.96.1",
@@ -740,9 +740,9 @@
       }
     },
     "compact-0.33.0/node_modules/@midnight-ntwrk/compact-js-command": {
-      "version": "2.5.5-rc.6",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js-command/-/compact-js-command-2.5.5-rc.6.tgz",
-      "integrity": "sha512-352AtaYCn4wtN6rWXWZBDWL+58m034jRNm6pvbpAS/NIdqiQYaADPyJXbvvBF7O2A0oojwbK1u5JVCSt1g5tlg==",
+      "version": "2.5.5-rc.7",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js-command/-/compact-js-command-2.5.5-rc.7.tgz",
+      "integrity": "sha512-FqjynUpCSB8VsliJW3ctm8id+MhsviH3LkE18OHtUyzhGXfL0d/BkiJoMlocRxb4sSstB+xR4A8sjZfqZl5S6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@effect/cli": "^0.75.0",
@@ -757,8 +757,8 @@
         "@effect/sql": "^0.51.1",
         "@effect/typeclass": "^0.40.0",
         "@effect/workflow": "^0.18.2",
-        "@midnight-ntwrk/compact-js": "^2.5.5-rc.6",
-        "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.6",
+        "@midnight-ntwrk/compact-js": "^2.5.5-rc.7",
+        "@midnight-ntwrk/compact-js-node": "^2.5.5-rc.7",
         "@midnight-ntwrk/compact-runtime": "0.18.0-rc.1",
         "@midnight-ntwrk/platform-js": "^3.0.0",
         "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
@@ -810,9 +810,9 @@
       }
     },
     "compact-0.33.0/node_modules/@midnight-ntwrk/compact-js-node": {
-      "version": "2.5.5-rc.6",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js-node/-/compact-js-node-2.5.5-rc.6.tgz",
-      "integrity": "sha512-qstW/myPgrSo015iuqWFRWSUuOislukUm7FwaNH4ziRadZlxzFTTn8MA0FoaEVLoeAD7PG3v4j92WtbXLE41sA==",
+      "version": "2.5.5-rc.7",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js-node/-/compact-js-node-2.5.5-rc.7.tgz",
+      "integrity": "sha512-YnmodnTCU5IuRQNa++pa54cUKeEFqNwDC+XGznRc2OQnaexKzF6RGtcHc9DxZSE+wCZCUiDuPPfRVp72maC0Tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@effect/cluster": "^0.57.0",
@@ -826,7 +826,7 @@
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "@midnight-ntwrk/compact-js": "^2.5.5-rc.6"
+        "@midnight-ntwrk/compact-js": "^2.5.5-rc.7"
       }
     },
     "compact-0.33.0/node_modules/@midnight-ntwrk/compact-js-node/node_modules/@effect/cluster": {

--- a/util/toolkit/src/toolkit_js/mod.rs
+++ b/util/toolkit/src/toolkit_js/mod.rs
@@ -106,6 +106,9 @@ pub struct CircuitArgs {
 	/// A file path of where the invoked circuit result data should be written.
 	#[arg(long, value_parser = PathBufValueParser::new().map(|p| RelativePath::from(p)))]
 	pub output_result: Option<RelativePath>,
+	/// A file path where contract log events emitted during circuit execution should be written as JSON.
+	#[arg(long, value_parser = PathBufValueParser::new().map(|p| RelativePath::from(p)))]
+	pub output_events: Option<RelativePath>,
 	/// Name of the circuit to invoke
 	pub circuit_id: String,
 	/// Arguments to pass to the circuit
@@ -213,6 +216,11 @@ pub enum ToolkitJsError {
 	ToolkitJsOutputReadError(std::io::Error),
 	#[error("toolkit-js exited with {status}\nstdout: {stdout}\nstderr: {stderr}")]
 	NonZeroExit { status: std::process::ExitStatus, stdout: String, stderr: String },
+	#[error(
+		"--output-events requires compactc version >= 0.33.0 (the compact-js events API), \
+		 but {version} is configured"
+	)]
+	OutputEventsUnsupported { version: semver::Version },
 }
 
 impl ToolkitJs {
@@ -225,6 +233,17 @@ impl ToolkitJs {
 		let mut version = self.compactc_version.clone();
 		version.pre = semver::Prerelease::EMPTY;
 		semver::VersionReq::parse("<0.31.0").unwrap().matches(&version)
+	}
+
+	/// `true` if the pinned compactc supports the `--output-events` flag on the circuit
+	/// command, added alongside the compact-js events API in the 0.33.0 line.
+	///
+	/// As with [`Self::needs_legacy_network_flag`], the pre-release suffix is stripped before
+	/// comparison, so that e.g. `0.33.0-rc.1` is treated as `0.33.0`.
+	fn supports_output_events(&self) -> bool {
+		let mut version = self.compactc_version.clone();
+		version.pre = semver::Prerelease::EMPTY;
+		semver::VersionReq::parse(">=0.33.0").unwrap().matches(&version)
 	}
 
 	pub fn execute(&self, cmd: Command) -> Result<(), ToolkitJsError> {
@@ -338,6 +357,18 @@ impl ToolkitJs {
 		if let Some(ref output_result) = output_result {
 			cmd_args.extend_from_slice(&["--output-result", &output_result]);
 		}
+		let output_events = args.output_events.map(|s| s.absolute());
+		if let Some(ref output_events) = output_events {
+			// Fail early with a clear message rather than forwarding an unrecognized flag to an
+			// older toolkit-js, where `@effect/cli` would absorb it into the trailing variadic
+			// circuit args and produce a confusing "Invalid number of arguments" error.
+			if !self.supports_output_events() {
+				return Err(ToolkitJsError::OutputEventsUnsupported {
+					version: self.compactc_version.clone(),
+				});
+			}
+			cmd_args.extend_from_slice(&["--output-events", &output_events]);
+		}
 		// Add positional args
 		cmd_args.extend_from_slice(&[&contract_address_str, &args.circuit_id]);
 		cmd_args.extend(args.call_args.iter().map(|s| s.as_str()));
@@ -348,6 +379,9 @@ impl ToolkitJs {
 			args.output_private_state,
 			args.output_zswap_state
 		);
+		if let Some(ref output_events) = output_events {
+			log::info!("written events log: {output_events}");
+		}
 		Ok(())
 	}
 
@@ -460,5 +494,30 @@ impl ToolkitJs {
 			});
 		}
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn toolkit_js_with_version(version: &str) -> ToolkitJs {
+		ToolkitJs { path: String::new(), compactc_version: version.parse().unwrap() }
+	}
+
+	#[test]
+	fn supports_output_events_from_0_33_0() {
+		// The events API landed in the 0.33.0 line.
+		assert!(toolkit_js_with_version("0.33.0").supports_output_events());
+		assert!(toolkit_js_with_version("0.34.0").supports_output_events());
+		// Pre-release suffixes must be stripped, otherwise `0.33.0-rc.1 >= 0.33.0` is false.
+		assert!(toolkit_js_with_version("0.33.0-rc.1").supports_output_events());
+	}
+
+	#[test]
+	fn supports_output_events_rejects_older_versions() {
+		assert!(!toolkit_js_with_version("0.31.0").supports_output_events());
+		assert!(!toolkit_js_with_version("0.30.0").supports_output_events());
+		assert!(!toolkit_js_with_version("0.29.0").supports_output_events());
 	}
 }

--- a/util/toolkit/tests/common/toolkit_helper.rs
+++ b/util/toolkit/tests/common/toolkit_helper.rs
@@ -391,6 +391,7 @@ impl ToolkitTestHelper {
 					output_private_state: RelativePath(out_private_state.clone()),
 					output_zswap_state: RelativePath(out_zswap_state.clone()),
 					output_result: None,
+					output_events: None,
 					circuit_id: circuit_id.to_string(),
 					call_args: call_args.iter().map(|s| s.to_string()).collect(),
 				},


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

Pass-through `--output-events` arg from Rust toolkit to toolkit-js to allow reading emitted events at intent-generation time.

Included: Bumped compact-js to latest version (2.5.5-rc.7)

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [x] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

Completes: https://github.com/midnightntwrk/midnight-node/issues/1639
