### PR TITLE
fix: reserve-contracts CLI change-federated-ops on local-env (Ogmios 3002)

### DIFF
--- a/changes/node/changed/reserve-contracts-cli-additionalutxo-fix.md
+++ b/changes/node/changed/reserve-contracts-cli-additionalutxo-fix.md
@@ -1,0 +1,15 @@
+#fix #tooling
+# Fix reserve-contracts CLI governance-update txs on local-env (Ogmios 3002)
+
+The bun CLI's governance-update commands (e.g. `change-federated-ops`) failed
+with Ogmios error 3002 ("additional UTxO entries overlap with those that exist
+in the ledger") when spending existing on-chain Plutus script UTxOs via the
+kupmios provider: Blaze passes the tx's attached on-chain inputs to Ogmios
+`evaluateTransaction` as `additionalUtxo`, which Ogmios rejects. `complete-tx.ts`
+now reuses the local UPLC evaluator (already run in phase 1) for phase-2
+completion, avoiding the provider evaluate round-trip — guarded to only apply
+when the local eval succeeded, so deploy-time commands are unchanged. Bumps the
+`midnight-reserve-contracts` submodule.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1934
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1933


### PR DESCRIPTION
# Overview

Fixes the `midnight-reserve-contracts` bun CLI failing to build governance-update
transactions (e.g. `change-federated-ops`) on local-env with Ogmios error **3002**
("additional UTxO entries overlap with those that exist in the ledger"). When a
command spends existing on-chain Plutus script UTxOs, Blaze passes those inputs to
Ogmios `evaluateTransaction` as `additionalUtxo`, which Ogmios rejects. `complete-tx.ts`
now reuses the phase-1 local UPLC evaluator for phase-2 completion, avoiding the provider
evaluate round-trip — guarded to only apply when the local eval already succeeded, so
deploy-time flows are unchanged. Bumps the `midnight-reserve-contracts` submodule.

Closes #1933

## 📌 Submission Checklist

- [x] Changes are backward-compatible
- [x] Pull request description explains why the change is needed
- [x] I have included a change file

## 🧪 Testing Evidence

`bun cli change-federated-ops -p kupmios --use-build …` now builds + signs, and
`sign-and-submit` lands the tx on local-env (previously threw 3002 at `complete()`).
Verified end-to-end while reducing permissioned candidates 5→3.

## 🔱 Fork Strategy

- [x] N/A — local-env tooling only (reserve-contracts CLI); no node runtime/client change.

## Links

- Closes #1933
