### PR TITLE
test: add e2e block-production & committee regression guard

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1834,6 +1834,10 @@ local-env-ci:
             echo "=== post-suite liveness check ===" && \
             cd "$ROOT" && \
             ./local-environment/check-health.sh -u http://localhost:9933 -b 50 -t 360 && \
+            echo "=== block-production / committee audit (runs last, over the most blocks) ===" && \
+            ( cd "$ROOT/tests/e2e" && \
+              cargo test --test e2e_tests --no-default-features --features local -- --ignored block_production --nocapture ) && \
+            cd "$ROOT" && \
             rm -f /root/.docker/config.json
     END
 

--- a/changes/node/added/block-production-committee-e2e.md
+++ b/changes/node/added/block-production-committee-e2e.md
@@ -1,0 +1,24 @@
+#tests #ci
+# Add e2e regression guard for block authorship & committee rotation
+
+Adds an ignored e2e test (`tests/e2e/tests/block_production.rs`) that audits the
+newest finalized blocks and asserts the deterministic invariants behind the
+aura-fork removal (#1700) and pallet-session migration (#1800):
+
+- every block's AURA author (`aura.authorities.at(parent)[slot % len]`) is a
+  member of `sidechain_getEpochCommittee` for the parent's sidechain epoch
+  (parent-state read → boundary-safe: the first block of a session is produced
+  by the previous committee);
+- per epoch, on-chain `aura.authorities` == `sidechain_getEpochCommittee`;
+- `session.validators` and `aura.authorities` stay equal length;
+- session index is monotonic and finalized heights are contiguous.
+
+Adds the supporting `MidnightClient` helpers (`get_epoch_committee`,
+`get_block_digest_info`, `get_aura_authorities_hex_at`, `get_session_index_at`,
+`get_session_validators_len_at`, `get_sidechain_epoch_and_slot`,
+`get_mainchain_epoch`). The test is `#[ignore]` so the parallel suite skips it;
+`+local-env-ci` runs it as the final step (after the suite + health check) so it
+analyses the most blocks — bounded to the newest 200.
+
+PR: (added when the PR is opened)
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1759

--- a/changes/node/added/block-production-committee-e2e.md
+++ b/changes/node/added/block-production-committee-e2e.md
@@ -20,5 +20,5 @@ Adds the supporting `MidnightClient` helpers (`get_epoch_committee`,
 `+local-env-ci` runs it as the final step (after the suite + health check) so it
 analyses the most blocks — bounded to the newest 200.
 
-PR: (added when the PR is opened)
+PR: https://github.com/midnightntwrk/midnight-node/pull/1926
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1759

--- a/tests/e2e/src/api/midnight.rs
+++ b/tests/e2e/src/api/midnight.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 use subxt::extrinsics::ExtrinsicEvents;
 use subxt::rpcs::{RpcClient, rpc_params};
 use subxt::tx::TransactionProgress;
+use subxt::config::substrate::{DigestItem, SubstrateHeader};
+use subxt::ext::codec::Decode;
 use subxt::utils::H256;
 use subxt::{OnlineClient, SubstrateConfig};
 use tokio::time::{sleep, timeout, Instant};
@@ -61,6 +63,36 @@ pub struct AriadneParametersResponse {
     pub permissioned_candidates: Option<Vec<serde_json::Value>>,
     /// Map of candidate registrations
     pub candidate_registrations: serde_json::Value,
+}
+
+/// One member of a sidechain epoch committee (from `sidechain_getEpochCommittee`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpochCommitteeMember {
+    /// Sidechain (cross-chain) public key, hex `0x…`.
+    pub sidechain_pub_key: String,
+}
+
+/// Response of `sidechain_getEpochCommittee` — the ordered committee for a
+/// sidechain epoch (AURA walks this list by `slot % len`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpochCommitteeResponse {
+    /// The sidechain epoch this committee serves.
+    pub sidechain_epoch: u64,
+    /// Ordered committee members (may repeat when a member holds >1 seat).
+    pub committee: Vec<EpochCommitteeMember>,
+}
+
+/// Digest-derived facts about one block, used by the block-production audit.
+#[derive(Debug, Clone)]
+pub struct BlockDigestInfo {
+    /// Block number.
+    pub number: u64,
+    /// Parent block hash (its committee is the one that produced this block).
+    pub parent_hash: H256,
+    /// AURA slot from the `PreRuntime` digest (None if absent, e.g. genesis).
+    pub aura_slot: Option<u64>,
 }
 
 /// C-to-M bridge data from all `Bridge::handle_transfers` calls of one block.
@@ -1095,6 +1127,125 @@ impl MidnightClient {
     pub async fn get_current_epoch(&self) -> Result<u64, Box<dyn std::error::Error>> {
         let status = self.get_sidechain_status().await?;
         Ok(status.epoch)
+    }
+
+    // ========== Block-production / committee audit helpers ==========
+
+    /// The ordered committee for a sidechain epoch via `sidechain_getEpochCommittee`.
+    pub async fn get_epoch_committee(
+        &self,
+        sc_epoch: u64,
+    ) -> Result<EpochCommitteeResponse, Box<dyn std::error::Error>> {
+        Ok(self
+            .rpc_client
+            .request("sidechain_getEpochCommittee", rpc_params![sc_epoch])
+            .await?)
+    }
+
+    /// Current sidechain `(epoch, slot)` read straight from `sidechain_getStatus`
+    /// (raw JSON — the response is `{ sidechain: { epoch, slot, .. }, .. }`).
+    pub async fn get_sidechain_epoch_and_slot(
+        &self,
+    ) -> Result<(u64, u64), Box<dyn std::error::Error>> {
+        let v: serde_json::Value = self
+            .rpc_client
+            .request("sidechain_getStatus", rpc_params![])
+            .await?;
+        let epoch = v["sidechain"]["epoch"]
+            .as_u64()
+            .ok_or("sidechain_getStatus: missing sidechain.epoch")?;
+        let slot = v["sidechain"]["slot"]
+            .as_u64()
+            .ok_or("sidechain_getStatus: missing sidechain.slot")?;
+        Ok((epoch, slot))
+    }
+
+    /// Current mainchain (Cardano) epoch from `sidechain_getStatus`.
+    pub async fn get_mainchain_epoch(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        let v: serde_json::Value = self
+            .rpc_client
+            .request("sidechain_getStatus", rpc_params![])
+            .await?;
+        v["mainchain"]["epoch"]
+            .as_u64()
+            .ok_or_else(|| "sidechain_getStatus: missing mainchain.epoch".into())
+    }
+
+    /// Decode a block's number, parent hash and AURA slot from its header digest.
+    pub async fn get_block_digest_info(
+        &self,
+        block_hash: H256,
+    ) -> Result<BlockDigestInfo, Box<dyn std::error::Error>> {
+        let header: SubstrateHeader<H256> = self
+            .rpc_client
+            .request("chain_getHeader", rpc_params![block_hash])
+            .await?;
+        let aura_slot = header.digest.logs.iter().find_map(|log| match log {
+            DigestItem::PreRuntime(engine, data) if *engine == *b"aura" => data
+                .get(0..8)
+                .and_then(|b| b.try_into().ok())
+                .map(u64::from_le_bytes),
+            _ => None,
+        });
+        Ok(BlockDigestInfo {
+            number: header.number,
+            parent_hash: header.parent_hash,
+            aura_slot,
+        })
+    }
+
+    /// `aura.authorities` (the ordered list AURA walks) at a block, as `0x…` hex keys.
+    ///
+    /// Decodes the raw storage bytes as `Vec<[u8; 32]>` (a `BoundedVec<AuraId>`
+    /// SCALE-encodes identically) rather than the generated `Public` type, which
+    /// doesn't implement `Encode`/`AsRef` for extracting the inner bytes.
+    pub async fn get_aura_authorities_hex_at(
+        &self,
+        block_hash: H256,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let at = self.online_client().at_block(block_hash).await?;
+        let fetched = at
+            .storage()
+            .try_fetch(mn_meta::storage().aura().authorities(), ())
+            .await?;
+        let Some(value) = fetched else {
+            return Ok(vec![]);
+        };
+        let authorities = <Vec<[u8; 32]>>::decode(&mut value.bytes())?;
+        Ok(authorities
+            .iter()
+            .map(|key| format!("0x{}", hex::encode(key)))
+            .collect())
+    }
+
+    /// `session.validators` length at a block.
+    pub async fn get_session_validators_len_at(
+        &self,
+        block_hash: H256,
+    ) -> Result<usize, Box<dyn std::error::Error>> {
+        let at = self.online_client().at_block(block_hash).await?;
+        let decoded = at
+            .storage()
+            .try_fetch(mn_meta::storage().session().validators(), ())
+            .await?
+            .map(|v| v.decode())
+            .transpose()?;
+        Ok(decoded.map(|validators| validators.len()).unwrap_or(0))
+    }
+
+    /// `session.currentIndex` at a block.
+    pub async fn get_session_index_at(
+        &self,
+        block_hash: H256,
+    ) -> Result<u32, Box<dyn std::error::Error>> {
+        let at = self.online_client().at_block(block_hash).await?;
+        let decoded = at
+            .storage()
+            .try_fetch(mn_meta::storage().session().current_index(), ())
+            .await?
+            .map(|v| v.decode())
+            .transpose()?;
+        Ok(decoded.unwrap_or(0))
     }
 
     /// Wait until the sidechain reaches a specific epoch.

--- a/tests/e2e/tests/block_production.rs
+++ b/tests/e2e/tests/block_production.rs
@@ -1,0 +1,269 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Block-production / committee regression guard for the aura-fork removal
+//! (#1700) and pallet-session migration (#1800).
+//!
+//! Over the most-recent finalized blocks it asserts the *deterministic*
+//! invariants (the statistical/experimental analysis lives in the manual
+//! `local-environment` `block-stats` tool):
+//!
+//! - **Authorship legitimacy** — every finalized block's AURA author
+//!   (`aura.authorities.at(parent)[slot % len]`) is a member of the committee
+//!   the committee-management RPC reports for the parent's sidechain epoch.
+//!   Since the block is finalized (the node's verifier already checked its
+//!   seal), this confirms only legitimate current-committee members produce.
+//! - **Committee source agreement** — per epoch, on-chain `aura.authorities`
+//!   equals `sidechain_getEpochCommittee` (independent sources agree).
+//! - **session/aura alignment** — `session.validators` and `aura.authorities`
+//!   have equal length (the #1800 session→aura handoff).
+//! - **session index monotonic** and **finalized heights contiguous**.
+//!
+//! It reads the parent block's state on purpose: the first block of a session
+//! is produced by the *previous* committee (rotation runs during that block),
+//! so the parent-epoch committee is the right thing to check against — this is
+//! what makes the assertions boundary-safe.
+//!
+//! `#[ignore]` so the parallel suite skips it; `+local-env-ci` runs it as a
+//! dedicated final step (after the suite + health check) to maximise the block
+//! count it can analyse.
+
+use midnight_node_e2e::api::midnight::MidnightClient;
+use midnight_node_e2e::config::Settings;
+use midnight_node_e2e::e2e_test;
+use std::collections::{HashMap, HashSet};
+use subxt::utils::H256;
+
+/// How many of the newest finalized blocks to analyse. Sized to cover a full
+/// CI run's production (~120 blocks over the ~25 min `+local-env-ci` job, since
+/// this runs as the final step) with headroom, while still bounding the read on
+/// a long-lived local chain (thousands of blocks) — cost is ~linear, ~75ms/block.
+const WINDOW: u64 = 200;
+/// Minimum blocks required to run; below this the chain is too young — soft-skip.
+const FLOOR: usize = 12;
+/// Fallback sidechain slots-per-epoch if it can't be derived from status.
+const DEFAULT_SLOTS_PER_EPOCH: u64 = 5;
+
+#[e2e_test]
+#[ignore = "post-suite: run as the final +local-env-ci step for max block count"]
+async fn block_production_and_committee_invariants() {
+    let settings = Settings::default();
+    let client = MidnightClient::new(settings.node_client).await;
+
+    // --- Sidechain slots-per-epoch: epoch = floor(slot / spe) ⇒ slot/epoch ≈ spe.
+    let (sc_epoch_now, sc_slot_now) = client
+        .get_sidechain_epoch_and_slot()
+        .await
+        .expect("sidechain_getStatus");
+    let spe = if sc_epoch_now > 0 {
+        ((sc_slot_now as f64) / (sc_epoch_now as f64)).round() as u64
+    } else {
+        DEFAULT_SLOTS_PER_EPOCH
+    }
+    .max(1);
+    tracing::info!("slots-per-epoch = {spe}");
+
+    // --- Identity bridge: getEpochCommittee returns sidechain keys, aura.authorities
+    // returns aura keys — map between them via the Ariadne permissioned candidates.
+    let mc_epoch = client.get_mainchain_epoch().await.expect("mainchain epoch");
+    let ariadne = client
+        .get_ariadne_parameters(mc_epoch, None)
+        .await
+        .expect("ariadne parameters");
+    let mut aura_to_sidechain: HashMap<String, String> = HashMap::new();
+    for cand in ariadne.permissioned_candidates.unwrap_or_default() {
+        let sc = cand["sidechainPublicKey"].as_str().map(str::to_lowercase);
+        let aura = cand["keys"]["aura"].as_str().map(str::to_lowercase);
+        if let (Some(sc), Some(aura)) = (sc, aura) {
+            aura_to_sidechain.insert(aura, sc);
+        }
+    }
+    assert!(
+        !aura_to_sidechain.is_empty(),
+        "could not build aura↔sidechain key map from Ariadne permissioned candidates \
+         (mc epoch {mc_epoch}) — cannot relate aura authorities to the committee RPC"
+    );
+
+    // --- Collect the newest finalized window.
+    let head = client
+        .get_finalized_block_number()
+        .await
+        .expect("finalized head");
+    let start = head.saturating_sub(WINDOW).max(1);
+    let count = (head - start + 1) as usize;
+    if count < FLOOR {
+        tracing::warn!(
+            "block-production audit: only {count} finalized block(s) (#{start}..#{head}); \
+             need {FLOOR} — chain too young, soft-skipping"
+        );
+        return;
+    }
+    tracing::info!("auditing finalized blocks #{start}..#{head} ({count} blocks)");
+
+    // Per-epoch caches (aura.authorities & the committee are constant within an epoch).
+    let mut committee_by_epoch: HashMap<u64, Vec<String>> = HashMap::new(); // sidechain keys
+    let mut aura_by_epoch: HashMap<u64, Vec<String>> = HashMap::new(); // aura keys
+    let mut val_len_by_epoch: HashMap<u64, usize> = HashMap::new();
+    let mut source_checked: HashSet<u64> = HashSet::new();
+
+    let mut prev: Option<(H256, u64)> = None; // (hash, slot) of the previous height
+    let mut last_session: Option<u32> = None;
+    let mut blocks_checked = 0usize;
+    let mut boundary_blocks = 0usize;
+
+    for height in start..=head {
+        let hash = client
+            .get_block_hash_at_height(height as u32)
+            .await
+            .expect("block hash at height");
+        let info = client
+            .get_block_digest_info(hash)
+            .await
+            .expect("block digest info");
+
+        let Some(slot) = info.aura_slot else {
+            // No AURA pre-digest (e.g. genesis) — break the contiguity chain.
+            prev = None;
+            continue;
+        };
+
+        // session index monotonic (read at this block).
+        let session_index = client
+            .get_session_index_at(hash)
+            .await
+            .expect("session index");
+        if let Some(prev_idx) = last_session {
+            assert!(
+                session_index >= prev_idx,
+                "session index went backwards at #{height}: {prev_idx} -> {session_index}"
+            );
+        }
+        last_session = Some(session_index);
+
+        if let Some((parent_hash, parent_slot)) = prev {
+            // Finalized heights must be contiguous.
+            assert_eq!(
+                parent_hash,
+                info.parent_hash,
+                "non-contiguous finalized chain: #{height}'s parent != #{}",
+                height - 1
+            );
+
+            // The committee that PRODUCED this block is the parent-epoch committee.
+            let parent_epoch = parent_slot / spe;
+            let own_epoch = slot / spe;
+            if parent_epoch != own_epoch {
+                boundary_blocks += 1;
+            }
+
+            // getEpochCommittee(parent_epoch) — sidechain keys.
+            if !committee_by_epoch.contains_key(&parent_epoch) {
+                let resp = client
+                    .get_epoch_committee(parent_epoch)
+                    .await
+                    .expect("getEpochCommittee");
+                let members = resp
+                    .committee
+                    .iter()
+                    .map(|m| m.sidechain_pub_key.to_lowercase())
+                    .collect();
+                committee_by_epoch.insert(parent_epoch, members);
+            }
+            let committee = &committee_by_epoch[&parent_epoch];
+
+            // aura.authorities at parent — aura keys.
+            if !aura_by_epoch.contains_key(&parent_epoch) {
+                let auth = client
+                    .get_aura_authorities_hex_at(parent_hash)
+                    .await
+                    .expect("aura authorities");
+                aura_by_epoch.insert(
+                    parent_epoch,
+                    auth.into_iter().map(|s| s.to_lowercase()).collect(),
+                );
+            }
+            let aura = &aura_by_epoch[&parent_epoch];
+            assert!(
+                !aura.is_empty(),
+                "empty aura.authorities at parent of #{height}"
+            );
+
+            // session.validators length == aura.authorities length (#1800 handoff).
+            if !val_len_by_epoch.contains_key(&parent_epoch) {
+                let len = client
+                    .get_session_validators_len_at(parent_hash)
+                    .await
+                    .expect("session validators len");
+                val_len_by_epoch.insert(parent_epoch, len);
+            }
+            assert_eq!(
+                val_len_by_epoch[&parent_epoch],
+                aura.len(),
+                "session.validators len != aura.authorities len at parent of #{height} \
+                 (epoch {parent_epoch})"
+            );
+
+            // Authorship legitimacy: author = aura.authorities[slot % len]; its sidechain
+            // key must be in the committee the RPC reports for the parent epoch.
+            let author_aura = &aura[(slot % aura.len() as u64) as usize];
+            match aura_to_sidechain.get(author_aura) {
+                Some(author_sc) => assert!(
+                    committee.iter().any(|m| m == author_sc),
+                    "block #{height} author {author_aura} (sidechain {author_sc}) is NOT in \
+                     getEpochCommittee(epoch {parent_epoch}) = {committee:?}"
+                ),
+                None => tracing::warn!(
+                    "block #{height}: author aura key {author_aura} not in Ariadne map \
+                     (likely a just-removed candidate); skipping its membership check"
+                ),
+            }
+
+            // Committee source agreement (once per epoch): aura.authorities == getEpochCommittee.
+            if source_checked.insert(parent_epoch) {
+                let mapped: Option<Vec<String>> = aura
+                    .iter()
+                    .map(|a| aura_to_sidechain.get(a).cloned())
+                    .collect();
+                match mapped {
+                    Some(mut lhs) => {
+                        let mut rhs = committee.clone();
+                        lhs.sort();
+                        rhs.sort();
+                        assert_eq!(
+                            lhs, rhs,
+                            "aura.authorities != getEpochCommittee for epoch {parent_epoch}"
+                        );
+                    }
+                    None => tracing::warn!(
+                        "epoch {parent_epoch}: an aura authority is absent from the Ariadne map; \
+                         skipping committee-source agreement for this epoch"
+                    ),
+                }
+            }
+
+            blocks_checked += 1;
+        }
+
+        prev = Some((hash, slot));
+    }
+
+    assert!(
+        blocks_checked > 0,
+        "no blocks were checked — window collection produced nothing usable"
+    );
+    tracing::info!(
+        "✅ block-production audit passed: {blocks_checked} block(s), \
+         {} epoch(s), {boundary_blocks} session-boundary block(s)",
+        source_checked.len()
+    );
+}

--- a/tests/e2e/tests/cnight/observation.rs
+++ b/tests/e2e/tests/cnight/observation.rs
@@ -8,7 +8,7 @@ use midnight_node_metadata::midnight_metadata_latest::c_night_observation::event
 };
 use midnight_node_toolkit::cli_parsers::SchemeSeed;
 use midnight_node_toolkit::commands::dust_balance::{
-    self, DustBalanceArgs, DustBalanceJson, DustBalanceResult,
+    DustBalanceArgs, DustBalanceJson, DustBalanceResult,
 };
 use midnight_node_toolkit::tx_generator::source::Source;
 use std::collections::HashMap;

--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -719,6 +719,7 @@ pub(crate) fn fetch_concurrency() -> usize {
 }
 
 // -------- TEST MODULES --------
+mod block_production;
 mod c2m_bridge;
 mod cnight;
 mod contract_state;


### PR DESCRIPTION
# Overview

Adds an e2e regression guard for block production and committee rotation,
locking into CI the deterministic invariants that were validated manually for
the aura-fork removal (#1700) and the pallet-session migration (#1800).

`tests/e2e/tests/block_production.rs` audits the newest finalized blocks and asserts:

- **Authorship legitimacy** — every block's AURA author
  (`aura.authorities.at(parent)[slot % len]`) is a member of
  `sidechain_getEpochCommittee` for the parent's sidechain epoch. Reading the
  **parent** state is deliberate: the first block of a session is produced by
  the *previous* committee (rotation runs during that block), so this is
  boundary-safe. As the block is finalized (the node's verifier already checked
  its seal), this confirms only legitimate current-committee members produce.
- **Committee source agreement** — per epoch, on-chain `aura.authorities` equals
  `sidechain_getEpochCommittee` (two independent sources must agree).
- **session/aura alignment** — `session.validators` and `aura.authorities` stay
  equal length (the pallet_session → aura handoff).
- **session index monotonic** and **finalized heights contiguous**.

The test is `#[ignore]` so the parallel suite skips it; `+local-env-ci` runs it
as the **final** step (after the suite + health check) so it analyses the most
blocks — bounded to the newest 200. Supporting `MidnightClient` helpers were
added (`get_epoch_committee`, `get_block_digest_info`, `get_aura_authorities_hex_at`,
`get_session_index_at`, `get_session_validators_len_at`, `get_sidechain_epoch_and_slot`,
`get_mainchain_epoch`). Also drops a pre-existing unused `self` import in the
cnight e2e test (separate commit).

Statistical/experimental analysis (seat-allocation convergence, per-Cardano-epoch
tables, permissioned-candidate-removal detection) intentionally stays out of CI —
it needs hundreds of epochs and a mid-run governance action the ~120-block CI run
can't provide.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- N/A: test-only, no feature -->
- [ ] Update documentation (if relevant) <!-- N/A -->
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- N/A -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Ran the ignored test against a local `local-env` (runtime 2.1.0):

```
cargo test --test e2e_tests --no-default-features --features local -- --ignored block_production --nocapture

INFO block_production_and_committee_invariants: slots-per-epoch = 5
INFO block_production_and_committee_invariants: auditing finalized blocks #5691..#5891 (201 blocks)
INFO block_production_and_committee_invariants: ✅ block-production audit passed: 200 block(s), 41 epoch(s), 40 session-boundary block(s)
test block_production::block_production_and_committee_invariants ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 14.46s
```

- Normal suite run (without `--ignored`) reports it as `ignored` (0 run), confirming it only runs in the dedicated final `+local-env-ci` step.
- `cargo fmt` and `cargo clippy -p midnight-node-e2e --features local --tests` are clean.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] N/A <!-- test-only; no runtime or client behaviour change -->

## Links

- Issue: https://github.com/midnightntwrk/midnight-node/issues/1759
