### PR TITLE
fix: get_block_by_hash handles large block numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11368,6 +11368,7 @@ dependencies = [
  "sidechain-mc-hash",
  "sp-partner-chains-bridge",
  "sp-timestamp",
+ "tokio",
 ]
 
 [[package]]

--- a/partner-chains/toolkit/data-sources/mock/Cargo.toml
+++ b/partner-chains/toolkit/data-sources/mock/Cargo.toml
@@ -26,6 +26,9 @@ pallet-sidechain-rpc = { workspace = true, optional = true }
 authority-selection-inherents = { workspace = true, optional = true }
 sp-partner-chains-bridge = { workspace = true, optional = true }
 
+[dev-dependencies]
+tokio = { workspace = true }
+
 [features]
 default = ["std", "block-source", "candidate-source"]
 std = [
@@ -38,6 +41,3 @@ candidate-source = ["authority-selection-inherents"]
 mc-hash = ["sidechain-mc-hash"]
 sidechain-rpc = ["pallet-sidechain-rpc"]
 bridge = ["sp-partner-chains-bridge"]
-
-[lib]
-test = false

--- a/partner-chains/toolkit/data-sources/mock/src/block.rs
+++ b/partner-chains/toolkit/data-sources/mock/src/block.rs
@@ -50,14 +50,14 @@ impl BlockDataSourceMock {
 	) -> Result<Option<MainchainBlock>> {
 		// reverse of computation in `get_latest_stable_block_for`
 		let block_number = u32::from_be_bytes(hash.0[..4].try_into().unwrap());
-		let timestamp = block_number * 20000;
+		let timestamp = u64::from(block_number) * 20000;
 		let epoch = block_number / self.block_per_epoch();
 		Ok(Some(MainchainBlock {
 			number: McBlockNumber(block_number),
 			hash,
 			epoch: McEpochNumber(epoch),
 			slot: McSlotNumber(epoch.into()),
-			timestamp: timestamp.into(),
+			timestamp,
 		}))
 	}
 }
@@ -84,5 +84,20 @@ impl BlockDataSourceMock {
 			.duration_since(std::time::UNIX_EPOCH)
 			.unwrap()
 			.as_millis() as u64
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn get_block_by_hash_handles_large_block_numbers() {
+		let source = BlockDataSourceMock::new(43200000);
+		let mut hash_arr = [0u8; 32];
+		hash_arr[..4].copy_from_slice(&u32::MAX.to_be_bytes());
+		let block = source.get_block_by_hash(McBlockHash(hash_arr)).await.unwrap().unwrap();
+		assert_eq!(block.number, McBlockNumber(u32::MAX));
+		assert_eq!(block.timestamp, u64::from(u32::MAX) * 20000);
 	}
 }


### PR DESCRIPTION
# Overview

In midnight-node repo, partner-chains/toolkit/data-sources/mock/src/block.rs:53, get_block_by_hash computes let timestamp = block_number * 20000; where block_number is a u32 parsed from arbitrary hash bytes. This multiplication overflows u32 and panics in debug builds ('attempt to multiply with overflow'), crashing any CFG_PRESET=dev node run from a debug binary. Fixed by widening to u64 before multiplying.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
