### PR TITLE
[DO NOT MERGE] explore: ledger 8->9 hardfork migration as a multi-block migration

### DIFF
--- a/changes/runtime/changed/ledger-8-to-9-hardfork-migration.md
+++ b/changes/runtime/changed/ledger-8-to-9-hardfork-migration.md
@@ -3,14 +3,49 @@
 # On-chain ledger 8->9 hardfork state migration
 
 Lets a ledger-8 chain (e.g. `1.0.1`) runtime-upgrade in place to the current
-ledger-9 runtime. A new host fn, `migrate_state_v8_to_v9`, runs the
+ledger-9 runtime. A new host fn, `migrate_state_v8_to_v9_step`, runs the
 `StateTranslationTable` (ported from `midnight-ledger` PR #539) to translate
 the on-chain `LedgerState` from v13 to v18. It's wired in as
-`pallet_midnight::migrations::v2::MigrateV1ToV2`, a `VersionedMigration<1,2,..>`
-that fires once when a ledger-8 chain (pallet-midnight storage version 1)
-upgrades to this runtime (storage version 2); a fresh ledger-9 genesis starts
-at version 2 and skips it. The migration's weight is derived from the ledger
-cost model rather than a hand-tuned estimate.
+`pallet_midnight::migrations::v2::MigrateV1ToV2`, a `SteppedMigration` under the
+already-deployed `pallet-migrations`, which fires once when a ledger-8 chain
+(pallet-midnight storage version 1) upgrades to this runtime (storage version 2);
+a fresh ledger-9 genesis starts at version 2 and skips it.
+
+The translation walks the whole state DAG, so its cost is unbounded in state
+size — for mainnet-sized state it measures well under a second and completes in
+the upgrade block itself, but a single-block migration that overran would make
+the upgrade block take longer than a slot to execute on every importing node.
+Running it as a multi-block migration turns that failure mode into graceful
+multi-block progress: each step gets 75% of the per-block MBM service weight as
+its ledger cost-model budget, parks the in-flight translation in the ledger
+arena, and hands back the arena key as its cursor.
+
+The ledger's translation engine is only resumable down to the granularity of its
+persistent memo cache, so each state has a threshold budget below which a step
+makes no net progress. Measured on synthetic states the threshold is tens of
+milliseconds against a ~1.2s per-block budget, and it tracks the state's node
+granularity rather than its total size. To guarantee termination regardless, the
+migration doubles its per-step budget every 16 blocks it has been running (capped
+at 2^20x); a normally-progressing migration finishes long before the first
+doubling.
+
+Multi-block migrations are serviced *after* a block's inherents, so for the
+blocks the migration spans the ledger is paused: the post-block ledger update is
+skipped, `pallet-cnight-observation` skips `process_tokens` without advancing
+`NextCardanoPosition`, and the Cardano-to-Midnight bridge defers the whole
+transfer batch without advancing its data checkpoint. Nothing is lost — both
+inherents re-deliver the same data in a later block, and `frame_executive`
+already restricts these blocks to inherents only.
+
+The toolkit's fork-aware block replay is updated to match. It now picks each
+block's ledger version from the tag embedded in the block's recorded state root
+rather than from the runtime spec version, because during the migration window the
+ledger-9 runtime is live while the state is still ledger-8; and it does not apply
+blocks whose state root is unchanged from their parent's, since the chain's ledger
+did not move in them either. `hardfork_e2e` waits for the finalized state to reach
+ledger 9 before building post-fork transactions — a client that syncs to a
+mid-migration head would otherwise build ledger-8 transactions, which those
+inherent-only blocks could not have included anyway.
 
 Also includes two fixes needed to support both ledger-8 and ledger-9 chains:
 version-aware genesis seeding (detected via `serialize::peek_tag` instead of

--- a/changes/runtime/changed/ledger-8-to-9-hardfork-migration.md
+++ b/changes/runtime/changed/ledger-8-to-9-hardfork-migration.md
@@ -54,4 +54,5 @@ hardcoding the v9 deserializer), and restoring the ledger-8
 still imports.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1925
+PR: https://github.com/midnightntwrk/midnight-node/pull/1962
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1580

--- a/ledger/helpers/src/fork/raw_block_data.rs
+++ b/ledger/helpers/src/fork/raw_block_data.rs
@@ -127,6 +127,44 @@ impl LedgerVersion {
 			_ => None,
 		}
 	}
+
+	/// Determine a block's ledger version from its recorded state root.
+	///
+	/// The root is a `tagged_serialize`d `TypedArenaKey<Ledger>` whose tag embeds
+	/// the `LedgerState` version (`storage-key(midnight:ledger-state[vN]:…)`), so
+	/// it reports the version of the state the block actually left behind.
+	///
+	/// This is *more* authoritative than the block's runtime spec version across
+	/// the ledger 8 -> 9 hardfork: the state translation is a multi-block
+	/// migration serviced after each block's inherents, so the first block (or
+	/// blocks) executed by the ledger-9 runtime still carry a ledger-8 state root.
+	/// Partitioning a replay by spec version alone would hand those blocks to the
+	/// ledger-9 context and fail its state-root check.
+	///
+	/// Returns `None` if the tag is unreadable or unrecognised.
+	pub fn from_state_root(state_root: &[u8]) -> Option<Self> {
+		use crate::ledger_9::ledger_storage::{arena::TypedArenaKey, db::DB, db::InMemoryDB as Db};
+		use midnight_serialize::{Tagged, peek_tag};
+
+		// The node wraps `LedgerState` in its own `Ledger` type, whose `Tagged`
+		// impl forwards to `LedgerState`'s, so the two produce the same key tag.
+		// The hasher parameter does not appear in the tag.
+		fn key_tag<T: Tagged>() -> String {
+			<TypedArenaKey<T, <Db as DB>::Hasher> as Tagged>::tag().into_owned()
+		}
+
+		let tag = peek_tag(&mut std::io::Cursor::new(state_root)).ok()?;
+		// Compared against the live types' tags rather than string literals, so a
+		// tag change upstream surfaces as an unknown version rather than a silent
+		// mis-dispatch.
+		if tag == key_tag::<crate::ledger_9::mn_ledger::structure::LedgerState<Db>>() {
+			Some(LedgerVersion::Ledger9)
+		} else if tag == key_tag::<crate::ledger_8::mn_ledger::structure::LedgerState<Db>>() {
+			Some(LedgerVersion::Ledger8)
+		} else {
+			None
+		}
+	}
 }
 
 impl RawBlockData {
@@ -151,9 +189,34 @@ impl RawBlockData {
 		}
 	}
 
-	/// Get the ledger version for this block.
+	/// The ledger version to replay this block under.
+	///
+	/// Prefers the version implied by the recorded state root, falling back to the
+	/// runtime spec version recorded at fetch time. See
+	/// [`LedgerVersion::from_state_root`] for why the state root wins: across the
+	/// ledger 8 -> 9 hardfork the state translation is a multi-block migration, so
+	/// the first block(s) under the ledger-9 runtime still leave a ledger-8 state
+	/// root behind.
 	pub fn ledger_version(&self) -> LedgerVersion {
-		self.ledger_version
+		self.state_root
+			.as_deref()
+			.and_then(LedgerVersion::from_state_root)
+			.unwrap_or(self.ledger_version)
+	}
+
+	/// Whether this block left the ledger state untouched, i.e. its recorded state
+	/// root is identical to `previous_state_root`.
+	///
+	/// True for the blocks the ledger 8 -> 9 migration spans: `pallet_midnight`'s
+	/// `on_finalize` skips the post-block ledger update while the translation is in
+	/// flight, and `frame_executive` admits only inherents in those blocks, so
+	/// nothing moves the state. A replay must skip them wholesale — applying a
+	/// post-block update would advance its own state past the chain's.
+	pub fn leaves_ledger_unchanged(&self, previous_state_root: Option<&Vec<u8>>) -> bool {
+		match (self.state_root.as_ref(), previous_state_root) {
+			(Some(root), Some(previous)) => root == previous,
+			_ => false,
+		}
 	}
 }
 
@@ -234,5 +297,71 @@ impl TryFrom<&SerializedTxBatches> for Vec<RawBlockData> {
 		}
 
 		Ok(blocks)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Real `pallet_midnight::StateKey` values observed on a dev chain across the
+	/// ledger 8 -> 9 hardfork.
+	const V8_ROOT_HEX: &str = "6d69646e696768743a73746f726167652d6b6579286c65646765722d73746174655b7631335d293a000bb99ebc32c6ec259251c930a09f1c63ece3e8197cb9ce8b8d4246dd26914182";
+	const V9_ROOT_HEX: &str = "6d69646e696768743a73746f726167652d6b6579286c65646765722d73746174655b7631385d293a00620d5ce98a447d2429b8cbb48ee9908af933023a256590b97f710d12a89f4edb";
+
+	fn block(number: u64, spec_version: LedgerVersion, root: Option<&str>) -> RawBlockData {
+		RawBlockData {
+			number,
+			ledger_version: spec_version,
+			state_root: root.map(|hex| hex::decode(hex).unwrap()),
+			..RawBlockData::new_from_timestamp(0, spec_version, Vec::new())
+		}
+	}
+
+	#[test]
+	fn ledger_version_from_state_root_tag() {
+		let v8 = hex::decode(V8_ROOT_HEX).unwrap();
+		let v9 = hex::decode(V9_ROOT_HEX).unwrap();
+		assert_eq!(LedgerVersion::from_state_root(&v8), Some(LedgerVersion::Ledger8));
+		assert_eq!(LedgerVersion::from_state_root(&v9), Some(LedgerVersion::Ledger9));
+		assert_eq!(LedgerVersion::from_state_root(b"not a tagged root"), None);
+	}
+
+	/// The migration window: the ledger-9 runtime is live (spec version says
+	/// `Ledger9`) but the state has not been translated yet. The replay must go by
+	/// the state root, or it hands the block to a ledger-9 context that cannot
+	/// reproduce a ledger-8 root.
+	#[test]
+	fn state_root_wins_over_spec_version() {
+		assert_eq!(
+			block(35, LedgerVersion::Ledger9, Some(V8_ROOT_HEX)).ledger_version(),
+			LedgerVersion::Ledger8,
+		);
+		assert_eq!(
+			block(36, LedgerVersion::Ledger9, Some(V9_ROOT_HEX)).ledger_version(),
+			LedgerVersion::Ledger9,
+		);
+	}
+
+	/// With no usable state root there is nothing better than the spec version.
+	#[test]
+	fn spec_version_is_the_fallback() {
+		assert_eq!(block(1, LedgerVersion::Ledger8, None).ledger_version(), LedgerVersion::Ledger8);
+		assert_eq!(block(1, LedgerVersion::Ledger7, None).ledger_version(), LedgerVersion::Ledger7);
+	}
+
+	#[test]
+	fn leaves_ledger_unchanged_detects_a_paused_block() {
+		let v8_root = hex::decode(V8_ROOT_HEX).unwrap();
+		let v9_root = hex::decode(V9_ROOT_HEX).unwrap();
+		let paused = block(35, LedgerVersion::Ledger9, Some(V8_ROOT_HEX));
+
+		assert!(paused.leaves_ledger_unchanged(Some(&v8_root)), "same root as parent");
+		assert!(!paused.leaves_ledger_unchanged(Some(&v9_root)), "different root from parent");
+		assert!(!paused.leaves_ledger_unchanged(None), "no parent root to compare against");
+		assert!(
+			!block(35, LedgerVersion::Ledger9, None).leaves_ledger_unchanged(Some(&v8_root)),
+			"no root of its own to compare",
+		);
 	}
 }

--- a/ledger/src/common/types.rs
+++ b/ledger/src/common/types.rs
@@ -266,6 +266,20 @@ pub struct BenchmarkClaimMintTxBuilder {
 	pub token: Vec<u8>,
 }
 
+/// Outcome of one bounded step of the ledger v8 -> v9 state translation
+/// (`Ledger9Bridge::migrate_state_v8_to_v9_step`).
+///
+/// Lives here rather than next to the host implementation because the on-chain
+/// half (`pallet_midnight::migrations::v2`) is `no_std`, whereas the translation
+/// module is std-only.
+#[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq, Eq)]
+pub enum TranslationStep {
+	/// Translation is incomplete. Pass `cursor` back to the next step verbatim.
+	InProgress { cursor: Vec<u8> },
+	/// Translation finished. Store `state_key` into `pallet_midnight::StateKey`.
+	Done { state_key: Vec<u8> },
+}
+
 pub type SegmentId = u16;
 
 #[derive(Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo)]

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -2,7 +2,8 @@
 use crate::ledger_9::Bridge;
 use crate::{
 	common::types::{
-		GasCost, Hash, SystemTransactionAppliedStateRoot, TransactionAppliedStateRoot, Tx,
+		GasCost, Hash, SystemTransactionAppliedStateRoot, TransactionAppliedStateRoot,
+		TranslationStep, Tx,
 	},
 	ledger_9::{BlockContext, types::LedgerApiError},
 };
@@ -501,29 +502,40 @@ pub trait Ledger9Bridge {
 		true
 	}
 
-	/// Translate the ledger state from ledger-v8 format to ledger-v9 format.
+	/// Run one bounded step of the ledger-v8 -> ledger-v9 state translation.
 	///
-	/// Called by `pallet_midnight`'s v8->v9 storage migration during the runtime
-	/// upgrade that crosses into ledger-9. `state_key` is the pallet's `StateKey`
-	/// (a v8 arena root); returns the new v9 arena root to store back, together
-	/// with the synthetic cost (picoseconds) the translation consumed against
-	/// the ledger's cost model, for the pallet to charge as this migration's
-	/// weight.
-	fn migrate_state_v8_to_v9(
+	/// Driven once per block by `pallet_midnight`'s v8->v9 multi-block migration
+	/// during the runtime upgrade that crosses into ledger-9. `state_key` is the
+	/// pallet's `StateKey` (a v8 arena root), read only when `cursor` is empty;
+	/// `cursor` is the previous step's [`TranslationStep::InProgress`] payload,
+	/// verbatim; `budget_ps` is the picosecond budget this step may spend against
+	/// the ledger's deterministic cost model.
+	///
+	/// Returns [`TranslationStep::Done`] with the new v9 arena root to store back
+	/// into `StateKey`, or [`TranslationStep::InProgress`] with the cursor for the
+	/// next block's step.
+	fn migrate_state_v8_to_v9_step(
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
-	) -> AllocateAndReturnByCodec<Result<(Vec<u8>, u64), LedgerApiError>> {
+		cursor: PassFatPointerAndRead<&[u8]>,
+		budget_ps: u64,
+	) -> AllocateAndReturnByCodec<Result<TranslationStep, LedgerApiError>> {
 		// Ensure the ledger arena is initialized before translating. The migration
-		// runs in the Executive migrations tuple, before pallet_midnight's
-		// on_initialize/on_runtime_upgrade have (re)initialized storage this block.
-		// `set_default_storage` is idempotent — a no-op if the pre-fork ledger-8
-		// blocks already set it (v8 and v9 share the same storage backend).
+		// runs in `pallet_migrations`' MBM service, before pallet_midnight's
+		// on_initialize/on_runtime_upgrade have (re)initialized storage on the
+		// first block of the upgrade. `set_default_storage` is idempotent — a
+		// no-op if the pre-fork ledger-8 blocks already set it (v8 and v9 share
+		// the same storage backend).
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::set_default_storage(*self);
-			crate::host_api::migration_8_to_9::migrate_state_v8_to_v9::<DbUnified>(state_key)
+			crate::host_api::migration_8_to_9::migrate_state_v8_to_v9_step::<DbUnified>(
+				state_key, cursor, budget_ps,
+			)
 		} else {
 			Bridge::<Signature, DbSeparate>::set_default_storage(*self);
-			crate::host_api::migration_8_to_9::migrate_state_v8_to_v9::<DbSeparate>(state_key)
+			crate::host_api::migration_8_to_9::migrate_state_v8_to_v9_step::<DbSeparate>(
+				state_key, cursor, budget_ps,
+			)
 		}
 	}
 

--- a/ledger/src/host_api/migration_8_to_9.rs
+++ b/ledger/src/host_api/migration_8_to_9.rs
@@ -21,15 +21,56 @@
 //! the `LedgerState` itself lives in the process-global ledger arena (parity-db).
 //! When the runtime upgrades from a ledger-8 runtime (spec < 2_000_000) to a
 //! ledger-9 runtime (spec >= 2_000_000), the on-chain migration
-//! (`pallet_midnight::migrations`) calls [`Ledger9Bridge::migrate_state_v8_to_v9`]
-//! which lands here: it reads the v8 arena root, walks the v8 `LedgerState`
-//! translating it into a v9 `LedgerState`, re-persists it, and returns the new v9
-//! arena root for the pallet to store back into `StateKey`.
+//! (`pallet_midnight::migrations::v2`) drives
+//! [`Ledger9Bridge::migrate_state_v8_to_v9_step`] once per block: it reads the v8
+//! arena root, walks the v8 `LedgerState` translating it into a v9 `LedgerState`,
+//! re-persists it, and returns the new v9 arena root for the pallet to store back
+//! into `StateKey`.
+//!
+//! The walk is unbounded in state size, so it is *stepped*: each call gets a
+//! picosecond budget against the ledger's deterministic cost model, and returns
+//! either [`TranslationStep::Done`] or a [`TranslationStep::InProgress`] cursor
+//! to hand back next block. The cursor is an (untagged) serialized
+//! `TypedArenaKey<TranslationCursor>` — the in-flight `TypedTranslationState` is
+//! parked in the arena, so only ~40 bytes cross the host boundary and live in
+//! on-chain storage.
+//!
+//! ## The budget has a per-state floor
+//!
+//! `TypedTranslationState::run` is **not** resumable at arbitrary granularity,
+//! and this is a property of the engine, not of the cursor: every `run` call
+//! round-trips its state through `InflightTranslationState`, and that conversion
+//! keeps only the memo-cache entries whose *source* node has an `ArenaKey::Ref`
+//! key — results memoised against an inlined (small) node live in a transient
+//! map that is dropped (`TranslationCacheKey::persist` in midnight-storage's
+//! `state_translation`). Work spent below the nearest `Ref` node is therefore
+//! thrown away if the budget runs out mid-way.
+//!
+//! Consequently each state has a threshold budget below which `run` makes no net
+//! progress — measured empirically it either sits on a fixed point or cycles
+//! between a handful of states. The threshold tracks the state's *node
+//! granularity*, not its total size (a 512-entry and a 2048-entry `u128` map both
+//! need ~20ms, while the 2048-entry translation as a whole needs ~200ms), so it
+//! stays small as state grows. The runtime's per-block budget is ~1.2s, comfortably
+//! above it.
+//!
+//! For scale: the `dev` genesis state the `hardfork_e2e` test forks from
+//! (61KB, `ledger-state[v13]`) translates in a single step at any budget from
+//! ~140us up, i.e. ~4 orders of magnitude inside one block's share. It is
+//! indivisible below that — a consequence of being all-small-nodes — so the
+//! multi-block path cannot be exercised on it by shrinking the budget alone;
+//! shrinking it past the threshold instead exercises the pallet's escalation.
+//!
+//! The pallet still guarantees termination rather than relying on that: it grows
+//! the per-step budget the longer the migration runs (see
+//! `pallet_midnight::migrations::v2`), so a state whose threshold does exceed one
+//! block's budget eventually gets a step big enough to finish.
 //!
 //! v8 and v9 share one storage crate (`ledger-storage-ledger-8`,
 //! midnight-storage 2.0.1) and hence one arena, so the translation reads and
 //! writes the same parity-db instance the pre-fork ledger-8 blocks populated.
 
+use crate::common::types::TranslationStep;
 use crate::ledger_8::api::Ledger as Ledger8;
 use crate::ledger_9::api::Ledger as Ledger9;
 use crate::ledger_9::types::{DeserializationError, LedgerApiError, SerializationError};
@@ -37,153 +78,383 @@ use midnight_node_ledger_helpers::state_translation_v8_to_v9::StateTranslationTa
 
 use base_crypto::cost_model::CostDuration;
 use ledger_storage_ledger_8 as storage;
-use midnight_serialize::{tagged_deserialize, tagged_serialize};
+use midnight_serialize::{
+	Deserializable, Serializable, Tagged, tagged_deserialize, tagged_serialize,
+};
 use storage::{
-	arena::{Sp, TypedArenaKey},
+	Storable,
+	arena::{ArenaKey, Sp, TypedArenaKey},
 	db::DB,
 	state_translation::TypedTranslationState,
+	storable::Loader,
 	storage::default_storage,
 };
 
 type LedgerState8<D> = mn_ledger_8::structure::LedgerState<D>;
 type LedgerState9<D> = mn_ledger_9::structure::LedgerState<D>;
 
+/// The in-flight v8 -> v9 translation engine.
+type Translation<D> =
+	TypedTranslationState<LedgerState8<D>, LedgerState9<D>, StateTranslationTable, D>;
+
 const LOG_TARGET: &str = "midnight::ledger::migration_8_to_9";
 
-/// Picoseconds granted to each `TypedTranslationState::run` step. The migration
-/// is single-block (it must complete within one host call), so we loop over
-/// `run` with a per-step budget until the translation reports a result.
-///
-/// This budget also doubles as the quantization granularity of the synthetic
-/// cost reported back to the pallet (see `consumed_cost_ps` below): `run`
-/// doesn't return unused budget, so every completed step is charged in full.
-/// 10ms keeps that over-approximation small relative to real translation
-/// costs while still comfortably draining dev/undeployed-sized state in a
-/// handful of iterations; the loop cap is a runaway backstop only.
-const RUN_BUDGET_PS: u64 = 10_000_000_000;
-const MAX_STEPS: usize = 100_000;
+/// Storage tag for [`TranslationCursor`]. Versioned explicitly: the cursor is
+/// on-chain state for the duration of the hardfork, so its shape must not drift
+/// silently.
+const TRANSLATION_CURSOR_TAG: &str = "midnight-node:ledger-v8-to-v9-translation-cursor[v1]";
 
-/// Translate the ledger state referenced by a v8 arena root (`state_key_v8`,
-/// the pallet's `StateKey` bytes) into a v9 ledger state, persist it, and
-/// return the new v9 arena root (to store back into `StateKey`) together with
-/// the synthetic cost, in picoseconds, the translation consumed against the
-/// ledger's deterministic cost model — for the pallet to charge as this
-/// migration's weight.
-///
-/// If `state_key_v8` already references a ledger-9 state this is a no-op: it
-/// returns the key unchanged with zero cost (see the idempotency guard below).
-pub fn migrate_state_v8_to_v9<D: DB>(
-	state_key_v8: &[u8],
-) -> Result<(Vec<u8>, u64), LedgerApiError> {
-	let t_total = std::time::Instant::now();
+/// Cost the translation engine charges per translated node (a flat 20us
+/// heuristic, `midnight-storage`'s `state_translation`). Floor for a step's
+/// budget, so a zero budget still translates one node.
+const NODE_COST_PS: u64 = 20_000_000;
 
-	// 0. Idempotency guard: no-op if the state is already ledger-9.
-	//
-	// The pallet gates this behind `VersionedMigration<1, 2>`, but the on-chain
-	// pallet-midnight storage version is not a faithful proxy for the ledger
-	// version. The 2.0.0 runtime (spec 2_000_000) already runs ledger-9 yet
-	// shipped pallet-midnight at storage version 1 (it had no v1->v2 migration),
-	// so a network upgrading 2.0.0 -> this runtime still triggers this migration
-	// even though its `StateKey` already points at a v9 arena root. Feeding that
-	// v9 root to the v8 decode below would fail on the tag mismatch and abort the
-	// upgrade (the pallet `expect`s success), bricking the chain. Detect it by
-	// the root's serialized tag — `TypedArenaKey`'s tag embeds the `LedgerState`
-	// version (`storage-key(midnight:ledger-state[vN]:...)`), so a successful
-	// tagged decode as a v9 key is a reliable, arena-free discriminator — and
-	// return the key unchanged with zero synthetic cost.
-	if tagged_deserialize::<TypedArenaKey<Ledger9<D>, D::Hasher>>(&mut &state_key_v8[..]).is_ok() {
-		log::info!(
-			target: LOG_TARGET,
-			"StateKey already references a ledger-9 state; skipping v8->v9 translation (no-op)"
-		);
-		return Ok((state_key_v8.to_vec(), 0));
+/// Single-child [`Storable`] wrapper that makes a partially complete
+/// [`Translation`] addressable by an `ArenaKey`, so it can be parked in the arena
+/// between blocks and resumed from the on-chain cursor.
+///
+/// The wrapper is needed because [`TypedTranslationState`] carries no `#[tag]`
+/// and hence is not [`Tagged`]: `Arena::get_lazy` requires `Storable + Tagged`,
+/// the untagged `get_lazy_unversioned` is crate-private, and `Arena::get` is
+/// eager with unbounded recursion (it would force the entire work queue and memo
+/// cache every block).
+///
+/// Both `Storable` and `Tagged` are hand-written: the `Storable` derive's
+/// generated `tag_unique_factor` emits `<FieldTy>::tag()`, which would
+/// re-require `Tagged` on the field we are wrapping precisely because it has
+/// none.
+struct TranslationCursor<D: DB> {
+	state: Sp<Translation<D>, D>,
+}
+
+// Hand-written: `#[derive(Clone)]` would add a spurious `D: Clone` bound.
+impl<D: DB> Clone for TranslationCursor<D> {
+	fn clone(&self) -> Self {
+		Self { state: self.state.clone() }
+	}
+}
+
+impl<D: DB> Tagged for TranslationCursor<D> {
+	fn tag() -> std::borrow::Cow<'static, str> {
+		std::borrow::Cow::Borrowed(TRANSLATION_CURSOR_TAG)
 	}
 
-	// 1. Decode the v8 arena root and load the v8 ledger wrapper from the arena.
-	let t_load = std::time::Instant::now();
-	let key8: TypedArenaKey<Ledger8<D>, D::Hasher> = tagged_deserialize(&mut &state_key_v8[..])
-		.map_err(|e| {
-			log::error!(target: LOG_TARGET, "failed to deserialize v8 state key: {e:?}");
-			LedgerApiError::Deserialization(DeserializationError::TypedArenaKey)
-		})?;
-	let ledger8: Sp<Ledger8<D>, D> = default_storage::<D>().arena.get_lazy(&key8).map_err(|e| {
-		log::error!(target: LOG_TARGET, "failed to load v8 ledger from arena: {e:?}");
-		LedgerApiError::NoLedgerState
-	})?;
-	log::debug!(target: LOG_TARGET, "[perf] migrate_state_v8_to_v9 load took {:?}", t_load.elapsed());
+	fn tag_unique_factor() -> String {
+		TRANSLATION_CURSOR_TAG.into()
+	}
+}
 
-	// 2. Run the state translation table over the inner v8 `LedgerState`.
-	let t_translate = std::time::Instant::now();
-	let input: Sp<LedgerState8<D>, D> = Sp::new(ledger8.state.clone());
-	let mut tl =
-		TypedTranslationState::<LedgerState8<D>, LedgerState9<D>, StateTranslationTable, D>::start(
-			input,
-		)
-		.map_err(|e| {
+impl<D: DB> Storable<D> for TranslationCursor<D> {
+	fn children(&self) -> Vec<ArenaKey<D::Hasher>> {
+		vec![Sp::as_child(&self.state)]
+	}
+
+	fn to_binary_repr<W: std::io::Write>(&self, _writer: &mut W) -> Result<(), std::io::Error> {
+		Ok(())
+	}
+
+	fn from_binary_repr<R: std::io::Read>(
+		_reader: &mut R,
+		child_nodes: &mut impl Iterator<Item = ArenaKey<D::Hasher>>,
+		loader: &impl Loader<D>,
+	) -> Result<Self, std::io::Error> {
+		Ok(Self { state: loader.get_next(child_nodes)? })
+	}
+}
+
+/// Run one bounded step of the v8 -> v9 ledger state translation.
+///
+/// * `state_key_v8` — the pallet's `StateKey` bytes (a v8 arena root). Only read
+///   when `cursor` is empty, i.e. when starting a fresh translation.
+/// * `cursor` — empty to start, otherwise the [`TranslationStep::InProgress`]
+///   cursor returned by the previous step, verbatim.
+/// * `budget_ps` — picoseconds this step may spend against the ledger's
+///   deterministic cost model. Must clear the state's threshold budget for the
+///   step to make net progress; see the module docs. A step that makes no
+///   progress returns a cursor equal to the one it was given, which is not an
+///   error — the caller is expected to retry with a larger budget.
+///
+/// Returns [`TranslationStep::Done`] with the new v9 arena root (to store back
+/// into `StateKey`) once the walk completes, or [`TranslationStep::InProgress`]
+/// with the cursor to feed the next step.
+///
+/// If `state_key_v8` already references a ledger-9 state this is a no-op: it
+/// returns `Done` with the key unchanged (see the idempotency guard below).
+///
+/// Deliberately does *not* flush the arena — `pallet_midnight::on_finalize`
+/// flushes once per block, which is the right granularity given blocks are
+/// atomic (a restart re-executes the whole block).
+pub fn migrate_state_v8_to_v9_step<D: DB>(
+	state_key_v8: &[u8],
+	cursor: &[u8],
+	budget_ps: u64,
+) -> Result<TranslationStep, LedgerApiError> {
+	let t_total = std::time::Instant::now();
+	let arena = &default_storage::<D>().arena;
+
+	// 1. Resume the parked translation, or start a fresh one from the v8 root.
+	//
+	// `resumed` is the cursor node we loaded, kept so its GC root marking can be
+	// dropped once its successor is persisted below.
+	let (tl, resumed) = if cursor.is_empty() {
+		// Idempotency guard: no-op if the state is already ledger-9.
+		//
+		// The pallet gates this behind an `on_chain_storage_version() >= 2`
+		// check, but the on-chain pallet-midnight storage version is not a
+		// faithful proxy for the ledger version. The 2.0.0 runtime (spec
+		// 2_000_000) already runs ledger-9 yet shipped pallet-midnight at
+		// storage version 1 (it had no v1->v2 migration), so a network upgrading
+		// 2.0.0 -> this runtime still triggers this migration even though its
+		// `StateKey` already points at a v9 arena root. Feeding that v9 root to
+		// the v8 decode below would fail on the tag mismatch and fail the
+		// upgrade. Detect it by the root's serialized tag — `TypedArenaKey`'s tag
+		// embeds the `LedgerState` version (`storage-key(midnight:ledger-state[vN]:...)`),
+		// so a successful tagged decode as a v9 key is a reliable, arena-free
+		// discriminator — and return the key unchanged.
+		if tagged_deserialize::<TypedArenaKey<Ledger9<D>, D::Hasher>>(&mut &state_key_v8[..])
+			.is_ok()
+		{
+			log::info!(
+				target: LOG_TARGET,
+				"StateKey already references a ledger-9 state; skipping v8->v9 translation (no-op)"
+			);
+			return Ok(TranslationStep::Done { state_key: state_key_v8.to_vec() });
+		}
+
+		let t_load = std::time::Instant::now();
+		let key8: TypedArenaKey<Ledger8<D>, D::Hasher> = tagged_deserialize(&mut &state_key_v8[..])
+			.map_err(|e| {
+				log::error!(target: LOG_TARGET, "failed to deserialize v8 state key: {e:?}");
+				LedgerApiError::Deserialization(DeserializationError::TypedArenaKey)
+			})?;
+		let ledger8: Sp<Ledger8<D>, D> = arena.get_lazy(&key8).map_err(|e| {
+			log::error!(target: LOG_TARGET, "failed to load v8 ledger from arena: {e:?}");
+			LedgerApiError::NoLedgerState
+		})?;
+		log::debug!(target: LOG_TARGET, "[perf] v8->v9 load took {:?}", t_load.elapsed());
+
+		let input: Sp<LedgerState8<D>, D> = Sp::new(ledger8.state.clone());
+		let tl = Translation::<D>::start(input).map_err(|e| {
 			log::error!(target: LOG_TARGET, "failed to start v8->v9 translation: {e:?}");
 			LedgerApiError::HostApiError
 		})?;
+		(tl, None)
+	} else {
+		let cursor_key: TypedArenaKey<TranslationCursor<D>, D::Hasher> =
+			Deserializable::deserialize(&mut &cursor[..], 0).map_err(|e| {
+				log::error!(target: LOG_TARGET, "failed to deserialize translation cursor: {e:?}");
+				LedgerApiError::Deserialization(DeserializationError::TypedArenaKey)
+			})?;
+		let parked: Sp<TranslationCursor<D>, D> = arena.get_lazy(&cursor_key).map_err(|e| {
+			log::error!(target: LOG_TARGET, "failed to load translation cursor from arena: {e:?}");
+			LedgerApiError::NoLedgerState
+		})?;
+		let tl = (*parked.state).clone();
+		(tl, Some(parked))
+	};
 
-	let run_budget = CostDuration::from_picoseconds(RUN_BUDGET_PS);
-	let mut steps = 0usize;
-	let state9: Sp<LedgerState9<D>, D> = loop {
-		steps += 1;
-		if steps > MAX_STEPS {
-			log::error!(target: LOG_TARGET, "v8->v9 translation did not converge in {MAX_STEPS} steps");
-			return Err(LedgerApiError::HostApiError);
-		}
-		tl = tl.run(run_budget).map_err(|e| {
+	// 2. Advance the translation by one bounded `run`.
+	let t_run = std::time::Instant::now();
+	let tl = tl
+		.run(CostDuration::from_picoseconds(budget_ps.max(NODE_COST_PS)))
+		.map_err(|e| {
 			log::error!(target: LOG_TARGET, "v8->v9 translation step failed: {e:?}");
 			LedgerApiError::HostApiError
 		})?;
-		if let Some(result) = tl.result().map_err(|e| {
-			log::error!(target: LOG_TARGET, "v8->v9 translation result failed: {e:?}");
-			LedgerApiError::HostApiError
-		})? {
-			break result;
-		}
-	};
-	// Every completed `run` call before the last one must have exhausted its
-	// full `RUN_BUDGET_PS` — otherwise `tl.result()` would already have been
-	// `Some` and the loop would have stopped there. Only the final call may
-	// have used less. `steps * RUN_BUDGET_PS` is therefore a deterministic
-	// upper bound on the synthetic cost actually consumed, accurate to one
-	// `RUN_BUDGET_PS` quantum.
-	let consumed_cost_ps = steps as u64 * RUN_BUDGET_PS;
-	log::info!(
-		target: LOG_TARGET,
-		"v8->v9 ledger state translation complete in {steps} step(s), {:?}, {consumed_cost_ps}ps synthetic cost",
-		t_translate.elapsed()
-	);
-
-	// 3. Wrap the translated state in the v9 ledger wrapper, persist it, and
-	//    flush the arena so the new root is durable before the pallet stores it.
-	let t_persist = std::time::Instant::now();
-	let ledger9 = Ledger9::new((*state9).clone());
-	let mut sp9: Sp<Ledger9<D>, D> = default_storage::<D>().arena.alloc(ledger9);
-	sp9.persist();
-	default_storage::<D>().with_backend(|backend| backend.flush_all_changes_to_db());
-	log::debug!(
-		target: LOG_TARGET,
-		"[perf] migrate_state_v8_to_v9 persist+flush took {:?}",
-		t_persist.elapsed()
-	);
-
-	// 4. Serialize the new v9 arena root for the pallet to store in `StateKey`.
-	let mut bytes = Vec::new();
-	tagged_serialize(&sp9.as_typed_key(), &mut bytes).map_err(|e| {
-		log::error!(target: LOG_TARGET, "failed to serialize v9 state key: {e:?}");
-		LedgerApiError::Serialization(SerializationError::TypedArenaKey)
+	let result = tl.result().map_err(|e| {
+		log::error!(target: LOG_TARGET, "v8->v9 translation result failed: {e:?}");
+		LedgerApiError::HostApiError
 	})?;
 
-	log::debug!(target: LOG_TARGET, "[perf] migrate_state_v8_to_v9 took {:?}", t_total.elapsed());
-	Ok((bytes, consumed_cost_ps))
+	// 3. Park the outcome in the arena: either the finished v9 ledger (whose root
+	//    the pallet stores in `StateKey`) or the in-flight translation (whose root
+	//    becomes the next step's cursor).
+	let step = match result {
+		Some(state9) => {
+			let ledger9 = Ledger9::new((*state9).clone());
+			let mut sp9: Sp<Ledger9<D>, D> = arena.alloc(ledger9);
+			sp9.persist();
+			let mut bytes = Vec::new();
+			tagged_serialize(&sp9.as_typed_key(), &mut bytes).map_err(|e| {
+				log::error!(target: LOG_TARGET, "failed to serialize v9 state key: {e:?}");
+				LedgerApiError::Serialization(SerializationError::TypedArenaKey)
+			})?;
+			log::info!(
+				target: LOG_TARGET,
+				"v8->v9 ledger state translation complete (final step took {:?})",
+				t_run.elapsed()
+			);
+			TranslationStep::Done { state_key: bytes }
+		},
+		None => {
+			let mut parked: Sp<TranslationCursor<D>, D> =
+				arena.alloc(TranslationCursor { state: arena.alloc(tl) });
+			parked.persist();
+			// Untagged: the cursor is this migration's private format, and
+			// `TranslationCursor`'s tag is long enough to matter against the
+			// pallet's bounded cursor.
+			let mut bytes = Vec::new();
+			Serializable::serialize(&parked.as_typed_key(), &mut bytes).map_err(|e| {
+				log::error!(target: LOG_TARGET, "failed to serialize translation cursor: {e:?}");
+				LedgerApiError::Serialization(SerializationError::TypedArenaKey)
+			})?;
+			log::debug!(
+				target: LOG_TARGET,
+				"v8->v9 translation step incomplete after {:?}; parked cursor ({} bytes)",
+				t_run.elapsed(),
+				bytes.len()
+			);
+			TranslationStep::InProgress { cursor: bytes }
+		},
+	};
+
+	// 4. Drop the GC-root marking on the cursor we resumed from, now that its
+	//    successor is persisted, so intermediate roots don't accumulate.
+	if let Some(prev) = resumed {
+		prev.unpersist();
+	}
+
+	log::debug!(target: LOG_TARGET, "[perf] migrate_state_v8_to_v9_step took {:?}", t_total.elapsed());
+	Ok(step)
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use ledger_storage_ledger_8::db::InMemoryDB;
+
+	/// Seed a v8 `LedgerState` into the arena the way a pre-fork ledger-8 node
+	/// would, and return the `StateKey` bytes the pallet would hold.
+	fn seed_v8_state(state: LedgerState8<InMemoryDB>) -> Vec<u8> {
+		let ledger = Ledger8::<InMemoryDB>::new(state);
+		let mut sp = default_storage::<InMemoryDB>().arena.alloc(ledger);
+		sp.persist();
+		let mut bytes = Vec::new();
+		tagged_serialize(&sp.as_typed_key(), &mut bytes).expect("serialize v8 state key");
+		bytes
+	}
+
+	/// A v8 state big enough to need several translation steps: `entries`
+	/// `bridge_receiving` rows build a `u128` MPT deep enough that its interior
+	/// nodes are separate arena nodes, which is the granularity the translation
+	/// engine can actually suspend at.
+	fn v8_state_with_bridge_entries(network_id: &str, entries: u32) -> LedgerState8<InMemoryDB> {
+		use base_crypto::hash::HashOutput;
+		use coin_structure::coin::UserAddress;
+
+		let mut state = LedgerState8::<InMemoryDB>::new(network_id);
+		for i in 0..entries {
+			let mut bytes = [0u8; 32];
+			bytes[..4].copy_from_slice(&i.to_be_bytes());
+			state.bridge_receiving =
+				state.bridge_receiving.insert(UserAddress(HashOutput(bytes)), i as u128);
+		}
+		state
+	}
+
+	/// Comfortably above the fixtures' threshold budget (see the module docs), so
+	/// stepping actually converges, while still far below what the whole walk
+	/// needs. Empirically the 2048-entry fixture needs ~20ms per step to progress
+	/// and ~200ms in total.
+	const STEP_BUDGET_PS: u64 = 25 * 1_000_000_000;
+
+	/// Enough to translate either fixture in a single step.
+	const UNBOUNDED_BUDGET_PS: u64 = 60 * 1_000_000_000_000;
+
+	/// Drive `migrate_state_v8_to_v9_step` to completion with `budget_ps` per
+	/// step, returning the final v9 `StateKey` bytes and the number of steps.
+	fn translate_stepped(state_key_v8: &[u8], budget_ps: u64) -> (Vec<u8>, usize) {
+		let mut cursor = Vec::new();
+		for steps in 1..=200 {
+			match migrate_state_v8_to_v9_step::<InMemoryDB>(state_key_v8, &cursor, budget_ps)
+				.expect("translation step")
+			{
+				TranslationStep::Done { state_key } => return (state_key, steps),
+				TranslationStep::InProgress { cursor: next } => {
+					assert!(!next.is_empty(), "in-progress cursor must be non-empty");
+					assert_ne!(
+						next, cursor,
+						"step {steps} made no progress: {budget_ps}ps is below this state's \
+						 threshold budget",
+					);
+					cursor = next;
+				},
+			}
+		}
+		panic!("translation did not converge in 200 steps at {budget_ps}ps per step")
+	}
+
+	/// The load-bearing determinism guarantee: the cursor is on-chain state, so
+	/// every node importing the migration blocks must reproduce the same bytes.
+	/// A translation split over many bounded steps must therefore land on
+	/// exactly the same v9 arena root as one unbounded translation.
+	#[test]
+	fn stepped_translation_matches_single_shot() {
+		let state_key_v8 = seed_v8_state(v8_state_with_bridge_entries("stepped-vs-one-shot", 2048));
+
+		// A budget well below what the whole walk needs, so it is spread over
+		// several steps, i.e. several blocks.
+		let (stepped, steps) = translate_stepped(&state_key_v8, STEP_BUDGET_PS);
+		assert!(steps > 1, "a small budget must force a multi-step translation (took {steps})");
+
+		// Enough budget for the whole walk in one step.
+		let (single_shot, one) = translate_stepped(&state_key_v8, UNBOUNDED_BUDGET_PS);
+		assert_eq!(one, 1, "an unbounded budget must finish in one step");
+
+		assert_eq!(
+			hex::encode(&stepped),
+			hex::encode(&single_shot),
+			"stepped translation must produce the same v9 root as a single-shot one",
+		);
+	}
+
+	/// The parked cursor must survive the full serialize -> `get_lazy` -> `run`
+	/// round trip, which is what carries the translation across a block boundary.
+	#[test]
+	fn cursor_round_trips_through_the_arena() {
+		let state_key_v8 = seed_v8_state(v8_state_with_bridge_entries("cursor-round-trip", 2048));
+
+		let TranslationStep::InProgress { cursor } =
+			migrate_state_v8_to_v9_step::<InMemoryDB>(&state_key_v8, &[], STEP_BUDGET_PS)
+				.expect("first step")
+		else {
+			panic!("a partial budget must leave the translation in progress");
+		};
+
+		// The cursor decodes as a typed arena key that resolves in the arena.
+		let key: TypedArenaKey<TranslationCursor<InMemoryDB>, sha2::Sha256> =
+			Deserializable::deserialize(&mut &cursor[..], 0).expect("cursor decodes");
+		default_storage::<InMemoryDB>()
+			.arena
+			.get_lazy(&key)
+			.expect("cursor resolves in the arena");
+
+		// `&[]` for the state key proves the resume path never touches it.
+		let resumed = migrate_state_v8_to_v9_step::<InMemoryDB>(&[], &cursor, STEP_BUDGET_PS)
+			.expect("resumed step");
+		assert_ne!(
+			resumed,
+			TranslationStep::InProgress { cursor: cursor.clone() },
+			"resuming must advance the translation",
+		);
+	}
+
+	/// The 2.0.0 -> this-runtime path: pallet-midnight is at storage version 1
+	/// but `StateKey` already references a ledger-9 root. The step must no-op
+	/// rather than fail the v8 decode.
+	#[test]
+	fn already_v9_state_key_short_circuits() {
+		let state = mn_ledger_9::structure::LedgerState::<InMemoryDB>::new("already-v9");
+		let ledger = Ledger9::<InMemoryDB>::new(state);
+		let mut sp = default_storage::<InMemoryDB>().arena.alloc(ledger);
+		sp.persist();
+		let mut state_key_v9 = Vec::new();
+		tagged_serialize(&sp.as_typed_key(), &mut state_key_v9).expect("serialize v9 state key");
+
+		let step = migrate_state_v8_to_v9_step::<InMemoryDB>(&state_key_v9, &[], STEP_BUDGET_PS)
+			.expect("v9 short-circuit");
+		assert_eq!(step, TranslationStep::Done { state_key: state_key_v9 });
+	}
 
 	/// Dev-only: verify that seeding a v8 genesis blob with *this* crate's
 	/// ledger_8 `Ledger` wrapper reproduces the exact arena root a ledger-8 node
@@ -205,11 +476,7 @@ mod tests {
 		let state: LedgerState8<InMemoryDB> =
 			midnight_serialize::tagged_deserialize(&mut &genesis[..])
 				.expect("deserialize v8 state");
-		let ledger = Ledger8::<InMemoryDB>::new(state);
-		let mut sp = default_storage::<InMemoryDB>().arena.alloc(ledger);
-		sp.persist();
-		let mut got = Vec::new();
-		tagged_serialize(&sp.as_typed_key(), &mut got).expect("serialize key");
+		let got = seed_v8_state(state);
 
 		assert_eq!(
 			got,

--- a/pallets/c2m-bridge/src/lib.rs
+++ b/pallets/c2m-bridge/src/lib.rs
@@ -385,6 +385,19 @@ pub mod pallet {
 	}
 
 	impl<T: Config> pallet_partner_chains_bridge::TransferHandler<BridgeRecipient> for Pallet<T> {
+		/// Defer the whole batch while the ledger v8 -> v9 state translation is in
+		/// flight. The bridge inherent runs *before* the multi-block migration is
+		/// serviced, so at this point the ledger state key still references a state
+		/// the current ledger API cannot read: both the
+		/// `get_c_to_m_bridge_min_amount` read below and the system transaction
+		/// `handle_regular_transfer` builds would fail, and the error is swallowed
+		/// — silently dropping user funds. `handle_transfers` leaves its data
+		/// checkpoint unchanged, so these transfers are re-delivered once the
+		/// migration completes.
+		fn can_handle_transfers() -> bool {
+			!T::MidnightSystemTransactionExecutor::ledger_migration_pending()
+		}
+
 		fn handle_incoming_transfer(transfer: BridgeTransferV1<BridgeRecipient>) {
 			match T::MinBridgeAmountProvider::get_c_to_m_bridge_min_amount() {
 				Ok(min_amount) => {

--- a/pallets/c2m-bridge/src/mock.rs
+++ b/pallets/c2m-bridge/src/mock.rs
@@ -31,6 +31,11 @@ pub mod mock_pallet {
 	#[pallet::storage]
 	pub type TransfersCount<T: Config> = StorageValue<_, u8, ValueQuery>;
 
+	/// Stands in for `pallet_midnight`'s in-flight ledger migration, so tests can
+	/// drive the `TransferHandler::can_handle_transfers` gate.
+	#[pallet::storage]
+	pub type LedgerMigrationPending<T: Config> = StorageValue<_, bool, ValueQuery>;
+
 	impl<T> MidnightSystemTransactionExecutor for Pallet<T> {
 		fn execute_system_transaction(tx: Vec<u8>) -> Result<Hash, DispatchError> {
 			let bounded_vec: BoundedVec<u8, MaxTxLength> = tx.clone().try_into().unwrap();
@@ -38,6 +43,10 @@ pub mod mock_pallet {
 			let count = TransfersCount::<Test>::get();
 			TransfersCount::<Test>::put(count + 1);
 			Ok([count; 32])
+		}
+
+		fn ledger_migration_pending() -> bool {
+			LedgerMigrationPending::<Test>::get()
 		}
 	}
 

--- a/pallets/c2m-bridge/src/tests.rs
+++ b/pallets/c2m-bridge/src/tests.rs
@@ -88,6 +88,26 @@ fn emits_events() {
 	})
 }
 
+/// The bridge inherent runs before multi-block migrations are serviced, so while
+/// the ledger v8 -> v9 translation is in flight the handler must refuse the whole
+/// batch — `pallet_partner_chains_bridge` then leaves its data checkpoint
+/// unchanged and re-delivers the transfers later.
+#[test]
+fn defers_transfers_while_the_ledger_migration_is_pending() {
+	new_test_ext().execute_with(|| {
+		assert!(
+			<C2MBridge as TransferHandler<BridgeRecipient>>::can_handle_transfers(),
+			"transfers must be accepted when no ledger migration is pending",
+		);
+
+		mock_pallet::LedgerMigrationPending::<Test>::put(true);
+		assert!(
+			!<C2MBridge as TransferHandler<BridgeRecipient>>::can_handle_transfers(),
+			"transfers must be deferred while the ledger migration is pending",
+		);
+	})
+}
+
 #[test]
 fn nonce_influences_addressed_transfers() {
 	new_test_ext().execute_with(|| {

--- a/pallets/cnight-observation/mock/src/mock_with_capture.rs
+++ b/pallets/cnight-observation/mock/src/mock_with_capture.rs
@@ -13,6 +13,7 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use frame_support::sp_runtime::{
 	BuildStorage,
 	traits::{BlakeTwo256, Get, IdentityLookup},
@@ -150,9 +151,19 @@ pub struct MidnightSystemTx {}
 
 static CAPTURED_SYSTEM_TXS: LazyLock<Mutex<Vec<Vec<u8>>>> = LazyLock::new(|| Mutex::new(vec![]));
 
+/// Stands in for `pallet_midnight`'s in-flight ledger migration, so tests can
+/// drive the `process_tokens` freeze without a real v8 ledger state.
+static LEDGER_MIGRATION_PENDING: AtomicBool = AtomicBool::new(false);
+
 impl MidnightSystemTx {
 	pub fn pop_captured_system_txs() -> Vec<Vec<u8>> {
 		CAPTURED_SYSTEM_TXS.lock().unwrap().drain(..).collect()
+	}
+
+	/// Sets whether [`MidnightSystemTransactionExecutor::ledger_migration_pending`]
+	/// reports an in-flight ledger migration.
+	pub fn set_ledger_migration_pending(pending: bool) {
+		LEDGER_MIGRATION_PENDING.store(pending, Ordering::SeqCst);
 	}
 }
 
@@ -162,6 +173,10 @@ impl MidnightSystemTransactionExecutor for MidnightSystemTx {
 	) -> Result<midnight_node_ledger::types::Hash, __private::DispatchError> {
 		CAPTURED_SYSTEM_TXS.lock().unwrap().push(serialized_system_transaction);
 		Ok(midnight_node_ledger::types::Hash::default())
+	}
+
+	fn ledger_migration_pending() -> bool {
+		LEDGER_MIGRATION_PENDING.load(Ordering::SeqCst)
 	}
 }
 

--- a/pallets/cnight-observation/src/lib.rs
+++ b/pallets/cnight-observation/src/lib.rs
@@ -666,9 +666,20 @@ pub mod pallet {
 			// the migration drains it. Skip processing entirely; `NextCardanoPosition`
 			// stays unchanged so the next block's inherent re-presents the same UTXOs
 			// (plus any new ones) and we resume once the migration finishes.
-			if Pallet::<T>::on_chain_storage_version() < STORAGE_VERSION {
+			let mapping_migration_pending =
+				Pallet::<T>::on_chain_storage_version() < STORAGE_VERSION;
+			// Likewise while the ledger v8 -> v9 state translation is in flight: MBM
+			// steps run *after* a block's inherents, so this mandatory inherent
+			// executes against a state the current ledger API cannot read, and
+			// `execute_system_transaction` below would fail — failing a mandatory
+			// inherent makes the block unimportable. Skipping leaves
+			// `NextCardanoPosition` unchanged, so the node's inherent data provider
+			// re-delivers the identical UTXO batch in a later block.
+			let ledger_migration_pending =
+				<T as Config>::MidnightSystemTransactionExecutor::ledger_migration_pending();
+			if mapping_migration_pending || ledger_migration_pending {
 				log::warn!(
-					"cnight-observation: skipping process_tokens (on-chain storage version {:?} < {:?}); MBM in progress",
+					"cnight-observation: skipping process_tokens (mapping migration pending: {mapping_migration_pending}, on-chain storage version {:?} of {:?}; ledger migration pending: {ledger_migration_pending})",
 					Pallet::<T>::on_chain_storage_version(),
 					STORAGE_VERSION,
 				);

--- a/pallets/cnight-observation/tests/tests.rs
+++ b/pallets/cnight-observation/tests/tests.rs
@@ -367,6 +367,97 @@ fn process_tokens_inherent_should_update_storage_correctly() {
 	});
 }
 
+/// `process_tokens` is a *mandatory* inherent and runs before multi-block
+/// migrations are serviced, so while the ledger v8 -> v9 translation is in flight
+/// it would execute a system transaction against a state the current ledger API
+/// cannot read — failing the inherent and making the block unimportable. It must
+/// skip instead, leaving `NextCardanoPosition` unchanged so the node's inherent
+/// data provider re-delivers the same UTXOs later.
+#[test]
+fn process_tokens_defers_while_ledger_migration_is_pending() {
+	new_test_ext().execute_with(|| {
+		init_ledger_state();
+		let (cardano_reward_address, dust_public_key) = test_wallet_pairing();
+
+		// pallet-midnight below storage version 2 == ledger v8->v9 translation
+		// still in flight.
+		StorageVersion::new(1).put::<mock::Midnight>();
+
+		let position_before = NextCardanoPosition::<Test>::get();
+
+		let utxos = vec![
+			ObservedUtxo {
+				header: test_header(1, 2, 0, None),
+				data: ObservedUtxoData::Registration(RegistrationData {
+					cardano_reward_address,
+					dust_public_key: dust_public_key.clone(),
+				}),
+			},
+			ObservedUtxo {
+				header: test_header(2, 0, 0, None),
+				data: ObservedUtxoData::AssetCreate(CreateData {
+					value: 100,
+					owner: cardano_reward_address,
+					utxo_tx_hash: tx_hash(1, 3),
+					utxo_tx_index: 0,
+				}),
+			},
+		];
+
+		let inherent_data = create_inherent(utxos, test_position(3, 0));
+		let call = CNightObservation::create_inherent(&inherent_data)
+			.expect("Expected to create inherent call");
+		let call = RuntimeCall::CNightObservation(call);
+		// The inherent still succeeds — it just does nothing.
+		assert_ok!(call.dispatch(frame_system::RawOrigin::None.into()));
+
+		assert_eq!(
+			NextCardanoPosition::<Test>::get(),
+			position_before,
+			"NextCardanoPosition must not advance while the ledger migration is pending",
+		);
+		assert_eq!(
+			Mapping::<Test>::iter_prefix_values(cardano_reward_address).count(),
+			0,
+			"no UTXO should have been handled",
+		);
+		let applied_system_tx = frame_system::Pallet::<Test>::events().iter().any(|record| {
+			matches!(
+				record.event,
+				mock::RuntimeEvent::MidnightSystem(
+					pallet_midnight_system::Event::SystemTransactionApplied(_)
+				)
+			)
+		});
+		assert!(!applied_system_tx, "no system transaction should have been applied");
+
+		// Once the migration completes, the re-delivered batch is applied.
+		StorageVersion::new(2).put::<mock::Midnight>();
+		advance_block_and_reset_events();
+
+		let inherent_data = create_inherent(
+			vec![ObservedUtxo {
+				header: test_header(1, 2, 0, None),
+				data: ObservedUtxoData::Registration(RegistrationData {
+					cardano_reward_address,
+					dust_public_key: dust_public_key.clone(),
+				}),
+			}],
+			test_position(3, 0),
+		);
+		let call = CNightObservation::create_inherent(&inherent_data)
+			.expect("Expected to create inherent call");
+		let call = RuntimeCall::CNightObservation(call);
+		assert_ok!(call.dispatch(frame_system::RawOrigin::None.into()));
+
+		assert_eq!(
+			Mapping::<Test>::iter_prefix_values(cardano_reward_address).collect::<Vec<_>>(),
+			vec![dust_public_key],
+		);
+		assert_eq!(NextCardanoPosition::<Test>::get(), test_position(3, 0));
+	});
+}
+
 #[test]
 fn removing_duplicate_registration_results_in_valid_registration() {
 	new_test_ext().execute_with(|| {

--- a/pallets/midnight-system/src/lib.rs
+++ b/pallets/midnight-system/src/lib.rs
@@ -177,5 +177,9 @@ pub mod pallet {
 
 			Ok(hash)
 		}
+
+		fn ledger_migration_pending() -> bool {
+			<T as Config>::LedgerStateProviderMut::ledger_migration_pending()
+		}
 	}
 }

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -78,6 +78,10 @@ pub mod pallet {
 
 			Ok(custom_result)
 		}
+
+		fn ledger_migration_pending() -> bool {
+			Pallet::<T>::ledger_migration_pending()
+		}
 	}
 
 	impl<T: Config> LedgerBlockContextProvider for Pallet<T> {
@@ -340,14 +344,31 @@ pub mod pallet {
 		}
 
 		fn on_finalize(_block: BlockNumberFor<T>) {
-			// Post Block Ledger Update
-			let state_key = StateKey::<T>::get();
-			let block_context = Self::get_block_context();
+			// While the v8 -> v9 state translation is still in flight, `StateKey`
+			// references a state this runtime's ledger-9 API cannot read, so
+			// `apply_post_block_update` would fail and (being `expect`ed) brick the
+			// chain. Skip the post-block update; the ledger is paused for the
+			// blocks the migration spans.
+			//
+			// The flush below still runs: it is what makes the in-flight
+			// translation cursor the migration parked in the arena durable, once
+			// per block.
+			if !Self::ledger_migration_pending() {
+				// Post Block Ledger Update
+				let state_key = StateKey::<T>::get();
+				let block_context = Self::get_block_context();
 
-			let state_root = LedgerApi::apply_post_block_update(&state_key, block_context.clone())
-				.expect("FATAL: Apply post block update failed");
+				let state_root =
+					LedgerApi::apply_post_block_update(&state_key, block_context.clone())
+						.expect("FATAL: Apply post block update failed");
 
-			StateKey::<T>::put(state_root);
+				StateKey::<T>::put(state_root);
+			} else {
+				log::info!(
+					target: "midnight::migration",
+					"ledger migration pending; skipping post-block ledger update"
+				);
+			}
 
 			// Flush ledger storage changes to disk
 			LedgerApi::flush_storage();
@@ -627,6 +648,24 @@ pub mod pallet {
 		pub fn get_ledger_state_root() -> Result<Vec<u8>, LedgerApiError> {
 			let state_key = StateKey::<T>::get();
 			LedgerApi::get_ledger_state_root(&state_key)
+		}
+
+		/// Whether the ledger v8 -> v9 state translation
+		/// ([`crate::migrations::v2`]) is still in flight, i.e. [`StateKey`]
+		/// still references a state this runtime's ledger-9 API cannot read.
+		///
+		/// True from the very first instruction of the upgrade block: the storage
+		/// version only flips on the migration's final step, whereas multi-block
+		/// migrations are serviced *after* the block's inherents. Every ledger
+		/// read/write reachable from an inherent or from `on_finalize` must
+		/// therefore be skipped while this holds — see the `on_finalize` guard
+		/// below, `pallet_cnight_observation::process_tokens`, and
+		/// `pallet_c2m_bridge`'s `can_handle_transfers`.
+		///
+		/// Compares against the literal `2` rather than [`STORAGE_VERSION`] so a
+		/// future storage version 3 doesn't accidentally re-freeze the ledger.
+		pub fn ledger_migration_pending() -> bool {
+			Self::on_chain_storage_version() < StorageVersion::new(2)
 		}
 
 		// Helper for the weight macro

--- a/pallets/midnight/src/migrations/mod.rs
+++ b/pallets/midnight/src/migrations/mod.rs
@@ -24,5 +24,5 @@ pub const PALLET_MIGRATIONS_ID: &[u8; 19] = b"pallet-midnight-mbm";
 // for the example of such a migration.
 // pub mod v1;
 
-/// Single-block ledger v8 -> v9 state translation (storage version 1 -> 2).
+/// Multi-block ledger v8 -> v9 state translation (storage version 1 -> 2).
 pub mod v2;

--- a/pallets/midnight/src/migrations/v2.rs
+++ b/pallets/midnight/src/migrations/v2.rs
@@ -18,18 +18,25 @@
 //! This is the on-chain half of the ledger 8 -> 9 hardfork. The pallet stores
 //! only the ledger state's arena root in [`crate::StateKey`]; the `LedgerState`
 //! itself lives in the ledger arena (parity-db). This migration hands the v8
-//! root to the [`migrate_state_v8_to_v9`](midnight_node_ledger::host_api::migration_8_to_9)
+//! root to the
+//! [`migrate_state_v8_to_v9_step`](midnight_node_ledger::host_api::migration_8_to_9)
 //! host function, which walks the v8 state, translates it into the v9 shape
 //! (see [`midnight_node_ledger::state_translation_v8_to_v9`]), re-persists it,
 //! and returns the new v9 root — which we write back into `StateKey`.
 //!
-//! It is a single-block migration: the host call translates the whole state in
-//! one shot (a few milliseconds for dev/undeployed-sized state). It is wired
-//! into [`crate::Migrations`](../../../runtime/src/lib.rs) via
-//! [`VersionedMigration`], so it runs at most once, when a runtime at
-//! pallet-midnight storage version 1 upgrades to this runtime (storage version
-//! 2). A chain whose genesis is already ledger-9 starts at storage version 2
-//! and never runs it.
+//! It is a [`SteppedMigration`] driven by `pallet-migrations`. The translation
+//! walks the whole state DAG, so its cost is unbounded in state size: for
+//! mainnet-sized state it completes in well under a second (i.e. in the upgrade
+//! block itself), but a single-block migration that overran would make the
+//! upgrade block take longer than a slot to execute on *every* importing node.
+//! Stepping it turns that failure mode into graceful multi-block progress. Each
+//! step gets a share of the MBM service weight as its cost-model budget (see
+//! [`step_budget_ps`]) and parks the in-flight translation in the ledger arena,
+//! handing back an arena key as its cursor.
+//!
+//! Unlike a `VersionedMigration`, an MBM gets no automatic storage-version gate,
+//! so [`MigrateV1ToV2::step`] reproduces it: a chain whose genesis is already
+//! ledger-9 starts at storage version 2 and short-circuits on the first step.
 //!
 //! Storage version 1 does not, however, imply the *ledger* state is still v8:
 //! the 2.0.0 runtime already ran ledger-9 yet shipped pallet-midnight at storage
@@ -37,54 +44,192 @@
 //! runtime triggers this migration over an already-v9 state. The host function
 //! detects that case and no-ops (returns the `StateKey` unchanged), so the only
 //! effect on that path is the storage-version bump to 2.
+//!
+//! ## The ledger is paused while this runs
+//!
+//! MBM steps are serviced in `frame_executive::inherents_applied()`, i.e. *after*
+//! the block's inherents, whereas `OnRuntimeUpgrade` ran *before* them. So from
+//! the first instruction of the upgrade block until this migration finishes,
+//! `StateKey` still references a v8 state under the v9 ledger API. Everything
+//! that would read or write the ledger from an inherent or from `on_finalize` is
+//! gated on [`crate::Pallet::ledger_migration_pending`] — see that function for
+//! the list. `frame_executive` additionally restricts these blocks to
+//! `ExtrinsicInclusionMode::OnlyInherents`, so no user transactions are lost
+//! either.
 
 #[cfg(feature = "try-runtime")]
 extern crate alloc;
 
 use crate::{Pallet, StateKey, pallet::Config};
 use frame_support::{
-	migrations::VersionedMigration, pallet_prelude::*, traits::UncheckedOnRuntimeUpgrade,
+	migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
+	pallet_prelude::*,
+	weights::WeightMeter,
 };
-use midnight_node_ledger::types::active_ledger_bridge as LedgerApi;
+use midnight_node_ledger::types::{TranslationStep, active_ledger_bridge as LedgerApi};
+use sp_runtime::Perbill;
 
 #[cfg(feature = "try-runtime")]
 use alloc::vec::Vec;
 
-/// [`UncheckedOnRuntimeUpgrade`] implementation wrapped by [`MigrateV1ToV2`].
-pub struct InnerMigrateV1ToV2<T: Config>(core::marker::PhantomData<T>);
+use super::PALLET_MIGRATIONS_ID;
 
-impl<T: Config> UncheckedOnRuntimeUpgrade for InnerMigrateV1ToV2<T> {
-	fn on_runtime_upgrade() -> Weight {
+/// Upper bound on the serialized in-flight translation cursor (an untagged
+/// `TypedArenaKey`, ~40 bytes in practice). Deliberately not
+/// [`crate::pallet::StateKeyLength`]: that bound is sized for the ledger state
+/// key and leaves no headroom for the cursor's own tag.
+pub type TranslationCursorLength = ConstU32<2048>;
+
+/// Share of the per-block MBM service weight handed to the ledger's cost model as
+/// one step's translation budget. The remainder absorbs the pallet's own
+/// reads/writes plus `pallet-migrations`' bookkeeping, so a step is always
+/// affordable out of a full [`WeightMeter`] — which matters because
+/// `pallet_migrations::exec_migration` treats [`SteppedMigrationError::InsufficientWeight`]
+/// from the *first* migration serviced in a block as a fatal `upgrade_failed`.
+const STEP_BUDGET_SHARE: Perbill = Perbill::from_percent(75);
+
+/// Steps taken at one budget level before it is doubled. See
+/// [`step_budget_ps`].
+const ESCALATE_EVERY_STEPS: u32 = 16;
+
+/// Cap on the number of budget doublings, i.e. 2^20 times the base budget. At
+/// the runtime's ~1.2s base that is over a fortnight of cost-model time, reached
+/// only after [`ESCALATE_EVERY_STEPS`] * 20 blocks.
+const MAX_BUDGET_DOUBLINGS: u32 = 20;
+
+/// Cost-model budget to grant the `steps`-th step, given the MBM service weight
+/// limit for this block.
+///
+/// `Weight::ref_time` is denominated in picoseconds
+/// (`WEIGHT_REF_TIME_PER_SECOND == 1e12`), so ledger cost-model picoseconds map
+/// 1:1 onto `ref_time` — the same mapping [`crate::Pallet::get_tx_weight`] uses
+/// for ordinary transactions.
+///
+/// The budget *grows* the longer the migration runs, because the ledger's
+/// translation engine has a per-state threshold budget below which a step makes
+/// no net progress (see
+/// [`migration_8_to_9`](midnight_node_ledger::host_api::migration_8_to_9)'s
+/// module docs). A state whose threshold exceeds one block's share would
+/// otherwise leave the migration — and with it the ledger — stuck forever.
+/// Doubling every [`ESCALATE_EVERY_STEPS`] blocks guarantees a step eventually
+/// large enough to finish, while a normally-progressing migration completes long
+/// before the first doubling.
+///
+/// Escalation deliberately does *not* raise what the step charges the
+/// [`WeightMeter`] (that stays at the base share, which is all the meter can
+/// afford). An escalated block therefore does more ledger work than it accounts
+/// for — the same over-run the single-block migration this replaced always risked,
+/// and only on a state that would otherwise be unmigratable.
+fn step_budget_ps(limit: Weight, steps: u32) -> u64 {
+	let base = (STEP_BUDGET_SHARE * limit).ref_time();
+	let doublings = (steps / ESCALATE_EVERY_STEPS).min(MAX_BUDGET_DOUBLINGS);
+	base.saturating_mul(1u64 << doublings)
+}
+
+/// Translates the ledger state from v8 to v9 and bumps pallet-midnight storage
+/// version 1 -> 2. Wired into `pallet_migrations::Config::Migrations`.
+pub struct MigrateV1ToV2<T: Config>(core::marker::PhantomData<T>);
+
+/// Migration cursor: the number of steps taken so far (which drives
+/// [`step_budget_ps`]) and the ledger's opaque in-flight translation cursor.
+pub type TranslationCursor = (u32, BoundedVec<u8, TranslationCursorLength>);
+
+impl<T: Config> SteppedMigration for MigrateV1ToV2<T> {
+	type Cursor = TranslationCursor;
+	type Identifier = MigrationId<19>;
+
+	fn id() -> Self::Identifier {
+		MigrationId { pallet_id: *PALLET_MIGRATIONS_ID, version_from: 1, version_to: 2 }
+	}
+
+	/// No cap. The framework compares `max_steps` against the number of *blocks*
+	/// elapsed since the migration started, and this translation is unbounded in
+	/// state size by design — any cap we picked could trip
+	/// `FreezeChainOnFailedMigration` on a large state instead of just taking
+	/// another block.
+	fn max_steps() -> Option<u32> {
+		None
+	}
+
+	fn step(
+		cursor: Option<Self::Cursor>,
+		meter: &mut WeightMeter,
+	) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+		// Stand-in for the `VersionedMigration<1, 2, ..>` gate MBMs don't provide:
+		// a chain whose genesis is already ledger-9 starts at storage version 2
+		// and must not translate anything. Only checked on the first step — once
+		// we have a cursor the translation is in flight and the version is still 1
+		// by construction.
+		if cursor.is_none() && !Pallet::<T>::ledger_migration_pending() {
+			log::info!(
+				target: "midnight::migration",
+				"pallet-midnight already at storage version {:?}; skipping ledger v8->v9 migration",
+				Pallet::<T>::on_chain_storage_version(),
+			);
+			return Ok(None);
+		}
+
+		let steps = cursor.as_ref().map(|(steps, _)| *steps).unwrap_or(0);
+		let budget_ps = step_budget_ps(meter.limit(), steps);
+
+		// Charge only the *base* share, which is what the meter can afford. The
+		// meter's limit is the `MaxServiceWeight` the runtime grants MBMs per
+		// block; deriving from it (rather than hardcoding a constant) is what makes
+		// a step provably affordable out of a full meter. `proof_size` is 0: this
+		// chain doesn't build a PoV. The reads/writes are `StateKey` plus the
+		// storage version.
+		let required = Weight::from_parts(step_budget_ps(meter.limit(), 0), 0)
+			.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+		if meter.try_consume(required).is_err() {
+			return Err(SteppedMigrationError::InsufficientWeight { required });
+		}
+
+		// One host call per step: `pallet-migrations` services a migration at most
+		// once per block, so an inner loop would only ever run once.
 		let state_key = StateKey::<T>::get();
+		let cursor_bytes = cursor.as_ref().map(|(_, c)| c.as_slice()).unwrap_or(&[]);
+		let step = LedgerApi::migrate_state_v8_to_v9_step(&state_key, cursor_bytes, budget_ps)
+			.map_err(|e| {
+				log::error!(
+					target: "midnight::migration",
+					"FATAL: ledger v8->v9 state migration step failed: {e:?}"
+				);
+				SteppedMigrationError::Failed
+			})?;
 
-		// The host function reads the v8 arena root, translates the referenced
-		// `LedgerState` to v9, re-persists it, and returns the new v9 root
-		// together with the synthetic cost (picoseconds) it charged the
-		// translation against the ledger's deterministic cost model. If the
-		// state is already v9 (e.g. a 2.0.0 -> this-runtime upgrade), it no-ops
-		// and returns the `state_key` unchanged with zero cost.
-		// A genuine failure here is unrecoverable: the chain would be left
-		// pointing at a v8 state a ledger-9 runtime cannot read, so we abort the
-		// upgrade.
-		let (new_state_key, consumed_cost_ps) = LedgerApi::migrate_state_v8_to_v9(&state_key)
-			.expect("FATAL: ledger v8->v9 state migration failed");
-
-		StateKey::<T>::put(new_state_key);
-		log::info!(
-			target: "midnight::migration",
-			"ledger v8->v9 state migration complete; StateKey re-pointed to v9 root ({consumed_cost_ps}ps synthetic cost)"
-		);
-
-		// The translation runs natively in the host call, so the pallet-side
-		// read/write above is negligible next to it; report the ledger's own
-		// synthetic cost as `ref_time` instead. This is the same 1:1 mapping
-		// `pallet_midnight::get_tx_weight` uses for ordinary transactions
-		// (ledger picoseconds -> `Weight` ref_time), and that cost model
-		// already prices the arena reads/writes the translation performs, so
-		// no separate `DbWeight` charge is added on top. `proof_size` is 0:
-		// this chain doesn't build a PoV. Capped at the block's max weight,
-		// since a pathological state could in principle exceed it.
-		Weight::from_parts(consumed_cost_ps, 0).min(T::BlockWeights::get().max_block)
+		match step {
+			TranslationStep::Done { state_key } => {
+				StateKey::<T>::put(state_key);
+				// MBMs don't bump the pallet's `StorageVersion`; do it ourselves so
+				// `on_chain_storage_version()` reflects the post-migration ledger
+				// version. This is also what un-freezes the ledger (see
+				// `Pallet::ledger_migration_pending`), so it must happen only once
+				// the state really is v9.
+				StorageVersion::new(2).put::<Pallet<T>>();
+				log::info!(
+					target: "midnight::migration",
+					"ledger v8->v9 state migration complete after {} step(s); StateKey re-pointed to v9 root",
+					steps.saturating_add(1),
+				);
+				Ok(None)
+			},
+			TranslationStep::InProgress { cursor } => {
+				let bounded = cursor.try_into().map_err(|_| {
+					log::error!(
+						target: "midnight::migration",
+						"FATAL: ledger v8->v9 translation cursor exceeds {} bytes",
+						<TranslationCursorLength as Get<u32>>::get(),
+					);
+					SteppedMigrationError::Failed
+				})?;
+				log::info!(
+					target: "midnight::migration",
+					"ledger v8->v9 state migration in progress after {} step(s) at {budget_ps}ps per step; ledger paused",
+					steps.saturating_add(1),
+				);
+				Ok(Some((steps.saturating_add(1), bounded)))
+			},
+		}
 	}
 
 	#[cfg(feature = "try-runtime")]
@@ -102,16 +247,44 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for InnerMigrateV1ToV2<T> {
 			!StateKey::<T>::get().is_empty(),
 			"ledger StateKey must remain populated after v8->v9 migration"
 		);
+		frame_support::ensure!(
+			Pallet::<T>::on_chain_storage_version() == 2,
+			"pallet-midnight storage version must be 2 after v8->v9 migration"
+		);
 		Ok(())
 	}
 }
 
-/// Translates the ledger state from v8 to v9 and bumps pallet-midnight storage
-/// version 1 -> 2. Wired into the runtime `Migrations` tuple.
-pub type MigrateV1ToV2<T> = VersionedMigration<
-	1,
-	2,
-	InnerMigrateV1ToV2<T>,
-	Pallet<T>,
-	<T as frame_system::Config>::DbWeight,
->;
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The runtime's MBM service weight: 80% of a 2s `max_block`.
+	fn limit() -> Weight {
+		Perbill::from_percent(80) * Weight::from_parts(2 * 1_000_000_000_000, u64::MAX)
+	}
+
+	#[test]
+	fn base_budget_is_the_configured_share_of_the_service_weight() {
+		// 75% of 80% of 2s == 1.2s of ledger cost-model time.
+		assert_eq!(step_budget_ps(limit(), 0), 1_200_000_000_000);
+	}
+
+	#[test]
+	fn budget_holds_steady_then_doubles() {
+		let base = step_budget_ps(limit(), 0);
+		for steps in 0..ESCALATE_EVERY_STEPS {
+			assert_eq!(step_budget_ps(limit(), steps), base, "step {steps} must stay at base");
+		}
+		assert_eq!(step_budget_ps(limit(), ESCALATE_EVERY_STEPS), base * 2);
+		assert_eq!(step_budget_ps(limit(), 2 * ESCALATE_EVERY_STEPS), base * 4);
+	}
+
+	#[test]
+	fn budget_escalation_is_capped() {
+		let base = step_budget_ps(limit(), 0);
+		let capped = base.saturating_mul(1 << MAX_BUDGET_DOUBLINGS);
+		assert_eq!(step_budget_ps(limit(), MAX_BUDGET_DOUBLINGS * ESCALATE_EVERY_STEPS), capped);
+		assert_eq!(step_budget_ps(limit(), u32::MAX), capped);
+	}
+}

--- a/pallets/midnight/src/mock.rs
+++ b/pallets/midnight/src/mock.rs
@@ -16,7 +16,7 @@ use crate as pallet_midnight;
 use frame_support::{
 	pallet_prelude::Weight,
 	parameter_types,
-	traits::{ConstU16, ConstU64},
+	traits::{ConstU16, ConstU64, GetStorageVersion},
 	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 
@@ -68,7 +68,9 @@ impl frame_system::Config for Test {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type RuntimeTask = ();
 	type SingleBlockMigrations = (); // replaces the `Executive` now for configuring migrations.
-	type MultiBlockMigrator = (); // the `pallet-migrations` would be set here, if deployed.
+	// The runtime wires `pallet-migrations` here; the mock leaves it unset and
+	// drives `migrations::v2::MigrateV1ToV2::step` directly instead.
+	type MultiBlockMigrator = ();
 	type PreInherents = (); // a hook that runs before any inherent.
 	type PostInherents = (); // a hook to run between inherents and `poll`/MBM logic.
 	type PostTransactions = (); // a hook to run after all transactions but before `on_idle`.
@@ -143,7 +145,17 @@ impl pallet_block_rewards::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+	let mut ext: sp_io::TestExternalities =
+		frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into();
+	// On a real chain `construct_runtime!`'s genesis build writes every pallet's
+	// current storage version via `OnGenesis`; this ext only assimilates
+	// `frame_system`'s genesis, so do it by hand. Without it
+	// `Pallet::ledger_migration_pending` would read version 0 and report an
+	// in-flight ledger v8->v9 migration, freezing the ledger for every test.
+	ext.execute_with(|| {
+		<Midnight as GetStorageVersion>::in_code_storage_version().put::<Midnight>();
+	});
+	ext
 }
 
 pub fn midnight_events() -> Vec<super::Event> {

--- a/pallets/midnight/src/tests.rs
+++ b/pallets/midnight/src/tests.rs
@@ -450,6 +450,148 @@ fn test_get_ledger_state_root_differs_from_zswap_state_root() {
 	});
 }
 
+/// Ledger v8 -> v9 multi-block migration ([`crate::migrations::v2`]).
+///
+/// Drives `SteppedMigration::step` directly — the mock leaves
+/// `frame_system::Config::MultiBlockMigrator` unset, so the MBM framework itself
+/// is not exercised here. The mock's ledger state is already v9, so the host
+/// function's idempotency guard makes the translation a single step; the
+/// multi-step and determinism properties are covered in
+/// `midnight_node_ledger::host_api::migration_8_to_9`'s tests.
+mod migration_v2 {
+	use super::*;
+	use crate::migrations::v2::MigrateV1ToV2;
+	use frame_support::{
+		migrations::{SteppedMigration, SteppedMigrationError},
+		traits::{GetStorageVersion, StorageVersion},
+		weights::WeightMeter,
+	};
+	use sp_runtime::Perbill;
+	use test_log::test;
+
+	type Migration = MigrateV1ToV2<Test>;
+
+	/// Same limit the runtime grants MBMs per block (80% of `max_block`).
+	fn service_meter() -> WeightMeter {
+		WeightMeter::with_limit(
+			Perbill::from_percent(80)
+				* <Test as frame_system::Config>::BlockWeights::get().max_block,
+		)
+	}
+
+	#[test]
+	fn pending_until_the_final_step_bumps_the_storage_version() {
+		mock::new_test_ext().execute_with(|| {
+			init_ledger_state(BlockContext::default());
+			// A ledger-8 chain arrives at this runtime on storage version 1.
+			StorageVersion::new(1).put::<mock::Midnight>();
+			let state_key_before = StateKey::<Test>::get();
+
+			assert!(
+				mock::Midnight::ledger_migration_pending(),
+				"the ledger must be frozen before the migration completes",
+			);
+
+			let mut meter = service_meter();
+			let cursor = Migration::step(None, &mut meter).expect("step must succeed");
+
+			assert!(cursor.is_none(), "an already-v9 state must finish in one step");
+			assert_eq!(
+				mock::Midnight::on_chain_storage_version(),
+				StorageVersion::new(2),
+				"the final step must bump the storage version to 2",
+			);
+			assert!(
+				!mock::Midnight::ledger_migration_pending(),
+				"the ledger must be un-frozen once the migration completes",
+			);
+			// The host function no-ops on an already-v9 root, so the key is
+			// rewritten with the same bytes.
+			assert_eq!(StateKey::<Test>::get(), state_key_before);
+			assert!(meter.consumed().ref_time() > 0, "the step must charge its budget");
+		});
+	}
+
+	#[test]
+	fn skips_when_genesis_is_already_at_version_two() {
+		mock::new_test_ext().execute_with(|| {
+			init_ledger_state(BlockContext::default());
+			// A chain whose genesis is already ledger-9 starts at version 2.
+			StorageVersion::new(2).put::<mock::Midnight>();
+			let state_key_before = StateKey::<Test>::get();
+
+			let mut meter = service_meter();
+			let cursor = Migration::step(None, &mut meter).expect("step must succeed");
+
+			assert!(cursor.is_none());
+			assert_eq!(StateKey::<Test>::get(), state_key_before);
+			assert_eq!(
+				meter.consumed(),
+				Weight::zero(),
+				"the version gate must short-circuit before charging anything",
+			);
+		});
+	}
+
+	/// The step budget is a fixed share of the meter's *limit*, so a meter that
+	/// has already been drawn down below that share must surface
+	/// `InsufficientWeight` (and be retried next block) rather than run a
+	/// short-changed step.
+	#[test]
+	fn insufficient_remaining_weight_defers_the_step() {
+		mock::new_test_ext().execute_with(|| {
+			init_ledger_state(BlockContext::default());
+			StorageVersion::new(1).put::<mock::Midnight>();
+
+			let mut meter = service_meter();
+			// Leave half the limit: less than the 75% share a step asks for.
+			let half = Perbill::from_percent(50) * meter.limit();
+			meter.consume(half);
+
+			let result = Migration::step(None, &mut meter);
+			assert!(
+				matches!(result, Err(SteppedMigrationError::InsufficientWeight { .. })),
+				"a drawn-down meter must surface InsufficientWeight, got {result:?}",
+			);
+			assert!(
+				mock::Midnight::ledger_migration_pending(),
+				"a deferred step must leave the ledger frozen",
+			);
+		});
+	}
+
+	/// The load-bearing guard: `on_finalize` runs on every block the migration
+	/// spans, and `apply_post_block_update` against a pre-migration state would
+	/// fail — and it is `expect`ed, so an unguarded `on_finalize` bricks the chain
+	/// on the upgrade block.
+	#[test]
+	fn on_finalize_skips_the_post_block_update_while_pending() {
+		mock::new_test_ext().execute_with(|| {
+			init_ledger_state(BlockContext::default());
+			StorageVersion::new(1).put::<mock::Midnight>();
+			let state_key_before = StateKey::<Test>::get();
+
+			// Must not panic, and must leave the ledger state key alone.
+			mock::Midnight::on_finalize(mock::System::block_number());
+			assert_eq!(
+				StateKey::<Test>::get(),
+				state_key_before,
+				"no post-block update may run while the migration is pending",
+			);
+
+			// Once the migration has completed, the post-block update resumes and
+			// advances the state key.
+			StorageVersion::new(2).put::<mock::Midnight>();
+			mock::Midnight::on_finalize(mock::System::block_number());
+			assert_ne!(
+				StateKey::<Test>::get(),
+				state_key_before,
+				"the post-block update must resume once the migration completes",
+			);
+		});
+	}
+}
+
 #[cfg(feature = "experimental")]
 #[ignore = "TODO UNSHIELDED - fix when Claim Mint is properly handled for Unshielded"]
 #[test]

--- a/partner-chains/toolkit/bridge/pallet/src/lib.rs
+++ b/partner-chains/toolkit/bridge/pallet/src/lib.rs
@@ -203,7 +203,22 @@ use sp_partner_chains_bridge::BridgeTransferV1;
 /// ledger structure. Calls to all functions defined by this trait should not return any errors
 /// as this would fail the block creation. Instead, any validation and business logic errors
 /// should be handled gracefully inside the handler code.
+///
+/// Note for downstream forks: [`Self::can_handle_transfers`] is a Midnight addition to the
+/// upstream trait. If patching this pallet is ever not an option, the same effect can be had
+/// without touching it, by having the handler queue every incoming transfer into its own storage
+/// and drain that queue from a hook once it is able to apply them.
 pub trait TransferHandler<Recipient> {
+	/// Whether the runtime can accept transfers in this block.
+	///
+	/// When `false` the pallet skips the whole batch and leaves [`pallet::DataCheckpoint`]
+	/// unchanged, so the inherent re-delivers the same transfers in a later block. Gating the
+	/// batch as a whole — rather than per transfer — is what makes re-delivery safe: no transfer
+	/// is ever applied twice because none is applied at all.
+	fn can_handle_transfers() -> bool {
+		true
+	}
+
 	/// Should handle an incoming token transfer of `token_mount` tokens to `recipient`
 	fn handle_incoming_transfer(_transfer: BridgeTransferV1<Recipient>);
 }
@@ -326,6 +341,16 @@ pub mod pallet {
 			ensure_none(origin)?;
 			ensure!(!InherentExecutedThisBlock::<T>::get(), Error::<T>::InherentAlreadyExecuted);
 			InherentExecutedThisBlock::<T>::put(true);
+			// Gate the batch *before* any mutation, so partial application is
+			// structurally impossible and re-delivery can never double-credit.
+			if !T::TransferHandler::can_handle_transfers() {
+				log::info!(
+					target: "partner-chains-bridge",
+					"transfer handler not ready; deferring {} transfer(s), data checkpoint unchanged",
+					transfers.len()
+				);
+				return Ok(());
+			}
 			for transfer in transfers {
 				T::TransferHandler::handle_incoming_transfer(transfer);
 			}

--- a/partner-chains/toolkit/bridge/pallet/src/mock.rs
+++ b/partner-chains/toolkit/bridge/pallet/src/mock.rs
@@ -34,7 +34,16 @@ pub mod mock_pallet {
 	#[pallet::unbounded]
 	pub type Transfers<T: Config> = StorageValue<_, Vec<BridgeTransferV1<RecipientAddress>>>;
 
+	/// Drives the `TransferHandler::can_handle_transfers` gate from tests.
+	/// Defaults to `false`, i.e. the handler is ready.
+	#[pallet::storage]
+	pub type HandlerNotReady<T: Config> = StorageValue<_, bool, ValueQuery>;
+
 	impl<T> TransferHandler<RecipientAddress> for Pallet<T> {
+		fn can_handle_transfers() -> bool {
+			!HandlerNotReady::<Test>::get()
+		}
+
 		fn handle_incoming_transfer(transfer: BridgeTransferV1<RecipientAddress>) {
 			Transfers::<Test>::append(transfer);
 		}

--- a/partner-chains/toolkit/bridge/pallet/src/tests.rs
+++ b/partner-chains/toolkit/bridge/pallet/src/tests.rs
@@ -107,6 +107,24 @@ mod handle_transfers {
 	}
 
 	#[test]
+	fn defers_the_whole_batch_when_the_handler_is_not_ready() {
+		new_test_ext().execute_with(|| {
+			mock_pallet::HandlerNotReady::<Test>::put(true);
+
+			assert_ok!(Bridge::handle_transfers(
+				RuntimeOrigin::none(),
+				transfers(),
+				data_checkpoint()
+			));
+
+			// Nothing applied and the checkpoint left untouched, so the inherent
+			// re-delivers the same transfers in a later block.
+			assert_eq!(mock_pallet::Transfers::<Test>::get(), None);
+			assert_eq!(DataCheckpoint::<Test>::get(), None);
+		})
+	}
+
+	#[test]
 	fn duplicate_inherent_protection_works() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(Bridge::handle_transfers(

--- a/primitives/midnight/src/lib.rs
+++ b/primitives/midnight/src/lib.rs
@@ -34,6 +34,15 @@ pub trait LedgerStateProviderMut {
 	fn mut_ledger_state<F, E, R>(f: F) -> Result<R, E>
 	where
 		F: FnOnce(Vec<u8>) -> Result<(Vec<u8>, R), E>;
+	/// Whether a ledger state migration is still in flight, i.e. the state key
+	/// references a state the *current* runtime's ledger API cannot read.
+	///
+	/// Multi-block migrations are serviced after a block's inherents, so every
+	/// mandatory inherent in a migration block runs against the pre-migration
+	/// state. Callers that touch the ledger from an inherent (or from
+	/// `on_finalize`) must skip that work while this is `true`, and must leave
+	/// their own progress markers untouched so the work is re-delivered later.
+	fn ledger_migration_pending() -> bool;
 }
 
 pub trait LedgerBlockContextProvider {
@@ -45,6 +54,10 @@ pub trait MidnightSystemTransactionExecutor {
 	fn execute_system_transaction(
 		serialized_system_transaction: Vec<u8>,
 	) -> Result<Hash, DispatchError>;
+	/// Whether a ledger state migration is still in flight, in which case
+	/// [`Self::execute_system_transaction`] would fail against the pre-migration
+	/// state. See [`LedgerStateProviderMut::ledger_migration_pending`].
+	fn ledger_migration_pending() -> bool;
 }
 
 #[derive(Clone, Encode, Decode, DecodeWithMemTracking, Debug, TypeInfo)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -543,8 +543,18 @@ parameter_types! {
 
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	// Append-only: `ActiveCursor.index` is an index into this tuple, so inserting
+	// ahead of an existing entry would misidentify an in-flight migration.
+	// Completed migrations are skipped via `Historic`, not removed.
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = (pallet_cnight_observation::migrations::v1::MigrateV0ToV1<Runtime>,);
+	type Migrations = (
+		pallet_cnight_observation::migrations::v1::MigrateV0ToV1<Runtime>,
+		// Ledger v8 -> v9 state translation (the ledger 8->9 hardfork). Runs once,
+		// when a ledger-8 runtime (pallet-midnight storage version 1) upgrades to
+		// this ledger-9 runtime (storage version 2). Normally completes in the
+		// upgrade block; pauses the ledger for as many blocks as it spans.
+		pallet_midnight::migrations::v2::MigrateV1ToV2<Runtime>,
+	);
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
@@ -1200,13 +1210,7 @@ pub type Executive = frame_executive::Executive<
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, TxExtension>;
 /// Migrations to apply on runtime upgrade.
-pub type Migrations = (
-	pallet_throttle::migrations::v1::MigrateV0ToV1<Runtime>,
-	// Ledger v8 -> v9 state translation (the ledger 8->9 hardfork). Runs once,
-	// when a ledger-8 runtime (pallet-midnight storage version 1) upgrades to
-	// this ledger-9 runtime (storage version 2).
-	pallet_midnight::migrations::v2::MigrateV1ToV2<Runtime>,
-);
+pub type Migrations = (pallet_throttle::migrations::v1::MigrateV0ToV1<Runtime>,);
 
 impl<LocalCall> frame_system::offchain::CreateTransaction<LocalCall> for Runtime
 where

--- a/util/toolkit/src/tx_generator/builder/mod.rs
+++ b/util/toolkit/src/tx_generator/builder/mod.rs
@@ -1250,6 +1250,49 @@ fn replay_blocks_7(
 	}
 }
 
+/// Tracks which blocks a replay must not apply to the ledger because the chain's
+/// own ledger state did not move in them.
+///
+/// That is the case for the blocks the ledger 8 -> 9 state translation spans:
+/// `pallet_midnight`'s `on_finalize` skips the post-block ledger update while the
+/// multi-block migration is in flight, and `frame_executive` admits only
+/// inherents in those blocks. Applying one would perform a post-block update the
+/// chain never did, advancing the local state past the chain's and failing the
+/// next block's state-root check.
+///
+/// Only the *ledger* application is skipped: the surrounding dust bookkeeping
+/// must still run, and the dust clock must not be advanced past the last block
+/// the ledger actually moved in.
+///
+/// Inert outside that window: if a block's recorded root equals its parent's, a
+/// replay that changed state would have failed the root check anyway.
+#[derive(Default)]
+struct LedgerPauseTracker<'a> {
+	last_applied: Option<&'a RawBlockData>,
+}
+
+impl<'a> LedgerPauseTracker<'a> {
+	/// Whether `block` should be applied to the ledger. Records it as the latest
+	/// applied block when so.
+	fn should_apply(&mut self, block: &'a RawBlockData) -> bool {
+		if block.leaves_ledger_unchanged(self.last_applied.and_then(|b| b.state_root.as_ref())) {
+			log::debug!(
+				"replay: not applying block {} — state root unchanged from parent (ledger paused)",
+				block.number,
+			);
+			return false;
+		}
+		self.last_applied = Some(block);
+		true
+	}
+
+	/// The last block the ledger actually moved in, i.e. the block whose context
+	/// the trailing dust update should use.
+	fn last_applied(&self) -> Option<&'a RawBlockData> {
+		self.last_applied
+	}
+}
+
 fn replay_blocks_8(
 	ctx: &midnight_node_ledger_helpers::ledger_8::context::LedgerContext<Db8>,
 	blocks_sorted_by_height: &[RawBlockData],
@@ -1257,9 +1300,12 @@ fn replay_blocks_8(
 	let mut events: Vec<midnight_node_ledger_helpers::ledger_8::Event<Db8>> = Vec::new();
 
 	let total = blocks_sorted_by_height.len();
+	let mut pause = LedgerPauseTracker::default();
 
 	for (i, block) in blocks_sorted_by_height.iter().enumerate() {
-		events.extend(apply_block_8(ctx, block));
+		if pause.should_apply(block) {
+			events.extend(apply_block_8(ctx, block));
+		}
 
 		let is_last = i + 1 == total;
 		if events.len() >= DUST_BATCH_SIZE || is_last {
@@ -1269,7 +1315,7 @@ fn replay_blocks_8(
 		}
 	}
 
-	if let Some(block) = blocks_sorted_by_height.last() {
+	if let Some(block) = pause.last_applied() {
 		ctx.update_dust_from_block(&block_context_from_raw_8(block));
 	}
 }
@@ -1284,8 +1330,11 @@ fn replay_blocks_9(
 	let mut remaining = wallets_sorted_by_height;
 	let total = blocks_sorted_by_height.len();
 	let mut last_info_at = std::time::Instant::now();
+	let mut pause = LedgerPauseTracker::default();
 
 	for (i, block) in blocks_sorted_by_height.iter().enumerate() {
+		let apply = pause.should_apply(block);
+
 		let n = remaining.partition_point(|(_, ws)| ws.block_height < block.number);
 		if n > 0 {
 			let (to_inject, rest) = remaining.split_at(n);
@@ -1298,7 +1347,9 @@ fn replay_blocks_9(
 			remaining = rest;
 		}
 
-		events.extend(apply_block_9(ctx, block));
+		if apply {
+			events.extend(apply_block_9(ctx, block));
+		}
 
 		let is_last = i + 1 == total;
 		if events.len() >= DUST_BATCH_SIZE || is_last {
@@ -1329,7 +1380,7 @@ fn replay_blocks_9(
 		inject_cached_wallets(ctx, remaining, &ls, height, schemes);
 	}
 
-	if let Some(block) = blocks_sorted_by_height.last() {
+	if let Some(block) = pause.last_applied() {
 		ctx.update_dust_from_block(&block_context_from_raw_9(block));
 	}
 }

--- a/util/toolkit/tests/common/wait_for_node.rs
+++ b/util/toolkit/tests/common/wait_for_node.rs
@@ -18,8 +18,47 @@
 //! commands, which fails with `OnlyGenesisFinalized` until finality has reached
 //! block 1, so finality (not best-block) is what tests need to wait for.
 
+use midnight_node_ledger_helpers::fork::raw_block_data::LedgerVersion;
 use midnight_node_toolkit::client::MidnightNodeClient;
 use std::time::{Duration, Instant};
+
+/// Wait until the finalized ledger state has been translated to ledger 9.
+///
+/// The ledger 8 -> 9 state translation is a multi-block migration, so for the
+/// blocks it spans the chain still carries a ledger-8 state root even though the
+/// ledger-9 runtime is live. A client that syncs to such a head would build
+/// ledger-8 transactions; those blocks admit inherents only, so nothing is lost
+/// by waiting for the migration to land first.
+pub async fn wait_for_ledger_9_state(ws_url: &str, timeout: Duration) {
+	let client = connect(ws_url, timeout).await;
+	let start = Instant::now();
+	loop {
+		match client.get_state_root_at(None).await {
+			Ok(Some(root)) => match LedgerVersion::from_state_root(&root) {
+				Some(LedgerVersion::Ledger9) => {
+					eprintln!(
+						"[wait_for_ledger_9] finalized state is ledger 9 (elapsed: {:.1}s)",
+						start.elapsed().as_secs_f32()
+					);
+					return;
+				},
+				other => eprintln!(
+					"[wait_for_ledger_9] finalized state is {other:?}, migration still pending (elapsed: {:.1}s)",
+					start.elapsed().as_secs_f32()
+				),
+			},
+			Ok(None) => eprintln!("[wait_for_ledger_9] no StateKey in storage yet"),
+			Err(e) => eprintln!("[wait_for_ledger_9] rpc error fetching StateKey: {e}"),
+		}
+		if start.elapsed() >= timeout {
+			panic!(
+				"timed out after {:?} waiting for the ledger 8->9 migration to complete on {ws_url}",
+				start.elapsed()
+			);
+		}
+		tokio::time::sleep(Duration::from_secs(1)).await;
+	}
+}
 
 pub async fn wait_for_finalized_block(ws_url: &str, target_block: u64, timeout: Duration) {
 	let client = connect(ws_url, timeout).await;

--- a/util/toolkit/tests/hardfork_e2e.rs
+++ b/util/toolkit/tests/hardfork_e2e.rs
@@ -16,7 +16,10 @@
 mod common;
 
 use clap::Parser;
-use common::{test_image, wait_for_node::wait_for_finalized_block};
+use common::{
+	test_image,
+	wait_for_node::{wait_for_finalized_block, wait_for_ledger_9_state},
+};
 use midnight_node_toolkit::cli::{Cli, run_command};
 use std::{process::Command, time::Duration};
 use testcontainers::{
@@ -140,7 +143,14 @@ async fn hardfork_single_tx() {
 	])
 	.await;
 
-	// 5. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
+	// 5. Wait for the v8 -> v9 state translation to land. It runs as a multi-block
+	//    migration serviced after each block's inherents, so the ledger state is
+	//    still v8 for the block(s) it spans — a client syncing to such a head
+	//    would build ledger-8 transactions. Those blocks admit inherents only, so
+	//    waiting costs nothing.
+	wait_for_ledger_9_state(&url, Duration::from_secs(180)).await;
+
+	// 6. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
 	run_cli(&[
 		"generate-txs",
 		"--fetch-cache",


### PR DESCRIPTION
# Overview

**[DO NOT MERGE]** — exploratory. This converts the ledger 8→9 hardfork state
migration (#1925) from a single-block `VersionedMigration<1, 2, …>` into a
`SteppedMigration` under the already-deployed `pallet-migrations`, end to end,
so we can see what a real MBM against ledger state actually costs us. It works —
`hardfork_e2e` passes and the migration genuinely spans multiple blocks — but the
value here is mostly the **findings**, and several pieces are worth landing on
their own regardless of whether we ever ship the MBM version.

Why we looked at this: the translation walks the whole state DAG, so its cost is
**unbounded in state size**. Mainnet-sized state measures well under a second, so
in practice it fits in one block — but if it ever overran, the upgrade block would
take longer than a slot to execute on *every* importing node, stalling the chain at
exactly the worst moment. Stepping it degrades that to "ledger paused for N blocks,
nothing lost".

## What we learned

**1. The ledger's translation engine is not resumable at fine granularity.**
This is the big one, and it invalidates the assumption the whole design rested on.
`TypedTranslationState::run` round-trips its state through
`InflightTranslationState` on *every* call, and that conversion keeps only
memo-cache entries whose source node has an `ArenaKey::Ref` key — results memoised
against an inlined (small) node are dropped (`TranslationCacheKey::persist`,
midnight-storage 2.0.1). Work below the nearest `Ref` node is thrown away when the
budget runs out.

So each state has a **threshold budget** below which stepping makes no net
progress. Measured on synthetic fixtures, `run` either sits on a fixed point
forever or *cycles* between a handful of states:

| fixture | per-step budget | outcome |
|---|---|---|
| 2048-entry `u128` map | 20 µs | fixed point, never progresses |
| 2048-entry `u128` map | 6 ms | cycles (revisits earlier roots) |
| 2048-entry `u128` map | 20 ms | converges in 8 steps |
| 2048-entry `u128` map | 200 ms | 1 step |
| `dev` genesis (61 KB, the `hardfork_e2e` fixture) | ≥140 µs | 1 step; indivisible below that |

The threshold tracks node *granularity*, not total size (512- and 2048-entry maps
both need ~20 ms), so it stays ~4 orders of magnitude below the ~1.2 s per-block
share — but it isn't *guaranteed* to. To make termination unconditional,
`step_budget_ps` doubles the budget every 16 blocks the migration has been running
(capped at 2²⁰×). Escalation deliberately does **not** raise what the step charges
the `WeightMeter`, so an escalated block over-runs its weight — the same risk the
single-block version always carried, and only on a state that would otherwise leave
the ledger frozen forever.

Worth raising upstream against `midnight-storage` — a `TranslationState` that
persisted its transient memo cache would make this genuinely resumable and remove
the need for escalation entirely.

**2. MBM steps run *after* a block's inherents.** `frame_executive` services them
in `inherents_applied()`, whereas `OnRuntimeUpgrade` ran *before*. So from the first
instruction of the upgrade block until the migration finishes, mandatory inherents
execute against a state the current ledger API cannot read. Three paths do that
today, two load-bearing:

| Path | Consequence if unguarded |
|---|---|
| `pallet_midnight::on_finalize` → `apply_post_block_update` (`.expect`) | **Panic → chain bricked**, every migration block |
| `pallet_cnight_observation::process_tokens` (mandatory inherent) → `execute_system_transaction` (`?`) | **Inherent fails → block unimportable → chain halted**, on any network with live cNIGHT data |
| partner-chains bridge inherent → `pallet_c2m_bridge::handle_incoming_transfer` (error swallowed by contract) | Bridge transfers **silently dropped** (fund loss) |

These are hit regardless of how fast the migration is, so the guards are not
optional. **Any** future MBM that touches ledger state will need this same
scaffolding — which is the main reason to land some of it early.

**3. The toolkit's fork-aware replay couldn't handle the window.** It partitioned
blocks by runtime spec version, which stops being authoritative the moment the
ledger-9 runtime is live while the state is still ledger-8. This surfaced as a
`StateRootMismatch` (v13 expected, v18 computed), and then — once version selection
was fixed — as a silent `Insufficient DUST`, because skipping a block with
`continue` also skipped the final dust-event flush and dropped every accumulated
event.

## 🗹 TODO before merging

- [x] Ready
- [ ] **Do not merge this branch.** It is here for review and to carve up (see below).
- [ ] Raise the `midnight-storage` memo-cache finding upstream.
- [ ] Decide whether we want the MBM version of the hardfork migration at all, given
      the engine caveat means it cannot guarantee bounded per-block work.

## 📦 Suggested subsets to merge as separate PRs

Commits are ordered and sliced so these can be cherry-picked directly. Caveat on
how far that is verified: **A+B+C together** were compile-checked at commit
`b14754a` (`cargo check --workspace --all-targets`, clean), and the full branch was
checked, clippied and tested. A, B and C are file-disjoint and don't reference each
other, so each alone should build — but I did not build them individually, and D was
not built without E. Worth a CI run per subset before merging any of them.

**A. `test(pallet-midnight): write the in-code storage version in the mock genesis`**
(`adc0af4`, 1 file) — **merge independently, no MBM dependency.**
`new_test_ext` only assimilates `frame_system`'s genesis, so unlike a real chain
(where `construct_runtime!` calls `OnGenesis` for every pallet) pallet-midnight's
storage version was never written and every test ran at version 0 instead of the
in-code 2. Harmless until something branches on the version — then the mock
silently exercises the wrong branch, which is exactly what bit us here. Also drops
the now-false `MultiBlockMigrator` comment.

**B. `feat(partner-chains-bridge): let the transfer handler defer a whole batch`**
(`1840287`, 3 files) — **merge independently; also worth upstreaming.**
Adds a defaulted `TransferHandler::can_handle_transfers()`. Today
`handle_incoming_transfer` returns `()` by contract, so a handler that is
temporarily unable to apply a transfer can only swallow the failure and drop it.
Gating the batch *before* any mutation makes partial application structurally
impossible, so re-delivery can never double-credit. Defaulted to `true`, so `()`,
the pallet mock and the demo runtime are unaffected. The trait doc records the
alternative if patching this vendored pallet isn't acceptable to its owners
(handler-side queue + drain hook).

**C. `fix(toolkit): derive a block's ledger version from its state root`**
(`b14754a`, 4 files) — **merge independently; a correctness fix on its own terms.**
The state root's tag reports the version of the state a block actually left behind;
the spec version reports which runtime executed it. The former is what a replay
needs, and they can disagree. Also fixes the dust-flush bug found above, and makes
`hardfork_e2e` wait for the finalized state to reach ledger 9. Inert outside a
hardfork window: if a block's root equalled its parent's, a replay that changed
state would already have failed the root check.

**D. `feat: freeze ledger writes while a ledger state migration is pending`**
(`e01fdab`, 9 files) — **mergeable after B; the reusable MBM scaffolding.**
`ledger_migration_pending()` on `LedgerStateProviderMut` and
`MidnightSystemTransactionExecutor`, plus the three guards. Currently defined as
`pallet_midnight::on_chain_storage_version() < 2`, so on `main` today it is
permanently `false` and the guards are dead code — landing it early is about having
the plumbing and tests in place before the next ledger-state MBM needs them, not
about changing behaviour. Happy to hold this one if we'd rather not carry dormant
guards.

**E. `feat: convert the ledger 8->9 hardfork migration to a multi-block migration`**
(`3cd7d5f`, 8 files) — **the exploratory core. Not proposed for merge.**
The stepped host fn, the `SteppedMigration`, the arena-parked cursor and the
budget escalation. Depends on D. Only worth landing if we decide the answer to the
open question above is yes.

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: amends the existing `changes/runtime/changed/ledger-8-to-9-hardfork-migration.md` rather than adding one, since this changes how the same feature behaves
- [ ] If the changes introduce a new feature, I have bumped the node minor version <!-- deliberately not bumped: not for merge -->
- [x] Update documentation (if relevant) <!-- module docs record the engine caveat and the measurements -->
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- N/A -->
- [x] No new todos introduced

## 🧪 Testing Evidence

Static, on this branch (rebased onto current `main`):

```
cargo check --workspace                                                            # clean
cargo clippy --workspace --all-targets --features runtime-benchmarks,try-runtime -- -D warnings   # clean (Earthfile:997 gate)
cargo fmt --all --check                                                            # clean
cargo test -p midnight-node-ledger --lib -p pallet-midnight -p pallet-cnight-observation \
           -p pallet-c2m-bridge -p pallet-partner-chains-bridge -p midnight-node-runtime \
           -p midnight-node-ledger-helpers                                         # 396 passed, 2 ignored
```

New tests worth calling out:

- **Stepped ≡ single-shot determinism** (`ledger/src/host_api/migration_8_to_9.rs`).
  The cursor is on-chain state, so every importing node must reproduce identical
  bytes. A 2048-entry fixture translated over many bounded steps lands on a
  byte-identical v9 arena root to one unbounded translation. Treat a failure here
  as a blocker, not a flake.
- Cursor round-trips serialise → `get_lazy` → `run`; a v9 `state_key` with an empty
  cursor short-circuits to `Done` unchanged (the 2.0.0 → this-runtime path, which
  was previously untested).
- `step()`-driven pallet tests: version gate, `InsufficientWeight` deferral, and
  `on_finalize` not bricking while pending.
- `process_tokens` leaves `NextCardanoPosition` unchanged and applies no system tx
  while pending, then applies the re-delivered batch afterwards.
- `handle_transfers` with `can_handle_transfers() == false` leaves `DataCheckpoint`
  unchanged and invokes the handler zero times.
- `LedgerVersion::from_state_root` / `leaves_ledger_unchanged`, against real v13 and
  v18 roots captured from a dev chain.

**End-to-end** — node image built from this tree (`earthly -P +node-image`), then:

```
NODE_IMAGE=midnight-node-hf:mbm MIDNIGHT_LEDGER_EXPERIMENTAL=1 RUST_LOG=info \
TESTCONTAINERS_RYUK_DISABLED=true \
cargo test --release -p midnight-node-toolkit --test hardfork_e2e -- --nocapture --test-threads=1
# test result: ok. 1 passed
```

The multi-block window was exercised **for real**, not simulated — no need to shrink
the budget artificially. `pallet-cnight-observation`'s own MBM consumes the upgrade
block's meter, so ours defers with `InsufficientWeight` and completes in the next
block. Node log across #34 → #36:

```
#35  ⚠️ Midnight declares internal migrations … On-chain `StorageVersion(1)` vs in-code `StorageVersion(2)`
#35  cnight-observation: skipping process_tokens (mapping migration pending: true, …; ledger migration pending: true)
#35  ledger migration pending; skipping post-block ledger update
#35  🎁 Prepared block for proposing at 35 … end: TransactionForbidden; extrinsics_count: 3
#36  cnight-observation: skipping process_tokens (mapping migration pending: false, …; ledger migration pending: true)
#36  v8->v9 ledger state translation complete (final step took 131.434µs)
#36  ledger v8->v9 state migration complete after 1 step(s); StateKey re-pointed to v9 root
#37  🎁 Prepared block for proposing at 37 … end: NoMoreTransactions
```

`TransactionForbidden` confirms `frame_executive` restricted the window to
inherents, and the post-fork `generate-txs single-tx` succeeds against the migrated
v9 state.

I also re-ran `hardfork_e2e` against the pre-MBM node image with this branch's
toolkit changes and it still passes, so subset **C** is not a behaviour change for
the single-block path.

## 🔱 Fork Strategy

- [x] Node Runtime Update
- [x] Node Client Update <!-- toolkit replay + test harness -->

No `spec_version` bump and no new storage items or extrinsics, so **no metadata
rebuild is needed**. Nothing is deployed on `002_001_000`, so the previous decision
not to bump stands.

## Links

Follow-up exploration on top of #1925 (ledger 8→9 hardfork on-chain migration).
Related: https://github.com/midnightntwrk/midnight-node/issues/1580
