### PR TITLE
fix(toolkit): don't report FAILED_TO_FINALIZE when the including block finalized

### DIFF
--- a/changes/toolkit/changed/sender-finality-fallback.md
+++ b/changes/toolkit/changed/sender-finality-fallback.md
@@ -1,0 +1,36 @@
+#toolkit
+# Fix sender reporting `FAILED_TO_FINALIZE` for txs whose including block finalized
+
+After a tx reached a best block, `wait_for_finalized` only matched
+`InFinalizedBlock` on the `submit_and_watch` subscription and silently
+swallowed terminal pool events (`Invalid`/`Dropped`/`Error`),
+subscription errors, and stream end — then reported
+`FAILED_TO_FINALIZE` without checking whether the already-known
+including block finalized. When the submit node's tx pool kills the
+watcher after inclusion (e.g. a stale pool copy of an already-included
+tx failing pre-dispatch with `IntentAlreadyExists` at the node's own
+authoring slot), a landed, finalizing transaction was reported as a
+finality failure. Downstream tooling then retried the same spend from
+cached state, producing false `DustDoubleSpend` / `NullifierAlreadyPresent`
+rejections.
+
+- Terminal subscription events are logged the moment they arrive, with
+  their reason.
+- On any watcher death (terminal event, stream end, or timeout), the
+  sender falls back to polling the node directly for whether the
+  `InBestBlock` block finalized, via the new reorg-safe
+  `MidnightNodeClient::is_block_finalized` (at or below finalized
+  height and canonical at its height).
+- Fallback-confirmed txs log `FINALIZED_VIA_FALLBACK` with a `reason`
+  field (instead of plain `FINALIZED`), so pool watcher deaths remain
+  countable per URL.
+- The fallback gets a minimum 10s polling window even when the watcher
+  dies near the end of the 60s finality budget.
+- Sibling fix in `wait_for_best_block`: `InFinalizedBlock` is now a
+  success arm (skipping the finality wait) instead of being recorded as
+  `last_status` and eventually reported as `FAILED_TO_REACH_BEST_BLOCK`
+  if the subscription coalesces straight to finalization.
+- `SenderError::FailedToFinalize` and the `FAILED_TO_FINALIZE` log line
+  now carry the underlying reason.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/XXXX

--- a/changes/toolkit/changed/sender-finality-fallback.md
+++ b/changes/toolkit/changed/sender-finality-fallback.md
@@ -33,4 +33,4 @@ rejections.
 - `SenderError::FailedToFinalize` and the `FAILED_TO_FINALIZE` log line
   now carry the underlying reason.
 
-PR: https://github.com/midnightntwrk/midnight-node/pull/XXXX
+PR: https://github.com/midnightntwrk/midnight-node/pull/1943

--- a/util/toolkit/src/client.rs
+++ b/util/toolkit/src/client.rs
@@ -144,6 +144,24 @@ impl MidnightNodeClient {
 		Ok(header.number)
 	}
 
+	/// Whether `hash` is on the finalized chain: at or below the finalized head
+	/// and canonical at its height.
+	pub async fn is_block_finalized(
+		&self,
+		hash: HashFor<MidnightNodeClientConfig>,
+	) -> Result<bool, ClientError> {
+		let Some(header) = self.rpc.chain_get_header(Some(hash)).await? else {
+			// The node no longer knows the block: pruned or reorged away.
+			return Ok(false);
+		};
+		if header.number > self.get_finalized_height().await? {
+			return Ok(false);
+		}
+		let canonical =
+			self.rpc.chain_get_block_hash(Some(BlockNumber::Number(header.number))).await?;
+		Ok(canonical == Some(hash))
+	}
+
 	pub async fn get_ledger_parameters(&self) -> Result<LedgerParameters, ClientError> {
 		let call = mn_meta::runtime_apis::RuntimeApi.midnight_runtime_api().get_ledger_parameters();
 		let response = self.api.at_current_block().await?.runtime_apis().call(call).await?;

--- a/util/toolkit/src/sender.rs
+++ b/util/toolkit/src/sender.rs
@@ -24,7 +24,7 @@ use std::{
 };
 use subxt::{
 	client::OnlineClientAtBlockImpl,
-	config::Hash,
+	config::{Hash, HashFor},
 	error::{BackendError, ExtrinsicError, RpcError},
 	tx::{TransactionInBlock, TransactionProgress, TransactionStatus},
 };
@@ -52,8 +52,8 @@ pub enum SenderError {
 		 evicted it. A synced node with finalized blocks does not imply the tx is valid."
 	)]
 	FailedToReachBestBlock { last_status: String },
-	#[error("tx reached best block but was not finalized within timeout")]
-	FailedToFinalize,
+	#[error("tx reached best block but was not finalized within timeout: {reason}")]
+	FailedToFinalize { reason: String },
 	#[error("runtime reported tx invalid: {message}")]
 	InvalidTransaction { message: String },
 	#[error("tx was dropped from the pool: {message}")]
@@ -127,10 +127,21 @@ pub struct ClientHandle {
 
 struct Progress {
 	url: String,
+	client: Arc<MidnightNodeClient>,
 	tx_progress: TransactionProgress<
 		MidnightNodeClientConfig,
 		OnlineClientAtBlockImpl<MidnightNodeClientConfig>,
 	>,
+}
+
+/// How finalization of a sent tx was confirmed.
+enum Finalized {
+	/// The tx subscription delivered `InFinalizedBlock`.
+	Subscription,
+	/// The subscription died without a finalization event, but a direct query
+	/// confirmed the including block finalized. Carries the reason the
+	/// subscription gave up.
+	Fallback { watch_reason: String },
 }
 
 pub struct Sender {
@@ -286,18 +297,27 @@ impl Sender {
 			midnight_tx_hash = &tx_hashes.midnight_tx_hash;
 			"SENT"
 		);
-		Ok((tx_hashes, Progress { url: client.url.clone(), tx_progress }))
+		Ok((
+			tx_hashes,
+			Progress { url: client.url.clone(), client: client.client.clone(), tx_progress },
+		))
 	}
 
+	/// Waits until the tx lands in a block. The `bool` in the success value is
+	/// true when the subscription skipped straight to `InFinalizedBlock`
+	/// (event coalescing under load) — the caller can skip the finality wait.
 	async fn wait_for_best_block(
 		mut progress: Progress,
 	) -> (
 		Progress,
 		Result<
-			TransactionInBlock<
-				MidnightNodeClientConfig,
-				OnlineClientAtBlockImpl<MidnightNodeClientConfig>,
-			>,
+			(
+				TransactionInBlock<
+					MidnightNodeClientConfig,
+					OnlineClientAtBlockImpl<MidnightNodeClientConfig>,
+				>,
+				bool,
+			),
 			SenderError,
 		>,
 	) {
@@ -307,7 +327,8 @@ impl Sender {
 		let wait_future = async {
 			while let Some(prog) = progress.tx_progress.next().await {
 				match prog {
-					Ok(TransactionStatus::InBestBlock(info)) => return Ok(info),
+					Ok(TransactionStatus::InBestBlock(info)) => return Ok((info, false)),
+					Ok(TransactionStatus::InFinalizedBlock(info)) => return Ok((info, true)),
 					Ok(TransactionStatus::Invalid { message }) => {
 						return Err(SenderError::InvalidTransaction { message });
 					},
@@ -322,7 +343,6 @@ impl Sender {
 							TransactionStatus::Validated => "Validated",
 							TransactionStatus::Broadcasted => "Broadcasted",
 							TransactionStatus::NoLongerInBestBlock => "NoLongerInBestBlock",
-							TransactionStatus::InFinalizedBlock(_) => "InFinalizedBlock",
 							_ => "Unknown",
 						};
 					},
@@ -357,41 +377,89 @@ impl Sender {
 
 	async fn wait_for_finalized(
 		mut progress: Progress,
-	) -> Option<
-		TransactionInBlock<
-			MidnightNodeClientConfig,
-			OnlineClientAtBlockImpl<MidnightNodeClientConfig>,
-		>,
-	> {
+		best_block_hash: HashFor<MidnightNodeClientConfig>,
+	) -> Result<Finalized, String> {
 		const FINALIZED_TIMEOUT: Duration = Duration::from_secs(60);
+		const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(2);
+		const MIN_FALLBACK_WINDOW: Duration = Duration::from_secs(10);
 
 		let url = progress.url.clone();
-		let wait_future = async {
-			while let Some(prog) = progress.tx_progress.next().await {
-				if let Ok(TransactionStatus::InFinalizedBlock(info)) = prog {
-					return Some(info);
-				}
-			}
-			None
-		};
+		let deadline = tokio::time::Instant::now() + FINALIZED_TIMEOUT;
 
-		match tokio::time::timeout(FINALIZED_TIMEOUT, wait_future).await {
-			Ok(result) => result,
-			Err(_) => {
+		let watch_future = async {
+			while let Some(prog) = progress.tx_progress.next().await {
+				let reason = match prog {
+					Ok(TransactionStatus::InFinalizedBlock(_)) => return Ok(()),
+					Ok(TransactionStatus::Invalid { message }) => {
+						format!("pool reported Invalid: {message}")
+					},
+					Ok(TransactionStatus::Dropped { message }) => {
+						format!("pool reported Dropped: {message}")
+					},
+					Ok(TransactionStatus::Error { message }) => {
+						format!("pool reported Error: {message}")
+					},
+					Ok(_) => continue,
+					Err(e) => format!("subscription error: {e}"),
+				};
 				log::warn!(
 					url = url;
-					"Timeout waiting for finalization after {} seconds",
-					FINALIZED_TIMEOUT.as_secs()
+					"terminal event on tx subscription after best block: {reason}"
 				);
-				None
-			},
+				return Err(reason);
+			}
+			let reason = "subscription ended without a finalization event".to_string();
+			log::warn!(url = url; "{reason}");
+			Err(reason)
+		};
+
+		let watch_reason = match tokio::time::timeout_at(deadline, watch_future).await {
+			Ok(Ok(())) => return Ok(Finalized::Subscription),
+			Ok(Err(reason)) => reason,
+			Err(_) => format!("no finalization event after {}s", FINALIZED_TIMEOUT.as_secs()),
+		};
+
+		// The subscription is not authoritative for a tx that already reached a best
+		// block: the pool can drop its watcher (terminal event, stream end) even
+		// though that block finalizes normally. Ask the node directly about the
+		// including block before declaring failure.
+		log::debug!(
+			url = url;
+			"tx subscription gave no finalization event ({watch_reason}), \
+			 checking finality of the including block directly"
+		);
+		// Guarantee a minimum direct-check window even when the watcher died late
+		// in the finalization budget — the check is cheap, and a watcher death at
+		// t=59s must not reintroduce the false failure right when the node is
+		// under load.
+		let fallback_deadline = deadline.max(tokio::time::Instant::now() + MIN_FALLBACK_WINDOW);
+		loop {
+			match progress.client.is_block_finalized(best_block_hash).await {
+				Ok(true) => return Ok(Finalized::Fallback { watch_reason }),
+				Ok(false) => {},
+				// Transient RPC failures must not fail the tx: log and let the
+				// next tick retry until the deadline.
+				Err(e) => {
+					log::warn!(url = url; "failed to check block finality: {e}");
+				},
+			}
+			if tokio::time::Instant::now() >= fallback_deadline {
+				break;
+			}
+			tokio::time::sleep(FINALITY_POLL_INTERVAL).await;
 		}
+		log::warn!(
+			url = url;
+			"including block not finalized within {}s ({watch_reason})",
+			FINALIZED_TIMEOUT.as_secs()
+		);
+		Err(watch_reason)
 	}
 
 	async fn send_and_log(&self, tx_hashes: &TxHashes, tx: Progress) -> Result<(), SenderError> {
 		let url = tx.url.clone();
 		let (progress, best_block_result) = Self::wait_for_best_block(tx).await;
-		let best_block = match best_block_result {
+		let (best_block, already_finalized) = match best_block_result {
 			Ok(info) => info,
 			Err(err) => {
 				let tag = match &err {
@@ -418,15 +486,50 @@ impl Sender {
 			"BEST_BLOCK"
 		);
 
-		let finalized = Self::wait_for_finalized(progress).await;
-		let message = if finalized.is_some() { "FINALIZED" } else { "FAILED_TO_FINALIZE" };
-		log::info!(
-			url = &url,
-			extrinsic_hash = &tx_hashes.extrinsic_hash,
-			midnight_tx_hash = &tx_hashes.midnight_tx_hash,
-			block_hash = hash_to_str(best_block.block_hash()).as_str();
-			"{message}"
-		);
-		if finalized.is_some() { Ok(()) } else { Err(SenderError::FailedToFinalize) }
+		if already_finalized {
+			log::info!(
+				url = &url,
+				extrinsic_hash = &tx_hashes.extrinsic_hash,
+				midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+				block_hash = hash_to_str(best_block.block_hash()).as_str();
+				"FINALIZED"
+			);
+			return Ok(());
+		}
+
+		match Self::wait_for_finalized(progress, best_block.block_hash()).await {
+			Ok(Finalized::Subscription) => {
+				log::info!(
+					url = &url,
+					extrinsic_hash = &tx_hashes.extrinsic_hash,
+					midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+					block_hash = hash_to_str(best_block.block_hash()).as_str();
+					"FINALIZED"
+				);
+				Ok(())
+			},
+			Ok(Finalized::Fallback { watch_reason }) => {
+				log::info!(
+					url = &url,
+					extrinsic_hash = &tx_hashes.extrinsic_hash,
+					midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+					block_hash = hash_to_str(best_block.block_hash()).as_str(),
+					reason = watch_reason.as_str();
+					"FINALIZED_VIA_FALLBACK"
+				);
+				Ok(())
+			},
+			Err(reason) => {
+				log::info!(
+					url = &url,
+					extrinsic_hash = &tx_hashes.extrinsic_hash,
+					midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+					block_hash = hash_to_str(best_block.block_hash()).as_str(),
+					reason = reason.as_str();
+					"FAILED_TO_FINALIZE"
+				);
+				Err(SenderError::FailedToFinalize { reason })
+			},
+		}
 	}
 }


### PR DESCRIPTION
# Overview

After a tx reached a best block, the toolkit sender's `wait_for_finalized` only matched `InFinalizedBlock` on the `submit_and_watch` subscription and silently swallowed terminal pool events (`Invalid`/`Dropped`/`Error`), subscription errors, and stream end — then reported `FAILED_TO_FINALIZE` without checking whether the already-known including block finalized.

This matters because the node's tx pool can kill the watcher *after* inclusion: on `214eebf`-lineage nodes under load (≥ ~24 concurrent watched txs), a stale pool copy of an already-included tx fails pre-dispatch with `ReplayProtectionViolation(IntentAlreadyExists)` at the submit node's own authoring slot, the pool marks it `Invalid`, and the subscription terminates — seconds before the including block finalizes. The toolkit then reported a landed, finalizing transaction as a finality failure, and batch tooling retried the same spend from cached state, producing false `DustDoubleSpend` (`Custom(196)`) / `NullifierAlreadyPresent` (`Custom(239)`) rejections that masqueraded as ledger double-spend bugs. (Node-side issue with full analysis to be filed separately; link will be added below.)

Changes:
- **Log terminal subscription events** the moment they arrive, with their reason — watcher deaths are now directly observable instead of silent.
- **Direct finality fallback:** on any watcher death (terminal event, stream end, or timeout), poll the node for whether the `InBestBlock` block finalized, via the new reorg-safe `MidnightNodeClient::is_block_finalized` (at or below finalized height *and* canonical at its height).
- **Distinct tag for recovered txs:** fallback-confirmed txs log `FINALIZED_VIA_FALLBACK` with a `reason` field, so pool watcher deaths remain countable per URL (`grep -c` friendly).
- **Minimum fallback window:** the direct check gets at least 10s of polling even when the watcher dies near the end of the 60s finality budget.
- **Sibling fix in `wait_for_best_block`:** `InFinalizedBlock` is now a success arm (skipping the finality wait) instead of being recorded as `last_status` and eventually reported as `FAILED_TO_REACH_BEST_BLOCK` if the subscription coalesces straight to finalization.
- `SenderError::FailedToFinalize` and the `FAILED_TO_FINALIZE` log line now carry the underlying reason.

## 🗹 TODO before merging

- [ ] Add node-repo issue link to the change file and Links section once filed
- [ ] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking) — log output gains new tags/fields; `SenderError::FailedToFinalize` gains a `reason` field (internal toolkit API)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: `changes/toolkit/changed/sender-finality-fallback.md`
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Validated on perfnet (8 validators + 1 RPC across 4 AWS regions, 6 s blocks) with an instrumented toolkit build of this branch: two identical 24-worker register-dust + funding-cascade runs of 500 wallets (1000 watched txs per leg), one submit node per leg:

| Submit node version | Watched txs | Watcher killed after inclusion (block finalized anyway) | True finality failures |
|---|---|---|---|
| `2.1.0-214eebf` | 1000 | **85 (8.5%)** — all `pool reported Invalid: Extrinsic marked as invalid` after `InBestBlock`, all recovered as `FINALIZED_VIA_FALLBACK` | 0 |
| `2.1.0-8fa07df` | 1000 | 0 | 0 |

Every fallback-recovered tx was confirmed applied on all 8 nodes and never reverted; chain finality stayed ≤ 3 blocks behind best with zero reorgs throughout. Before this fix, the same failure mode caused downstream retries to be rejected with `DustDoubleSpend`/`NullifierAlreadyPresent`.

Also: `cargo check`, `cargo clippy`, `cargo fmt` clean on `midnight-node-toolkit`.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: toolkit (client tooling) change only — no node/runtime impact, safe to roll out independently.
- [ ] N/A

## Links

Node-side issue (tx pool invalidates already-included txs and kills `submit_and_watch` subscriptions before finality): to be filed — link will be added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)