### PR TITLE
fix: narrow tblock_correction to the first tx in a block (backport of #1964)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9983,6 +9983,7 @@ dependencies = [
  "midnight-node-ledger-helpers",
  "midnight-node-res",
  "midnight-primitives",
+ "midnight-primitives-ledger",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/changes/node/changed/fix-tblock-correction-first-tx.md
+++ b/changes/node/changed/fix-tblock-correction-first-tx.md
@@ -1,0 +1,26 @@
+# Narrow the tblock correction to the first transaction of a block
+
+The `tblock_correction` shipped in #1932 was applied too broadly: every historical transaction
+was verified at `block_context.tblock + offset`. Preview stalled at #128536, unable to import
+#128537, whose transaction has an intent TTL of `1784987084` — two slots earlier than the
+`1784987088` that the correction produced.
+
+The offset was measured from the wrong base. During mempool ingress the node verifies a
+transaction at `ParentTimestamp + slot_duration * (1 + MaxSkippedSlots)`, and the including
+block's own timestamp is already one slot past the parent's, so adding the offset to it
+double-counts a slot. The correction is now measured from the parent block's timestamp
+(`BlockContext::last_block_time`), reproducing exactly the timestamp that the producing node's
+warm strict-cache entry was verified at — `1784987082` for the block above, which imports.
+
+The correction is also now limited to the *first* ledger transaction of a block (no user or
+system transaction applied yet, so the ledger state is still the parent's post-block state).
+That is the only position where the producing node's strict cache could have hit, so it is the
+only position where a transaction can have been verified ahead of its block's timestamp. It is
+no longer applied on the mempool path at all, where `validate_unsigned` already skews the block
+context it passes to the ledger.
+
+The config values are unchanged, but `tblock_correction_offset` is now relative to the parent
+block's timestamp and must equal `slot_duration_secs * (1 + MaxSkippedSlots)` (`6 * 2 = 12`).
+
+PR:
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1924

--- a/changes/node/changed/fix-tblock-correction-first-tx.md
+++ b/changes/node/changed/fix-tblock-correction-first-tx.md
@@ -22,5 +22,5 @@ context it passes to the ledger.
 The config values are unchanged, but `tblock_correction_offset` is now relative to the parent
 block's timestamp and must equal `slot_duration_secs * (1 + MaxSkippedSlots)` (`6 * 2 = 12`).
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/1964
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1924

--- a/changes/node/changed/fix-tblock-correction-first-tx.md
+++ b/changes/node/changed/fix-tblock-correction-first-tx.md
@@ -23,4 +23,5 @@ The config values are unchanged, but `tblock_correction_offset` is now relative 
 block's timestamp and must equal `slot_duration_secs * (1 + MaxSkippedSlots)` (`6 * 2 = 12`).
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/1964
+PR: https://github.com/midnightntwrk/midnight-node/pull/1965
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1924

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -44,6 +44,11 @@ scale-info.workspace = true
 
 [dev-dependencies]
 midnight-node-res = { workspace = true, features = ["test", "chain-spec"] }
+# The crate's own `#[cfg(test)]` modules (api::ledger, api::transaction) use
+# `extract_tx_with_context`, gated behind the helpers `can-panic` feature.
+# Enable it for test builds so the tests compile when the crate is tested
+# standalone.
+midnight-node-ledger-helpers = { workspace = true, features = ["can-panic", "test-utils"] }
 
 [features]
 default = [

--- a/ledger/helpers/src/versions/common/types.rs
+++ b/ledger/helpers/src/versions/common/types.rs
@@ -323,6 +323,15 @@ impl<D: DB> StorableSyntheticCost<D> {
 			_marker: PhantomData,
 		}
 	}
+
+	/// True when every cost component is zero, i.e. this is [`Self::zero`].
+	pub fn is_zero(&self) -> bool {
+		self.read_time == 0
+			&& self.compute_time == 0
+			&& self.block_usage == 0
+			&& self.bytes_written == 0
+			&& self.bytes_churned == 0
+	}
 }
 
 impl<D: DB> From<SyntheticCost> for StorableSyntheticCost<D> {

--- a/ledger/src/versions/block_context/post_ledger_8.rs
+++ b/ledger/src/versions/block_context/post_ledger_8.rs
@@ -29,6 +29,15 @@ impl Default for BlockContext {
 	}
 }
 
+impl BlockContext {
+	/// The parent block's timestamp, when the ledger version carries one.
+	///
+	/// See the ledger-7 counterpart in `pre_ledger_8.rs`, which returns `None`.
+	pub fn parent_block_time(&self) -> Option<u64> {
+		Some(self.last_block_time)
+	}
+}
+
 #[cfg(feature = "std")]
 impl From<super::onchain_runtime_local::context::BlockContext> for BlockContext {
 	fn from(value: super::onchain_runtime_local::context::BlockContext) -> Self {

--- a/ledger/src/versions/block_context/pre_ledger_8.rs
+++ b/ledger/src/versions/block_context/pre_ledger_8.rs
@@ -23,6 +23,17 @@ impl Default for BlockContext {
 	}
 }
 
+impl BlockContext {
+	/// The parent block's timestamp, when the ledger version carries one.
+	///
+	/// Ledger 7 block contexts have no parent timestamp, so no `tblock` correction is
+	/// possible here — and none is needed, since ledger-7 blocks predate
+	/// <https://github.com/midnightntwrk/midnight-node/issues/1924>.
+	pub fn parent_block_time(&self) -> Option<u64> {
+		None
+	}
+}
+
 #[cfg(feature = "std")]
 impl From<super::onchain_runtime_local::context::BlockContext> for BlockContext {
 	fn from(value: super::onchain_runtime_local::context::BlockContext) -> Self {

--- a/ledger/src/versions/common/api/ledger.rs
+++ b/ledger/src/versions/common/api/ledger.rs
@@ -96,6 +96,27 @@ impl<D: DB> Ledger<D> {
 		Self { state, block_fullness: SyntheticCost::ZERO.into() }
 	}
 
+	/// Builds a ledger with an arbitrary accrued `block_fullness`, so that
+	/// [`Self::is_block_start`] can be exercised without applying a real transaction.
+	#[cfg(test)]
+	pub(crate) fn new_with_block_fullness(
+		state: LedgerState<D>,
+		block_fullness: SyntheticCost,
+	) -> Self {
+		Self { state, block_fullness: block_fullness.into() }
+	}
+
+	/// True when no ledger transaction — user or system — has been applied yet in the
+	/// current block, i.e. [`Self::state`] is still exactly the parent's post-block state.
+	///
+	/// `block_fullness` is reset to zero by [`Self::post_block_update`] /
+	/// [`Self::apply_post_block_update`] and only ever accrues in
+	/// [`Self::apply_verified_transaction`] and [`Self::apply_system_tx`], so a zero fullness
+	/// is equivalent to "nothing has touched the ledger state in this block yet".
+	pub(crate) fn is_block_start(&self) -> bool {
+		self.block_fullness.is_zero()
+	}
+
 	pub(crate) fn get_zswap_state(
 		&self,
 		maybe_contract_address: Option<ContractAddress>,
@@ -258,7 +279,9 @@ mod tests {
 		Sp::new(ledger)
 	}
 
-	fn assert_apply_transaction(
+	/// Applies `bytes` to `ledger` without running the end-of-block update, leaving the
+	/// accrued `block_fullness` in place.
+	fn assert_apply_transaction_only(
 		api: &Api,
 		ledger: &mut Sp<Ledger<DefaultDB>>,
 		bytes: &[u8],
@@ -275,21 +298,53 @@ mod tests {
 				tx_ctx.block_context.tblock,
 			)
 			.unwrap_or_else(|err| panic!("Transaction not well-formed: {err:?}"));
-		let (mut new_ledger_state, _applied_stage) =
-			Ledger::<DefaultDB>::apply_verified_transaction(
-				ledger.clone(),
-				api,
-				&tx,
-				&verified_tx,
-				&tx_ctx,
-			)
-			.unwrap_or_else(|err| panic!("Can't apply transaction: {err}"));
-
-		new_ledger_state =
-			Ledger::<DefaultDB>::post_block_update(new_ledger_state, block_context.clone())
-				.expect("Post block update failed");
+		let (new_ledger_state, _applied_stage) = Ledger::<DefaultDB>::apply_verified_transaction(
+			ledger.clone(),
+			api,
+			&tx,
+			&verified_tx,
+			&tx_ctx,
+		)
+		.unwrap_or_else(|err| panic!("Can't apply transaction: {err}"));
 
 		*ledger = new_ledger_state;
+	}
+
+	fn assert_apply_transaction(
+		api: &Api,
+		ledger: &mut Sp<Ledger<DefaultDB>>,
+		bytes: &[u8],
+		block_context: &BlockContext,
+	) {
+		assert_apply_transaction_only(api, ledger, bytes, block_context);
+
+		*ledger = Ledger::<DefaultDB>::post_block_update(ledger.clone(), block_context.clone())
+			.expect("Post block update failed");
+	}
+
+	/// `is_block_start` is the gate `well_formed_tblock` uses to decide whether a transaction
+	/// sits at the head of its block, so it must follow `block_fullness` exactly: true on a
+	/// fresh block, false once a transaction has been applied, true again after the
+	/// end-of-block update.
+	#[test]
+	fn is_block_start_tracks_applied_transactions() {
+		if CRATE_NAME != crate::latest::CRATE_NAME {
+			println!("This test should only be run with ledger latest");
+			return;
+		}
+		let api = Api::new();
+		let mut ledger = prepare_ledger();
+		let (deploy_tx, block_context) = extract_tx_with_context(DEPLOY_TX);
+		let block_context: BlockContext = block_context.into();
+
+		assert!(ledger.is_block_start(), "a fresh block has applied no transactions");
+
+		assert_apply_transaction_only(&api, &mut ledger, &deploy_tx, &block_context);
+		assert!(!ledger.is_block_start(), "a transaction has been applied in this block");
+
+		ledger = Ledger::<DefaultDB>::post_block_update(ledger.clone(), block_context)
+			.expect("Post block update failed");
+		assert!(ledger.is_block_start(), "the end-of-block update starts a new block");
 	}
 
 	#[test]

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -552,15 +552,10 @@ where
 
 		let wrapped_cache_key = Self::tx_validation_cache_key(runtime_version, tx_serialized);
 
-		let tblock_ext = externalities.extension::<TBlockCorrectionExt>();
-		let tblock_correction = tblock_ext.map(|e| &e.0);
-		let was_cached = Self::do_validate_transaction(
-			&ledger,
-			&tx,
-			&block_context,
-			&wrapped_cache_key,
-			tblock_correction,
-		)?;
+		// No `tblock` correction on the mempool path: `validate_unsigned` already skews the
+		// block context it passes here by `slot_duration * (1 + MaxSkippedSlots)`.
+		let was_cached =
+			Self::do_validate_transaction(&ledger, &tx, &block_context, &wrapped_cache_key)?;
 
 		let tx_details = if get_tx_details {
 			let tx_gas_cost =
@@ -903,13 +898,7 @@ where
 		// Cache miss: compute VerifiedTransaction
 		let ctx = ledger.get_transaction_context(block_context.clone())?;
 
-		let tblock = if let Some(tc) = tblock_correction
-			&& block_context.tblock < tc.disable_after
-		{
-			ctx.block_context.tblock + DurationLedger::from_secs(tc.offset as i128)
-		} else {
-			ctx.block_context.tblock
-		};
+		let tblock = well_formed_tblock(ledger, block_context, tblock_correction);
 		let verified_tx =
 			tx.0.well_formed(
 				&ctx.ref_state,
@@ -941,7 +930,6 @@ where
 		tx: &Transaction<S, D>,
 		block_context: &BlockContext,
 		tx_hash: &WrappedHash,
-		tblock_correction: Option<&TBlockCorrection>,
 	) -> Result<bool, LedgerApiError>
 	where
 		VerifiedTransaction<D>: Send + Sync + 'static,
@@ -955,23 +943,18 @@ where
 
 		// Cache miss: transaction is entering the mempool or being re-validated
 		let tx_hash_hex = hex::encode(tx.hash());
-		let verified_tx = match Self::get_verified_transaction(
-			ledger,
-			tx,
-			block_context,
-			tx_hash,
-			tblock_correction,
-		) {
-			Ok(vt) => vt,
-			Err(e) => {
-				log::warn!(
-					target: LOG_TARGET,
-					"🚫 Rejected transaction {} from mempool: {e}",
-					tx_hash_hex
-				);
-				return Err(e);
-			},
-		};
+		let verified_tx =
+			match Self::get_verified_transaction(ledger, tx, block_context, tx_hash, None) {
+				Ok(vt) => vt,
+				Err(e) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"🚫 Rejected transaction {} from mempool: {e}",
+						tx_hash_hex
+					);
+					return Err(e);
+				},
+			};
 
 		// Dry-run apply to validate guaranteed execution against current state
 		let ctx = ledger.get_transaction_context(block_context.clone())?;
@@ -1167,6 +1150,42 @@ fn create_nonce(separator: &[u8], block_hash: &[u8], output_number: u8) -> Nonce
 	Nonce(HashOutput(h256.0))
 }
 
+/// The `tblock` to run `well_formed` against.
+///
+/// Blocks produced before `disable_after` can contain a *first* transaction whose `ctime` runs
+/// ahead of the block timestamp: the producing node served that transaction's `well_formed`
+/// result from the strict cache, where it had been verified during mempool ingress at
+/// `ParentTimestamp + slot_duration * (1 + MaxSkippedSlots)` (see
+/// `<pallet_midnight::Pallet as ValidateUnsigned>::validate_unsigned`). Reproduce that exact
+/// timestamp — and only for the first ledger tx in a block, which is the only position where
+/// that cache could hit — so those blocks still import.
+///
+/// A transaction only reaches a block through the producing node's own pool, so by the time that
+/// node ran `pre_dispatch` the strict cache was always warm for it: the pool verified it at
+/// `parent + offset` against the parent's post-block state, which is exactly the state and key
+/// `pre_dispatch` then looked up. The first ledger tx in a block was therefore *always* verified
+/// at `parent + offset`, never at the block's own timestamp — so this is a single unconditional
+/// rule, a total function of `(block_context, is_block_start, config)` evaluated identically on
+/// every node, with no try-then-retry branch for consensus to depend on.
+///
+/// See <https://github.com/midnightntwrk/midnight-node/issues/1924>
+#[cfg(feature = "std")]
+fn well_formed_tblock<D: DB>(
+	ledger: &Ledger<D>,
+	block_context: &BlockContext,
+	tblock_correction: Option<&TBlockCorrection>,
+) -> Timestamp {
+	if let Some(tc) = tblock_correction
+		&& block_context.tblock < tc.disable_after
+		&& ledger.is_block_start()
+		&& let Some(parent_block_time) = block_context.parent_block_time()
+	{
+		Timestamp::from_secs(parent_block_time) + DurationLedger::from_secs(tc.offset as i128)
+	} else {
+		Timestamp::from_secs(block_context.tblock)
+	}
+}
+
 #[cfg(feature = "std")]
 fn scale_normalized_cost(normalized: &LedgerNormalizedCost, max_weight: u64) -> GasCost {
 	let max_fp = *[
@@ -1186,8 +1205,92 @@ fn scale_normalized_cost(normalized: &LedgerNormalizedCost, max_weight: u64) -> 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use base_crypto_local::cost_model::FixedPoint;
+	use base_crypto_local::cost_model::{FixedPoint, SyntheticCost};
 	use coin_structure_local::coin::{ShieldedTokenType, UnshieldedTokenType};
+	use ledger_storage_local::DefaultDB;
+	use mn_ledger_local::structure::LedgerState;
+
+	/// Matches `res/cfg/default.toml`: `slot_duration_secs * (1 + MaxSkippedSlots)` = 6 * 2.
+	const OFFSET: i64 = 12;
+	/// Preview #128537, the block whose first transaction motivated the correction.
+	const BLOCK_TBLOCK: u64 = 1784987076;
+	const DISABLE_AFTER: u64 = 1785801600;
+
+	fn block_context() -> BlockContext {
+		BlockContext { tblock: BLOCK_TBLOCK, ..Default::default() }
+	}
+
+	fn correction(disable_after: u64) -> TBlockCorrection {
+		TBlockCorrection { offset: OFFSET, disable_after }
+	}
+
+	/// A ledger at the start of a block: nothing applied, `block_fullness` still zero.
+	fn ledger_at_block_start() -> Ledger<DefaultDB> {
+		Ledger::new(LedgerState::new("undeployed"))
+	}
+
+	/// A ledger mid-block: a transaction has already accrued `block_fullness`.
+	fn ledger_mid_block() -> Ledger<DefaultDB> {
+		let non_zero = SyntheticCost { block_usage: 1, ..SyntheticCost::ZERO };
+		Ledger::new_with_block_fullness(LedgerState::new("undeployed"), non_zero)
+	}
+
+	#[test]
+	fn well_formed_tblock_corrects_the_first_tx_in_a_historical_block() {
+		let bc = block_context();
+		let tblock =
+			well_formed_tblock(&ledger_at_block_start(), &bc, Some(&correction(DISABLE_AFTER)));
+
+		match bc.parent_block_time() {
+			// Ledger 8+: the tx is verified at the parent's timestamp plus the mempool skew,
+			// reproducing what the producing node's warm strict-cache entry was verified at.
+			Some(parent) => {
+				assert_eq!(
+					tblock,
+					Timestamp::from_secs(parent) + DurationLedger::from_secs(OFFSET as i128),
+				);
+				assert_ne!(
+					tblock,
+					Timestamp::from_secs(bc.tblock),
+					"the corrected timestamp must not be the block's own tblock"
+				);
+			},
+			// Ledger 7 block contexts carry no parent timestamp, so no correction is possible.
+			None => assert_eq!(tblock, Timestamp::from_secs(bc.tblock)),
+		}
+	}
+
+	#[test]
+	fn well_formed_tblock_is_uncorrected_without_a_configured_correction() {
+		let bc = block_context();
+		assert_eq!(
+			well_formed_tblock(&ledger_at_block_start(), &bc, None),
+			Timestamp::from_secs(BLOCK_TBLOCK),
+		);
+	}
+
+	#[test]
+	fn well_formed_tblock_is_uncorrected_at_or_after_disable_after() {
+		let bc = block_context();
+		// `disable_after` is exclusive of the correction: a block at the cutoff is not corrected.
+		assert_eq!(
+			well_formed_tblock(&ledger_at_block_start(), &bc, Some(&correction(BLOCK_TBLOCK))),
+			Timestamp::from_secs(BLOCK_TBLOCK),
+		);
+		assert_eq!(
+			well_formed_tblock(&ledger_at_block_start(), &bc, Some(&correction(BLOCK_TBLOCK - 1))),
+			Timestamp::from_secs(BLOCK_TBLOCK),
+		);
+	}
+
+	#[test]
+	fn well_formed_tblock_is_uncorrected_after_the_first_tx_in_a_block() {
+		let bc = block_context();
+		assert_eq!(
+			well_formed_tblock(&ledger_mid_block(), &bc, Some(&correction(DISABLE_AFTER))),
+			Timestamp::from_secs(BLOCK_TBLOCK),
+		);
+	}
 
 	fn normalized_all(value: FixedPoint) -> LedgerNormalizedCost {
 		LedgerNormalizedCost {

--- a/node/src/cfg/midnight_cfg/mod.rs
+++ b/node/src/cfg/midnight_cfg/mod.rs
@@ -106,10 +106,13 @@ pub struct MidnightCfg {
 	/// Default: "midnight-node"
 	pub prometheus_push_job_name: Option<String>,
 
-	/// Offset (seconds) for tblock to allow transactions with invalid ctime values
-	/// into blocks when syncing historical chain data
+	/// Offset (seconds) added to the *parent* block's timestamp when verifying the first
+	/// ledger transaction of a block, to allow transactions with invalid ctime values into
+	/// blocks when syncing historical chain data. Must equal the skew the mempool applies,
+	/// `slot_duration_secs * (1 + MaxSkippedSlots)`.
 	pub tblock_correction_offset: i64,
-	/// Time in seconds since unix epoch after which to ignore the tblock correction
+	/// Block timestamp (seconds since unix epoch) at and after which to ignore the tblock
+	/// correction. Compared against the block's own timestamp, not wall-clock time.
 	pub tblock_correction_disable_after: u64,
 }
 

--- a/pallets/midnight/Cargo.toml
+++ b/pallets/midnight/Cargo.toml
@@ -31,6 +31,8 @@ sp-tracing = { workspace = true}
 sidechain-domain.workspace = true
 
 [dev-dependencies]
+# Needed to register `TBlockCorrectionExt` on the test externalities.
+midnight-primitives-ledger = { workspace = true, features = ["std"] }
 sp-core.workspace = true
 sp-io.workspace = true
 sp-runtime.workspace = true

--- a/pallets/midnight/src/tests.rs
+++ b/pallets/midnight/src/tests.rs
@@ -18,7 +18,11 @@ use crate::{
 	mock::{RuntimeOrigin, Test},
 };
 use assert_matches::assert_matches;
-use frame_support::{assert_err, assert_ok, pallet_prelude::Weight, traits::OnFinalize};
+use frame_support::{
+	assert_err, assert_ok,
+	pallet_prelude::Weight,
+	traits::{OnFinalize, OnInitialize},
+};
 use frame_system::RawOrigin;
 use midnight_node_ledger::types::active_version::{
 	BlockContext, DeserializationError, LedgerApiError, MalformedError, TransactionError,
@@ -29,6 +33,7 @@ use midnight_node_res::{
 		CHECK_TX, CONTRACT_ADDR, DEPLOY_TX, MAINTENANCE_TX, STORE_TX, ZSWAP_TX,
 	},
 };
+use midnight_primitives_ledger::{TBlockCorrection, TBlockCorrectionExt};
 use sp_runtime::{
 	traits::ValidateUnsigned,
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
@@ -53,6 +58,49 @@ fn process_block(block_number: u64, block_context: BlockContext) {
 	mock::Midnight::on_finalize(block_number);
 	mock::System::set_block_number(block_number + 1);
 	mock::Timestamp::set_timestamp(block_context.tblock * 1000);
+}
+
+/// Drives the start of a block the way a real one is built: `on_initialize` records the parent
+/// block's timestamp (which becomes the ledger's `last_block_time`) while `pallet_timestamp`
+/// still holds it, and only then does the timestamp inherent set the block's own.
+fn begin_block(block_number: u64, parent_ts: u64, block_ts: u64) {
+	mock::System::set_block_number(block_number);
+	mock::Timestamp::set_timestamp(parent_ts * 1000);
+	<mock::Midnight as OnInitialize<u64>>::on_initialize(block_number);
+	mock::Timestamp::set_timestamp(block_ts * 1000);
+}
+
+/// A correction with a zero offset, which isolates what the correction is measured *from*: the
+/// corrected timestamp becomes exactly the parent block's, which is the timestamp the producing
+/// node's warm strict-cache entry was verified at. The offset arithmetic on top of that base is
+/// covered by the `well_formed_tblock` unit tests in `midnight-node-ledger`.
+fn parent_base_correction(disable_after: u64) -> TBlockCorrection {
+	TBlockCorrection { offset: 0, disable_after }
+}
+
+fn ext_with_correction(correction: Option<TBlockCorrection>) -> sp_io::TestExternalities {
+	let mut ext = mock::new_test_ext();
+	if let Some(correction) = correction {
+		ext.register_extension(TBlockCorrectionExt(correction));
+	}
+	ext
+}
+
+fn send_mn_transaction(tx: Vec<u8>) -> sp_runtime::DispatchResult {
+	mock::Midnight::send_mn_transaction(RuntimeOrigin::none(), tx)
+}
+
+/// A block timestamp shortly after `block_context`'s, distinct on every call.
+///
+/// The strict transaction-validation cache is a process-global static keyed by
+/// `(ledger state hash, tx hash, block timestamp)`, and every `tblock_correction` test below
+/// validates the same fixture against the same genesis state. Handing out a distinct block
+/// timestamp per assertion keeps them from serving each other's cached `well_formed` results —
+/// which would make an assertion pass without ever running the code it is testing. The
+/// timestamps stay well inside the fixture's validity window.
+fn uncached_block_ts(block_context: &BlockContext) -> u64 {
+	static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(101);
+	block_context.tblock + NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 #[test]
@@ -420,6 +468,86 @@ fn test_get_ledger_state_root_differs_from_zswap_state_root() {
 		let zswap_root = mock::Midnight::get_zswap_state_root().unwrap();
 
 		assert_ne!(ledger_root, zswap_root);
+	});
+}
+
+/// The first ledger transaction of a historical block is verified against the *parent* block's
+/// timestamp, not the block's own: DEPLOY_TX's intent no longer verifies a minute before its own
+/// block, so registering the correction must turn an accepted block into a rejected one.
+///
+/// See <https://github.com/midnightntwrk/midnight-node/issues/1924>
+#[test]
+fn test_tblock_correction_verifies_first_tx_against_parent_timestamp() {
+	let (tx, block_context) =
+		midnight_node_ledger_helpers::ledger_8::extract_tx_with_context(DEPLOY_TX);
+	let block_context: BlockContext = block_context.into();
+	let parent_ts = block_context.tblock - 60;
+
+	// Control: with no correction configured the tx is verified at the block's own timestamp.
+	ext_with_correction(None).execute_with(|| {
+		init_ledger_state(block_context.clone());
+		begin_block(1, parent_ts, uncached_block_ts(&block_context));
+
+		assert_ok!(send_mn_transaction(tx.clone()));
+	});
+
+	// With the correction configured the same tx is verified at `parent_ts` instead.
+	ext_with_correction(Some(parent_base_correction(u64::MAX))).execute_with(|| {
+		init_ledger_state(block_context.clone());
+		begin_block(1, parent_ts, uncached_block_ts(&block_context));
+
+		assert!(
+			send_mn_transaction(tx.clone()).is_err(),
+			"the first tx in the block must be verified at the parent block's timestamp"
+		);
+	});
+}
+
+/// `disable_after` is compared against the block's own timestamp, so a block at the cutoff is
+/// verified without any correction — the same block that the test above has rejected.
+#[test]
+fn test_tblock_correction_not_applied_at_or_after_disable_after() {
+	let (tx, block_context) =
+		midnight_node_ledger_helpers::ledger_8::extract_tx_with_context(DEPLOY_TX);
+	let block_context: BlockContext = block_context.into();
+	let parent_ts = block_context.tblock - 60;
+	let block_ts = uncached_block_ts(&block_context);
+
+	ext_with_correction(Some(parent_base_correction(block_ts))).execute_with(|| {
+		init_ledger_state(block_context.clone());
+		begin_block(1, parent_ts, block_ts);
+
+		assert_ok!(send_mn_transaction(tx.clone()));
+	});
+}
+
+/// Mempool ingress must not be corrected: `validate_unsigned` already skews the block context it
+/// passes to the ledger by `slot_duration * (1 + MaxSkippedSlots)`, so correcting there too would
+/// double-count a slot and reject valid transactions.
+///
+/// Both halves run in the same externalities, against the same block, with the same correction
+/// registered — only the entry point differs.
+#[test]
+fn test_tblock_correction_does_not_affect_mempool_validation() {
+	let (tx, block_context) =
+		midnight_node_ledger_helpers::ledger_8::extract_tx_with_context(DEPLOY_TX);
+	let block_context: BlockContext = block_context.into();
+	let parent_ts = block_context.tblock - 60;
+
+	ext_with_correction(Some(parent_base_correction(u64::MAX))).execute_with(|| {
+		init_ledger_state(block_context.clone());
+		begin_block(1, parent_ts, uncached_block_ts(&block_context));
+
+		let call = MidnightCall::send_mn_transaction { midnight_tx: tx.clone() };
+		assert_ok!(<mock::Midnight as ValidateUnsigned>::validate_unsigned(
+			TransactionSource::External,
+			&call
+		));
+
+		assert!(
+			send_mn_transaction(tx).is_err(),
+			"the block path must still apply the correction the mempool path ignores"
+		);
 	});
 }
 

--- a/res/cfg/default.toml
+++ b/res/cfg/default.toml
@@ -56,7 +56,12 @@ bootnodes = []
 # Disallow symlinks when loading config files
 unsafe_allow_symlinks = false
 
-# 12 seconds == 2 slots
+# Offset added to the *parent* block's timestamp when verifying the first ledger transaction
+# of a block produced before `tblock_correction_disable_after`. It must match the skew the
+# mempool applies in `<pallet_midnight as ValidateUnsigned>::validate_unsigned`, i.e.
+# `slot_duration_secs * (1 + MaxSkippedSlots)` — 6 * (1 + 1) = 12 seconds today.
+# See https://github.com/midnightntwrk/midnight-node/issues/1924
 tblock_correction_offset = 12
+# Blocks whose own timestamp is at or after this point never get the correction.
 # Tuesday, August 4, 2026 at 12:00:00 AM (UTC)
 tblock_correction_disable_after = 1785801600


### PR DESCRIPTION
# Overview

Backport of #1964 onto `release/node-1.0.2`. The `tblock_correction` shipped in #1932 (which is the tip of this base branch, `b3f9e196`) was applied too broadly: **every** historical transaction was verified at `block_context.tblock + offset`. Preview then stalled at **#128536**, unable to import **#128537**:

```
midnight::ledger_v2: Transaction malformed: ... Intent TTL has expired.
                     TTL: Timestamp(1784987084), Current block: Timestamp(1784987088)
runtime::executive:  Transaction(3) failed due to Invalid(Custom(182)).
```

Two things were wrong.

**1. The offset was measured from the wrong base.** During mempool ingress the node verifies a transaction at `ParentTimestamp + slot_duration * (1 + MaxSkippedSlots)` (`pallets/midnight/src/lib.rs:438-455`) — `ParentTimestamp` because during pool validation `pallet_timestamp::Now` still holds the parent's timestamp. The including block's own timestamp is already one slot past the parent's, so adding the offset to *it* double-counts a slot. For #128537: parent = 1784987070, block = 1784987076, and the shipped code produced 1784987088 while the warm strict-cache entry had actually been verified at 1784987082 — under the TTL, and it imports.

The correction is now measured from `BlockContext::last_block_time`, which is already available natively (fed from `ParentTimestamp`, set in `on_initialize` before the timestamp inherent runs), so **no runtime or host-API change** is needed. Ledger 7's `BlockContext` has no such field, hence a version-tolerant `parent_block_time() -> Option<u64>` accessor — `None` on ledger 7, which correctly disables the correction there (ledger-7 blocks predate the issue).

**2. It was applied at every position in a block.** The strict cache could only have hit for the *first* ledger transaction, so that is the only position where a transaction can have been verified ahead of its block's timestamp. The gate is `Ledger::block_fullness == ZERO` — reset by `apply_post_block_update` and only ever accrued by `apply_verified_transaction` / `apply_system_tx`, so zero fullness ⟺ nothing has been applied yet in this block ⟺ `LedgerState` is byte-identical to the parent's post-block state, which is exactly the condition under which the old strict-cache hit could occur. It is free to read and adds no state.

**3. The mempool path is no longer corrected at all** — `validate_unsigned` already skews the block context it passes to the ledger.

`well_formed_tblock` is a total function of `(block_context, is_block_start, config)`: one unconditional rule, evaluated identically on every node, with no try-then-retry branch for consensus to depend on.

Config values are unchanged, but `tblock_correction_offset` is now relative to the **parent** block's timestamp and must equal `slot_duration_secs * (1 + MaxSkippedSlots)`. On this branch `MaxSkippedSlots` defaults to `1` (`pallets/midnight/src/lib.rs:174`) and slot duration is 6s, so `6 * (1 + 1) = 12` — matching the existing `tblock_correction_offset = 12`. Comments in `res/cfg/default.toml` and `MidnightCfg` updated to say so.

## Differences from #1964

Two, both forced by this branch being ledger-8 based rather than ledger-9:

1. The three new pallet tests call `midnight_node_ledger_helpers::ledger_8::extract_tx_with_context` instead of `ledger_9::` — this branch's helpers crate defines only `ledger_7` and `ledger_8`. Folded into the cherry-picked commit so every commit compiles.
2. An extra commit, `test(ledger): enable helpers can-panic for the crate's own tests`. `cargo test -p midnight-node-ledger` did **not** compile on this base (8 errors at `b3f9e196`, pre-existing and unrelated): the crate's own `#[cfg(test)]` modules import `extract_tx_with_context`, gated behind the helpers `can-panic` feature that nothing enabled for its test build. Without this the new `well_formed_tblock` unit tests could not run at all. `main` carries the same dev-dependency fix, from a commit outside the two backported here.

## 🗹 TODO before merging

- [ ] **Preview re-sync past #128536** — the real check. Not run on this branch; see Testing Evidence.
- [ ] Ready

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Run on this branch, at `064725b9`:

```
cargo test -p midnight-node-ledger -p pallet-midnight   # 89 passed, 2 ignored (4 suites)
cargo test -p midnight-node-ledger well_formed_tblock   # 8 passed
cargo test -p pallet-midnight tblock_correction         # 3 passed
cargo check -p pallet-midnight -p midnight-node --tests # clean
cargo clippy -p midnight-node-ledger -p pallet-midnight -p midnight-node --all-targets  # clean
cargo fmt --all --check                                 # clean
```

The ledger code is compiled twice here (ledger 7/8, vs three times on `main`), so the new unit tests run once per instantiation — the `parent_block_time()` accessor is what keeps the ledger-7 build compiling and the ledger-7 assertions expect no correction.

**New unit tests** — `ledger/src/versions/common/mod.rs`, on `well_formed_tblock` directly:
- corrects the first tx of a historical block to `parent + offset`, and asserts that value is *not* the block's own `tblock` (ledger 7: no correction);
- uncorrected with no correction configured;
- uncorrected at and after `disable_after` (cutoff is exclusive);
- uncorrected once a tx has been applied in the block.

`ledger/src/versions/common/api/ledger.rs` — `is_block_start` follows `block_fullness` through the real apply path: true on a fresh block, false after `apply_verified_transaction`, true again after `post_block_update`.

**New pallet tests** — `pallets/midnight/src/tests.rs`, covering the wiring end-to-end by registering `TBlockCorrectionExt` on the test externalities (the harness registers no extensions today, so `tblock_correction` was `None` in all existing tests). They drive `on_initialize` → timestamp inherent in order so `ParentTimestamp` is real, and use a zero offset so the corrected timestamp *is* the parent's, isolating the base:
- the first tx of a block is verified at the parent's timestamp — the identical block is accepted without the extension and rejected with it;
- a block at `disable_after` is not corrected;
- `validate_unsigned` accepts while `send_mn_transaction` rejects, in the same externalities with the same correction registered.

The mutation-checking of these tests was done on #1964; the test bodies are unchanged here apart from the `ledger_8` retarget.

**Not yet done:** the preview re-sync. Success is importing #128537 and continuing, with `Intent TTL has expired. TTL: Timestamp(1784987084)` gone and 1784987082 used instead.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

Node client only — `well_formed_tblock` lives in the native ledger bridge and reads the parent timestamp already present in `BlockContext`. No runtime change, no host-API change, no state or storage-layout change, so no metadata or genesis rebuild.

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other:
- [ ] N/A

## Links

Backport of #1964
Follows up #1932
Relates to #1924

Assisted-by: Claude:claude-opus-5