### PR TITLE
feat(toolkit): add per-phase timing logs for transaction generation

### DIFF
--- a/changes/toolkit/added/tx-generation-perf-timings.md
+++ b/changes/toolkit/added/tx-generation-perf-timings.md
@@ -9,5 +9,11 @@ balancing loop (`pay_fees`, including the iteration count), real PLONK proving
 `RUST_LOG=debug`) to see the breakdown; a report script can grep for `[perf]` lines and
 aggregate per-phase trend lines across a run.
 
+`batch-single-tx` builds many transfers concurrently on one thread, so each transfer's
+future is wrapped in a `transfer{index=N, total=M}` tracing span; every `[perf]` line
+above is emitted from within that span, letting a report script correlate all five
+phase timings back to the same tx even though they interleave with other transfers'
+output.
+
 PR: https://github.com/midnightntwrk/midnight-node/pull/1912
 Issue: https://github.com/shieldedtech/midnight-performance/issues/292

--- a/changes/toolkit/added/tx-generation-perf-timings.md
+++ b/changes/toolkit/added/tx-generation-perf-timings.md
@@ -1,0 +1,13 @@
+#toolkit #perf
+# Add per-phase timing logs for transaction generation
+
+`single-tx` and `batch-single-tx` now emit `[perf]` debug-level log lines for each phase
+of building a transaction: coin/UTXO selection (`select_shielded_offer` /
+`select_unshielded_intents`), offer/intent construction (`build_offer_intents`), the fee
+balancing loop (`pay_fees`, including the iteration count), real PLONK proving
+(`prove_tx`), and serialization (`serialize`). Enable with `--verbose` (or
+`RUST_LOG=debug`) to see the breakdown; a report script can grep for `[perf]` lines and
+aggregate per-phase trend lines across a run.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/TODO
+Issue: https://github.com/shieldedtech/midnight-performance/issues/292

--- a/changes/toolkit/added/tx-generation-perf-timings.md
+++ b/changes/toolkit/added/tx-generation-perf-timings.md
@@ -9,5 +9,5 @@ balancing loop (`pay_fees`, including the iteration count), real PLONK proving
 `RUST_LOG=debug`) to see the breakdown; a report script can grep for `[perf]` lines and
 aggregate per-phase trend lines across a run.
 
-PR: https://github.com/midnightntwrk/midnight-node/pull/TODO
+PR: https://github.com/midnightntwrk/midnight-node/pull/1912
 Issue: https://github.com/shieldedtech/midnight-performance/issues/292

--- a/ledger/helpers/src/versions/common/context.rs
+++ b/ledger/helpers/src/versions/common/context.rs
@@ -194,6 +194,7 @@ impl<D: DB + Clone> LedgerContext<D> {
 	{
 		use rayon::prelude::*;
 		log::debug!(
+			target: super::transaction::PERF_TARGET,
 			"[perf] flushing {} events for {} wallets",
 			events.len(),
 			self.wallets.lock().expect("lock").len(),

--- a/ledger/helpers/src/versions/common/transaction.rs
+++ b/ledger/helpers/src/versions/common/transaction.rs
@@ -36,6 +36,15 @@ type Result<T, E = Box<dyn Error + Send + Sync>> = std::result::Result<T, E>;
 type DustSpendStates<D> = HashMap<WalletSeed, Sp<DustLocalState<D>, D>>;
 type GatheredDustSpends<D> = (Vec<DustSpend<ProofPreimageMarker, D>>, DustSpendStates<D>);
 
+/// Log target for the `[perf]` phase-timing records emitted while building transactions.
+///
+/// These records live in this helper crate but exist to instrument the toolkit's tx
+/// generation, so we tag them with the toolkit's target rather than this crate's. That way
+/// `midnight-node-toolkit --verbose` (which raises `midnight_node_toolkit=debug`) surfaces
+/// them alongside the toolkit's own `[perf]` lines, without also unmuting this crate's other
+/// (noisy, full-transaction) debug output.
+pub(super) const PERF_TARGET: &str = "midnight_node_toolkit";
+
 pub trait FromContext<D: DB + Clone, C: BuilderContext<D>> {
 	fn new_from_context(
 		context: Arc<C>,
@@ -200,7 +209,11 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 			intents = intents.insert(*segment_id, intent);
 		}
 
-		log::debug!("[perf] build_offer_intents took {:?}", build_offer_intents_start.elapsed());
+		log::debug!(
+			target: PERF_TARGET,
+			"[perf] build_offer_intents took {:?}",
+			build_offer_intents_start.elapsed()
+		);
 
 		let network_id = self.context.network_id().await;
 
@@ -246,6 +259,7 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 				} else {
 					self.confirm_dust_spends(&spends, updated_states)?;
 					log::debug!(
+						target: PERF_TARGET,
 						"[perf] pay_fees balance_iters={} took {:?}",
 						iteration,
 						balance_start.elapsed()
@@ -260,6 +274,7 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 				} else {
 					self.confirm_dust_spends(&spends, updated_states)?;
 					log::debug!(
+						target: PERF_TARGET,
 						"[perf] pay_fees balance_iters={} took {:?}",
 						iteration,
 						balance_start.elapsed()
@@ -269,6 +284,7 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 			}
 		}
 		log::debug!(
+			target: PERF_TARGET,
 			"[perf] pay_fees balance_iters=10 (exhausted) took {:?}",
 			balance_start.elapsed()
 		);
@@ -286,7 +302,7 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 			.prove(tx, rng.split(), resolver, parameters.cost_model.runtime_cost_model.clone())
 			.await
 			.seal(rng);
-		log::debug!("[perf] prove_tx took {:?}", prove_start.elapsed());
+		log::debug!(target: PERF_TARGET, "[perf] prove_tx took {:?}", prove_start.elapsed());
 		Ok(proven)
 	}
 

--- a/ledger/helpers/src/versions/common/transaction.rs
+++ b/ledger/helpers/src/versions/common/transaction.rs
@@ -168,6 +168,8 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 		let delay = self.context.ledger_parameters().await.global_ttl;
 		let ttl = now + delay;
 
+		let build_offer_intents_start = std::time::Instant::now();
+
 		let guaranteed_offer: Option<Offer<ProofPreimage, D>> = self
 			.guaranteed_offer
 			.as_mut()
@@ -198,6 +200,8 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 			intents = intents.insert(*segment_id, intent);
 		}
 
+		log::debug!("[perf] build_offer_intents took {:?}", build_offer_intents_start.elapsed());
+
 		let network_id = self.context.network_id().await;
 
 		let tx = Transaction::new(network_id.clone(), intents, guaranteed_offer, fallible_offer);
@@ -226,8 +230,9 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 	) -> Result<FinalizedTransaction<D>> {
 		let mut missing_dust = 0;
 		let dust_params = self.context.ledger_parameters().await.dust;
+		let balance_start = std::time::Instant::now();
 
-		for _ in 0..10 {
+		for iteration in 1..=10 {
 			let (spends, updated_states) =
 				self.gather_dust_spends(missing_dust, now, &dust_params)?;
 			let mut paid_tx = tx.clone();
@@ -240,6 +245,11 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 					missing_dust += dust;
 				} else {
 					self.confirm_dust_spends(&spends, updated_states)?;
+					log::debug!(
+						"[perf] pay_fees balance_iters={} took {:?}",
+						iteration,
+						balance_start.elapsed()
+					);
 					return self.prove_tx(paid_tx).await;
 				}
 			} else {
@@ -249,10 +259,19 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 					missing_dust += dust;
 				} else {
 					self.confirm_dust_spends(&spends, updated_states)?;
+					log::debug!(
+						"[perf] pay_fees balance_iters={} took {:?}",
+						iteration,
+						balance_start.elapsed()
+					);
 					return Ok(proven_tx);
 				}
 			}
 		}
+		log::debug!(
+			"[perf] pay_fees balance_iters=10 (exhausted) took {:?}",
+			balance_start.elapsed()
+		);
 		Err("Could not balance TX".into())
 	}
 
@@ -261,11 +280,14 @@ impl<D: DB + Clone, C: BuilderContext<D>> StandardTrasactionInfo<D, C> {
 		let resolver = self.context.resolver().await;
 		let parameters = self.context.ledger_parameters().await;
 		let mut rng = self.rng.split();
-		Ok(self
+		let prove_start = std::time::Instant::now();
+		let proven = self
 			.prover
 			.prove(tx, rng.split(), resolver, parameters.cost_model.runtime_cost_model.clone())
 			.await
-			.seal(rng))
+			.seal(rng);
+		log::debug!("[perf] prove_tx took {:?}", prove_start.elapsed());
+		Ok(proven)
 	}
 
 	#[cfg(feature = "erase-proof")]

--- a/util/toolkit/src/tx_generator/builder/builders/common/batch_single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/batch_single_tx.rs
@@ -23,6 +23,7 @@ use super::output_spec::{ShieldedOutputSpec, UnshieldedOutputSpec};
 use super::single_tx::{MAX_GUARANTEED_OUTPUTS, build_shielded_offer, build_unshielded_intents};
 use async_trait::async_trait;
 use futures::stream::StreamExt;
+use tracing::Instrument as _;
 
 use crate::{Progress, serde_def::SourceTransactions, tx_generator::builder::BatchSingleTxArgs};
 use midnight_node_ledger_helpers::fork::raw_block_data::SerializedTxBatches;
@@ -193,11 +194,13 @@ impl<C: BuilderContext<DefaultDB>> BuildTxs for BatchSingleTxBuilder<C> {
 		let futures: Vec<_> = self
 			.transfers
 			.iter()
-			.map(|spec| {
+			.enumerate()
+			.map(|(i, spec)| {
 				let context = self.context.clone();
 				let prover = self.prover.clone();
 				let spec = spec.clone();
 				let coin_selection = self.coin_selection;
+				let index = i + 1;
 				async move {
 					let result =
 						Self::build_single_transfer(context, prover, &spec, coin_selection)
@@ -213,6 +216,11 @@ impl<C: BuilderContext<DefaultDB>> BuildTxs for BatchSingleTxBuilder<C> {
 							});
 					result
 				}
+				// Tags every nested `[perf]` phase log (select/build_offer/pay_fees/prove_tx/
+				// serialize, emitted from single_tx.rs/transaction.rs/tx_serialization.rs) with
+				// this transfer's index, so a report script can correlate per-phase timings back
+				// to a single tx even though transfers build concurrently on one thread.
+				.instrument(tracing::debug_span!("transfer", index, total = num_transfers))
 			})
 			.collect();
 		let mut stream = futures::stream::iter(futures).buffered(self.concurrency);

--- a/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/single_tx.rs
@@ -236,6 +236,7 @@ pub(crate) fn build_shielded_offer<C: BuilderContext<DefaultDB>>(
 	}
 
 	// Per token type: select inputs and append a change refund if needed.
+	let select_start = std::time::Instant::now();
 	for (token_type, total_required) in totals {
 		let (token_inputs, change) = InputInfo::coins_to_cover_value(
 			context.clone(),
@@ -259,6 +260,7 @@ pub(crate) fn build_shielded_offer<C: BuilderContext<DefaultDB>>(
 			outputs_info.push(refund);
 		}
 	}
+	log::debug!("[perf] select_shielded_offer took {:?}", select_start.elapsed());
 
 	Ok(OfferInfo { inputs: inputs_info, outputs: outputs_info, transients: vec![] })
 }
@@ -311,6 +313,7 @@ pub(crate) async fn build_unshielded_intents<C: BuilderContext<DefaultDB>>(
 
 	// Per token type: select utxos (or use pinned utxos for the single-token case)
 	// and append a change refund if needed.
+	let select_start = std::time::Instant::now();
 	for (token_type, total_required) in totals {
 		let (token_inputs, remaining) = if input_utxos.is_empty() {
 			UtxoSpendInfo::utxos_to_cover_value(
@@ -346,6 +349,7 @@ pub(crate) async fn build_unshielded_intents<C: BuilderContext<DefaultDB>>(
 			outputs_info.push(refund);
 		}
 	}
+	log::debug!("[perf] select_unshielded_intents took {:?}", select_start.elapsed());
 
 	let inputs_outputs_len = inputs_info.len() + outputs_info.len();
 	let unshielded_offer = UnshieldedOfferInfo { inputs: inputs_info, outputs: outputs_info };

--- a/util/toolkit/src/tx_generator/builder/builders/common/tx_serialization.rs
+++ b/util/toolkit/src/tx_generator/builder/builders/common/tx_serialization.rs
@@ -26,7 +26,9 @@ use super::ledger_helpers_local::TransactionWithContext;
 pub fn build_single(
 	tx_with_context: TransactionWithContext<Signature, ProofMarker, DefaultDB>,
 ) -> SerializedTxBatches {
+	let start = std::time::Instant::now();
 	let initial_tx = serialize_tx(&tx_with_context);
+	log::debug!("[perf] serialize took {:?}", start.elapsed());
 	SerializedTxBatches { batches: vec![vec![initial_tx]] }
 }
 


### PR DESCRIPTION
# Overview

Adds granular, per-phase timing instrumentation to toolkit transaction generation
(`single-tx` and `batch-single-tx`), so the total tx-generation time can be broken down
into its component phases instead of only measured as one opaque window.

The toolkit already hides `log::debug!` output behind the existing `--verbose` /
`RUST_LOG=debug` flag, and already has a `[perf] <label> took <duration>` convention
(see `tx_generator/builder/mod.rs`). This PR extends that same convention to the phases
called out in the linked issue, rather than introducing a new flag:

- `select_shielded_offer` / `select_unshielded_intents` — coin/UTXO selection
  (`util/toolkit/.../single_tx.rs`, shared by both `single-tx` and `batch-single-tx`)
- `build_offer_intents` — offer/intent construction inside `StandardTrasactionInfo::build()`
  (`ledger/helpers/.../transaction.rs`)
- `pay_fees` — the fee-balancing loop, including a `balance_iters=N` count
- `prove_tx` — the real PLONK proving call (separate from the mock-proof path used
  inside the fee-balancing loop)
- `serialize` — `build_single` output serialization (`tx_serialization.rs`)

A report script can grep the `--verbose` output for `[perf]` lines to build per-phase
trend lines over a long-running batch.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- `cargo check -p midnight-node-ledger-helpers -p midnight-node-toolkit` (default features, and `--features erase-proof` for ledger-helpers)
- `cargo test -p midnight-node-toolkit --lib single_tx` (8 passed)
- `cargo fmt -- --check`
- `cargo clippy -p midnight-node-ledger-helpers -p midnight-node-toolkit --lib -- -D warnings`

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

Issue: https://github.com/shieldedtech/midnight-performance/issues/292