### PR TITLE
feat: Blockfrost data source support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ See [Genesis Verification Guide](docs/genesis/verification.md) for complete docu
 /tests/e2e/    - End-to-end test suite
 ```
 
+**Main chain follower:** Cardano data comes from a cardano-db-sync PostgreSQL database by default, or
+from a Blockfrost-compatible HTTP API when `blockfrost_endpoint` is set (no Cardano node or db-sync
+required). See [Blockfrost main chain follower](docs/blockfrost-main-chain-follower.md).
+
 **Consensus:** AURA (6-second blocks) + GRANDPA (finality) + BEEFY (bridge security)
 
 **Key dependencies:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "blockfrost"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e3c81065da79ceee495cfb762060ac0fe892ceb7eb1aa87805e6444b7f409c"
+dependencies = [
+ "blockfrost-openapi",
+ "futures",
+ "futures-timer",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "blockfrost-openapi"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaf3130c1ec8d5680aeda15e847ba6c109cc31a83f2aa293465b160992f9853"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,7 +3073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5687,7 +5714,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7891,6 +7918,8 @@ dependencies = [
  "async-trait",
  "authority-selection-inherents",
  "blake2b_simd",
+ "blockfrost",
+ "cardano-serialization-lib",
  "clap",
  "config",
  "derive-new",
@@ -7905,6 +7934,7 @@ dependencies = [
  "jsonrpsee",
  "local-ip-address",
  "log",
+ "lru 0.18.1",
  "midnight-node-ledger",
  "midnight-node-ledger-helpers",
  "midnight-node-res",
@@ -7939,6 +7969,7 @@ dependencies = [
  "partner-chains-db-sync-data-sources",
  "partner-chains-mock-data-sources",
  "partner-chains-node-commands",
+ "partner-chains-plutus-data",
  "prost 0.13.5",
  "reqwest 0.12.28",
  "sc-basic-authorship",
@@ -9047,6 +9078,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicbor"
@@ -12491,7 +12532,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -12511,7 +12552,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -13294,8 +13335,10 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -13304,12 +13347,16 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.7.0",
+ "serde",
+ "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ partner-chains-mock-data-sources = { default-features = false, path = "partner-c
 partner-chains-plutus-data = { default-features = false, path = "partner-chains/toolkit/smart-contracts/plutus-data" }
 db-sync-sqlx = { default-features = false, path = "partner-chains/toolkit/utils/db-sync-sqlx" }
 cardano-serialization-lib = { default-features = false, version = "15.0.3" }
+blockfrost = { version = "1.3.0" }
 substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2606" }
 
 pallet-sidechain = { default-features = false, path = "partner-chains/toolkit/sidechain/pallet" }

--- a/docs/blockfrost-main-chain-follower.md
+++ b/docs/blockfrost-main-chain-follower.md
@@ -1,0 +1,148 @@
+# Blockfrost main chain follower
+
+The node reads Cardano main chain data through one of two backends. By default it queries a
+**cardano-db-sync** PostgreSQL database, which means operating `cardano-node`, `cardano-db-sync`
+and PostgreSQL alongside the node.
+
+Setting `blockfrost_endpoint` switches all six main chain follower data sources to a
+**Blockfrost-compatible HTTP API** instead. No Cardano node, no db-sync, no database.
+
+Leave `blockfrost_endpoint` unset and nothing changes: the db-sync path is the default and is
+unaffected.
+
+## Configuration
+
+| TOML key | Environment variable | Notes |
+|----------|---------------------|-------|
+| `blockfrost_endpoint` | `BLOCKFROST_ENDPOINT` | Base URL of a Blockfrost-compatible API. Must be `http` or `https`; validated at startup. |
+| `blockfrost_project_id` | `BLOCKFROST_PROJECT_ID` | Secret. Required by hosted Blockfrost, usually unset for a self-hosted backend. ASCII alphanumeric. |
+
+Config validation requires **either** `db_sync_postgres_connection_string` **or**
+`blockfrost_endpoint`. Setting neither is a startup error.
+
+### Hosted Blockfrost
+
+```sh
+BLOCKFROST_ENDPOINT=https://cardano-preview.blockfrost.io/api/v0
+BLOCKFROST_PROJECT_ID=preview...
+```
+
+### Self-hosted
+
+Any Blockfrost-compatible implementation works. Two known to serve the endpoints this backend needs:
+
+- [Dolos](https://github.com/txpipe/dolos), which follows Cardano directly and needs no database.
+  Requires [txpipe/dolos#1151](https://github.com/txpipe/dolos/pull/1151) for complete endpoint
+  coverage, so until that is in a stable release you need a build containing it.
+- [blockfrost-backend-ryo](https://github.com/blockfrost/blockfrost-backend-ryo), the official
+  self-hosted API server. Note it sits on top of db-sync, so it does not remove the database.
+
+Point the node at whichever you run and leave `blockfrost_project_id` unset:
+
+```sh
+BLOCKFROST_ENDPOINT=http://127.0.0.1:3000
+```
+
+## What is not supported
+
+- **Genesis generation still requires db-sync.** The `generate-*-genesis` subcommands read Cardano
+  data directly through SQL rather than through a data source. Running them with only
+  `blockfrost_endpoint` set fails with a message saying so; they need
+  `db_sync_postgres_connection_string`.
+- **Partner-chains Prometheus metrics are unavailable on this path.** `McFollowerMetrics` is not
+  writable from outside the `partner-chains-db-sync-data-sources` crate. The Midnight-side
+  `MidnightDataSourceMetrics` is populated, using the same `midnight_data_source_query_time_elapsed`
+  labels as the db-sync sources, so both backends can be compared in one dashboard.
+
+## Operating cost
+
+Roughly **2 requests per Midnight block**, so about **28,000 requests/day** for a node at tip.
+Blockfrost's free tier (50,000/day) covers steady-state operation; the initial sync is the
+expensive part.
+
+| Network | Blocks | Bootstrap requests | Bootstrap time |
+|---------|--------|--------------------|----------------|
+| preview | ~226,000 | ~0.5M | ~12 h |
+| preprod | ~1.91M | ~4.0M | ~1.5 days |
+| mainnet | ~1.95M | ~4.05M | ~2.5 days |
+
+Bootstrap times are with a plan whose rate limit is not the constraint; on the free tier the daily
+cap sets the pace instead (preview is roughly ten days, mainnet is not practical). Bootstrap
+request totals are floors, since cNIGHT and bridge activity grows over time.
+
+Resource use is modest enough for small hardware: a Raspberry Pi 4 (4 GB) follows preview at tip
+using about 816 MB RSS for the node, alongside a co-located Dolos at about 719 MB.
+
+## Tuning
+
+`cnight_observation_window_size` (default 100,000) sets how many Cardano blocks the cNIGHT
+observation cache fetches per extension, and therefore roughly how much observation history it
+retains. Lower it to reduce memory at the cost of more fetch rounds. It does **not** cap the work
+of a single call: during catch-up one call extends until transaction capacity binds or coverage
+reaches the referenced tip.
+
+That catch-up cost is dominated by request count rather than per-request latency, so it is
+noticeably cheaper against a co-located backend. At tip the same query is served from the in-memory
+window and costs nothing either way.
+
+## Troubleshooting
+
+**Sync stops making progress, no errors.** Check for the over-quota message:
+
+```
+Blockfrost project is over its request limit (HTTP 402). Cardano main chain data cannot be read,
+so block import and authoring will not progress until the daily quota resets or the project's
+plan is upgraded.
+```
+
+402 is deliberately not retried, since a daily quota does not clear within a retry window.
+
+**Node exits at startup with a URL error.** `blockfrost_endpoint` is parsed at startup rather than
+per request, so a missing scheme fails immediately:
+
+```
+blockfrost_endpoint is not a valid URL (relative URL without a base): cardano-preview.blockfrost.io/api/v0
+```
+
+**403 "Network token mismatch".** The project id belongs to a different network than the endpoint.
+
+**Connects but behaves oddly against a self-hosted backend.** If the backend listens on IPv6 (`[::]:3000`) and something else on the host holds IPv4 `127.0.0.1:3000`, the node will reach the wrong service. Use `http://[::1]:3000` explicitly.
+
+**Request timing.** Every trait method and every HTTP call logs its duration under the `blockfrost`
+log target: run with `-l blockfrost=debug`.
+
+## Equivalence with db-sync
+
+The db-sync SQL is the specification: both backends must produce identical inherent data, because
+that data is consensus-critical.
+
+`node/tests/blockfrost_parity.rs` is an `#[ignore]`d test that points both backends at the same
+anchor block and asserts their results are equal. It requires a live db-sync and a live
+Blockfrost-compatible endpoint for the same network:
+
+```sh
+DB_SYNC_POSTGRES_CONNECTION_STRING=postgres://... \
+BLOCKFROST_ENDPOINT=https://cardano-preview.blockfrost.io/api/v0 \
+BLOCKFROST_PROJECT_ID=preview... \
+CNIGHT_MAPPING_VALIDATOR_ADDRESS=... CNIGHT_POLICY_ID=... \
+COMMITTEE_CANDIDATE_ADDRESS=... PERMISSIONED_CANDIDATE_POLICY_ID=... \
+FEDAUTH_COUNCIL_ADDRESS=... FEDAUTH_COUNCIL_POLICY_ID=... \
+FEDAUTH_TECHNICAL_COMMITTEE_ADDRESS=... FEDAUTH_TECHNICAL_COMMITTEE_POLICY_ID=... \
+BRIDGE_TOKEN_POLICY_ID=... ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR_ADDRESS=... \
+RESERVE_VALIDATOR_ADDRESS=... \
+cargo test -p midnight-node --test blockfrost_parity -- --ignored --nocapture
+```
+
+The per-domain values come from `res/<network>/` (`cnight-addresses.json`, `ics-addresses.json`,
+`federated-authority-addresses.json`) and the network's chain spec. Cardano network parameters
+default to testnet values, so mainnet and preprod runs also need `CARDANO_SECURITY_PARAMETER`,
+`MC__FIRST_EPOCH_TIMESTAMP_MILLIS`, `MC__EPOCH_DURATION_MILLIS`, `MC__FIRST_EPOCH_NUMBER` and
+`MC__FIRST_SLOT_NUMBER` from `res/cfg/<network>.toml`.
+
+`PARITY_WINDOW_BLOCKS` (default 1000) sets the look-back window. A domain whose inputs are not
+supplied fails the run rather than being skipped silently; set `PARITY_ALLOW_PARTIAL=1` to accept a
+partial comparison.
+
+One caveat when interpreting a pass: a comparison over a range containing no activity is equality
+between two empty sets and proves nothing. Check that the addresses under test actually have
+transactions in the chosen window before treating a green run as meaningful.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -133,6 +133,10 @@ sp-session-validator-management-query.workspace = true
 partner-chains-node-commands.workspace = true
 partner-chains-cli.workspace = true
 sp-partner-chains-bridge = { workspace = true, default-features = true }
+blockfrost.workspace = true
+cardano-serialization-lib = { workspace = true, default-features = true }
+partner-chains-plutus-data = { workspace = true, default-features = true }
+lru.workspace = true
 
 sc-storage-monitor.workspace = true
 sc-sysinfo.workspace = true

--- a/node/src/blockfrost/authority_selection.rs
+++ b/node/src/blockfrost/authority_selection.rs
@@ -1,0 +1,661 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Authority selection data source: ariadne parameters, candidate registrations and
+//! epoch nonce, mirroring the db-sync candidates queries.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use authority_selection_inherents::{AriadneParameters, AuthoritySelectionDataSource};
+use blockfrost::{
+	BlockCursor, Order, Pagination,
+	blockfrost_openapi::models::{block_content::BlockContent, tx_content_utxo::TxContentUtxo},
+};
+use cardano_serialization_lib::{Ed25519KeyHash, PlutusData};
+use lru::LruCache;
+use midnight_primitives_mainchain_follower::data_source::metrics::{
+	MidnightDataSourceMetrics, start_sub_query_timer,
+};
+use partner_chains_plutus_data::{
+	permissioned_candidates::PermissionedCandidateDatums,
+	registered_candidates::RegisterValidatorDatum,
+};
+use sidechain_domain::*;
+
+use super::client::*;
+use super::convert::*;
+use super::support::*;
+
+/// Same value as `CANDIDATES_FOR_EPOCH_CACHE_SIZE` used for the db-sync candidates cache.
+const AUTHORITY_CACHE_SIZE: usize = 64;
+
+// ---------------------------------------------------------------------------
+// Authority selection (candidates)
+// ---------------------------------------------------------------------------
+
+struct AuthorityCaches {
+	ariadne: LruCache<(u32, PolicyId), AriadneParameters>,
+	candidates: LruCache<(u32, String), Vec<CandidateRegistrations>>,
+	nonce: LruCache<u32, EpochNonce>,
+	highest_seen_stable_epoch: Option<u32>,
+}
+
+/// Mirrors midnight's `CandidatesDataSourceImpl` (+ its `CandidateDataSourceCached`
+/// stability-gated LRU caching).
+pub struct BlockfrostAuthoritySelectionDataSource {
+	client: Arc<BlockfrostClient>,
+	security_parameter: u32,
+	caches: Mutex<AuthorityCaches>,
+	/// Same handle and same sub-query labels as the db-sync source, so both backends
+	/// report into one histogram and can be compared directly.
+	metrics_opt: Option<MidnightDataSourceMetrics>,
+}
+
+impl BlockfrostAuthoritySelectionDataSource {
+	pub fn new(
+		client: Arc<BlockfrostClient>,
+		security_parameter: u32,
+		metrics_opt: Option<MidnightDataSourceMetrics>,
+	) -> Self {
+		let cap = NonZeroUsize::new(AUTHORITY_CACHE_SIZE).unwrap();
+		Self {
+			client,
+			security_parameter,
+			metrics_opt,
+			caches: Mutex::new(AuthorityCaches {
+				ariadne: LruCache::new(cap),
+				candidates: LruCache::new(cap),
+				nonce: LruCache::new(cap),
+				highest_seen_stable_epoch: None,
+			}),
+		}
+	}
+
+	fn data_epoch_of(&self, epoch: McEpochNumber) -> Result<u32, BoxError> {
+		let data_epoch = offset_data_epoch(&epoch).map_err(|offset| {
+			format!(
+				"Minimum supported epoch of data usage is {offset}, but {} was provided",
+				epoch.0
+			)
+		})?;
+		Ok(data_epoch.0)
+	}
+
+	/// Results for a stable data epoch are immutable and cacheable. Mirrors
+	/// `get_latest_stable_epoch`: the epoch of the highest stable block, minus one.
+	async fn can_cache(&self, data_epoch: u32) -> bool {
+		if let Ok(caches) = self.caches.lock()
+			&& let Some(highest) = caches.highest_seen_stable_epoch
+			&& data_epoch <= highest
+		{
+			return true;
+		}
+		let stable_epoch = async {
+			let latest =
+				deadline("blocks/latest", self.client.api.blocks_latest()).await.ok()?.ok()?;
+			let stable_height = block_height(&latest).ok()?.saturating_sub(self.security_parameter);
+			let stable = self.client.block_by_id(&stable_height.to_string()).await.ok()??;
+			u32::try_from(stable.epoch?).ok()?.checked_sub(1)
+		}
+		.await;
+		match stable_epoch {
+			Some(stable_epoch) => {
+				if let Ok(mut caches) = self.caches.lock() {
+					caches.highest_seen_stable_epoch = Some(stable_epoch);
+				}
+				data_epoch <= stable_epoch
+			},
+			None => false,
+		}
+	}
+
+	/// Last block of `epoch` (or of the closest earlier non-empty epoch), mirroring
+	/// the `epoch_no <= $1` semantics of `get_latest_block_for_epoch`.
+	async fn last_block_of_epoch(&self, epoch: u32) -> Result<Option<BlockContent>, BoxError> {
+		let _sq_timer =
+			start_sub_query_timer(&self.metrics_opt, "candidates_get_latest_block_for_epoch");
+		let mut n = i64::from(epoch);
+		while n >= 0 {
+			let _t = Timer::new(format!("GET epochs/{n}/blocks"));
+			let hashes = match deadline(
+				&format!("epochs/{n}/blocks"),
+				self.client.api.epochs_blocks(n as i32, Pagination::new(Order::Desc, 1, 1)),
+			)
+			.await?
+			{
+				Ok(hashes) => hashes,
+				Err(e) if is_404(&e) => vec![],
+				Err(e) => return Err(box_err(e)),
+			};
+			if let Some(hash) = hashes.first() {
+				return self.client.block_by_id(hash).await;
+			}
+			n -= 1;
+		}
+		Ok(None)
+	}
+
+	/// The most recent output carrying an asset of `unit` created at or before
+	/// `boundary_block`, together with its creating tx hash. Mirrors
+	/// `get_token_utxo_for_epoch`: ordered by (block, tx index) descending, spent-ness
+	/// deliberately not checked.
+	async fn latest_token_output_upto(
+		&self,
+		unit: &str,
+		boundary_block: u32,
+	) -> Result<Option<(RangeTx, TxContentUtxo)>, BoxError> {
+		let _sq_timer =
+			start_sub_query_timer(&self.metrics_opt, "candidates_get_token_utxo_for_epoch");
+		for page in 1..=MAX_PAGES {
+			let batch = self
+				.client
+				.range_txs_desc_page(TxSource::Asset(unit), boundary_block, page)
+				.await?;
+			let last_page = batch.len() < PAGE_SIZE;
+			for row in batch {
+				let utxos = self.client.tx_utxos(&row.tx_hash).await?;
+				if utxos.outputs.iter().any(|o| !o.collateral && has_unit(&o.amount, unit)) {
+					return Ok(Some((row, utxos)));
+				}
+			}
+			if last_page {
+				return Ok(None);
+			}
+		}
+		Err(too_many_pages(&format!("asset {unit}/transactions")))
+	}
+
+	async fn get_ariadne_parameters_uncached(
+		&self,
+		data_epoch: u32,
+		permissioned_candidate_policy: &PolicyId,
+	) -> Result<AriadneParameters, BoxError> {
+		// The permissioned-candidates token has an empty asset name: unit = policy id hex.
+		let unit = hex::encode(permissioned_candidate_policy.0);
+
+		// DParameter is now read from pallet_system_parameters storage, not from mainchain.
+		// This hardcoded value is unused - the actual d_parameter comes from the runtime.
+		let d_parameter =
+			DParameter { num_permissioned_candidates: 0, num_registered_candidates: 0 };
+
+		let boundary = self.last_block_of_epoch(data_epoch).await?;
+		let candidates_output = match boundary {
+			Some(boundary) => {
+				self.latest_token_output_upto(&unit, block_height(&boundary)?).await?
+			},
+			None => None,
+		};
+
+		let permissioned_candidates = match candidates_output {
+			None => None,
+			Some((_row, utxos)) => {
+				let output = utxos
+					.outputs
+					.iter()
+					.filter(|o| !o.collateral && has_unit(&o.amount, &unit))
+					.min_by_key(|o| o.output_index)
+					.expect("latest_token_output_upto only returns txs with a matching output");
+				let datum = self
+					.client
+					.datum(output.inline_datum.as_ref(), output.data_hash.as_ref())
+					.await?
+					.ok_or("Expected data was not found: Permissioned Candidates List Datum")?;
+				Some(PermissionedCandidateDatums::try_from(datum)?.into())
+			},
+		};
+
+		Ok(AriadneParameters { d_parameter, permissioned_candidates })
+	}
+
+	async fn get_candidates_uncached(
+		&self,
+		data_epoch: u32,
+		committee_candidate_address: &MainchainAddress,
+	) -> Result<Vec<CandidateRegistrations>, BoxError> {
+		let address = committee_candidate_address.to_string();
+		let Some(boundary) = self.last_block_of_epoch(data_epoch).await? else {
+			return Ok(vec![]);
+		};
+		let address_scan_timer =
+			start_sub_query_timer(&self.metrics_opt, "candidates_get_utxos_for_address");
+		let boundary_height = block_height(&boundary)?;
+
+		// TODO: this replays the address's entire transaction history on every uncached
+		// epoch, and the address is public, so anyone can lengthen that history by sending
+		// transactions to it. Make it incremental — keep the computed UTXO set and fetch
+		// only what is new since the last boundary, as `governance_body_authorities` does.
+		//
+		// Rebuild the as-of-boundary UTXO set of the committee candidate address:
+		// outputs created at block <= boundary minus outputs spent at block <= boundary.
+		// All listed txs are <= boundary, so spends after the boundary don't remove
+		// entries — the same semantics as db-sync's `get_utxos_for_address`.
+		let rows = self
+			.client
+			.range_txs(
+				TxSource::Address(&address),
+				None,
+				Some(BlockCursor::block(u64::from(boundary_height))),
+			)
+			.await?;
+
+		struct ActiveUtxo {
+			utxo_id: UtxoId,
+			datum: Option<PlutusData>,
+			tx_inputs: Vec<UtxoId>,
+			row: RangeTx,
+		}
+		let mut active: HashMap<(McTxHash, u16), ActiveUtxo> = HashMap::new();
+		for row in &rows {
+			let utxos = self.client.tx_utxos(&row.tx_hash).await?;
+			let tx_hash = McTxHash(decode_hash32(&row.tx_hash)?);
+			let tx_inputs: Vec<UtxoId> = utxos
+				.inputs
+				.iter()
+				.filter(|i| !i.collateral && !i.reference.unwrap_or(false))
+				.map(|i| {
+					Ok::<_, BoxError>(UtxoId {
+						tx_hash: McTxHash(decode_hash32(&i.tx_hash)?),
+						index: UtxoIndex(u16::try_from(i.output_index)?),
+					})
+				})
+				.collect::<Result<_, _>>()?;
+			for input in
+				utxos.inputs.iter().filter(|i| !i.collateral && !i.reference.unwrap_or(false))
+			{
+				if input.address == address {
+					active.remove(&(
+						McTxHash(decode_hash32(&input.tx_hash)?),
+						u16::try_from(input.output_index)?,
+					));
+				}
+			}
+			for output in utxos.outputs.iter().filter(|o| !o.collateral) {
+				if output.address == address {
+					let index = u16::try_from(output.output_index)?;
+					let datum = self
+						.client
+						.datum(output.inline_datum.as_ref(), output.data_hash.as_ref())
+						.await?;
+					active.insert(
+						(tx_hash, index),
+						ActiveUtxo {
+							utxo_id: UtxoId { tx_hash, index: UtxoIndex(index) },
+							datum,
+							tx_inputs: tx_inputs.clone(),
+							row: row.clone(),
+						},
+					);
+				}
+			}
+		}
+
+		// Block info (epoch/slot) for each creating tx.
+		let mut blocks: HashMap<u32, BlockContent> = HashMap::new();
+		for utxo in active.values() {
+			if let std::collections::hash_map::Entry::Vacant(entry) =
+				blocks.entry(utxo.row.block_height)
+			{
+				let block = self
+					.client
+					.block_by_id(&utxo.row.block_height.to_string())
+					.await?
+					.ok_or_else(|| format!("block {} not found", utxo.row.block_height))?;
+				entry.insert(block);
+			}
+		}
+
+		// Parse registrations, mirroring `parse_candidates` (log and skip invalid datums).
+		let mut candidates: Vec<(RegisterValidatorDatum, UtxoInfo, Vec<UtxoId>)> = Vec::new();
+		let mut active: Vec<ActiveUtxo> = active.into_values().collect();
+		active.sort_by_key(|u| (u.row.block_height, u.row.tx_index, u.utxo_id.index.0));
+		for utxo in active {
+			let Some(datum) = utxo.datum else {
+				log::error!("Missing registration datum for {:?}", utxo.utxo_id);
+				continue;
+			};
+			let Ok(datum) = RegisterValidatorDatum::try_from(datum) else {
+				log::error!("Invalid registration datum for {:?}", utxo.utxo_id);
+				continue;
+			};
+			let block = &blocks[&utxo.row.block_height];
+			let utxo_info = UtxoInfo {
+				utxo_id: utxo.utxo_id,
+				epoch_number: McEpochNumber(u32::try_from(
+					block.epoch.ok_or("block has no epoch")?,
+				)?),
+				block_number: McBlockNumber(utxo.row.block_height),
+				slot_number: McSlotNumber(u64::try_from(block.slot.ok_or("block has no slot")?)?),
+				tx_index_within_block: McTxIndexInBlock(utxo.row.tx_index),
+			};
+			candidates.push((datum, utxo_info, utxo.tx_inputs));
+		}
+
+		let registered = candidates
+			.into_iter()
+			.map(|(datum, utxo_info, tx_inputs)| {
+				make_registered_candidate(datum, utxo_info, tx_inputs)
+			})
+			.collect::<Vec<_>>();
+
+		// Stake distribution: per-pool sums for the data epoch. An entirely absent
+		// `epoch_stake` snapshot yields `stake_delegation: None` for every candidate
+		// (mirrors `stake_map.is_empty()`); a pool missing from a non-empty snapshot
+		// yields Some(0).
+		// Nothing to weight when no candidate registrations exist (the current state of
+		// all networks: `num_registered_candidates` is 0), so skip the probe entirely.
+		let epoch_has_stakes = if registered.is_empty() {
+			false
+		} else {
+			let _t = Timer::new(format!("GET epochs/{data_epoch}/stakes (sentinel)"));
+			match deadline(
+				&format!("epochs/{data_epoch}/stakes"),
+				self.client
+					.api
+					.epochs_stakes(data_epoch as i32, Pagination::new(Order::Asc, 1, 1)),
+			)
+			.await?
+			{
+				Ok(rows) => !rows.is_empty(),
+				Err(e) if is_404(&e) => false,
+				Err(e) => return Err(box_err(e)),
+			}
+		};
+
+		// Shadowing would not drop the address-scan guard, so its histogram would also
+		// cover this phase. The db-sync source drops at the same boundary.
+		drop(address_scan_timer);
+		let mut stake_by_pool: HashMap<MainchainKeyHash, StakeDelegation> = HashMap::new();
+		let _sq_timer =
+			start_sub_query_timer(&self.metrics_opt, "candidates_get_stake_distribution");
+		if epoch_has_stakes {
+			let pools: Vec<MainchainKeyHash> = registered
+				.iter()
+				.map(|c| MainchainKeyHash::from_vkey(&c.stake_pool_pub_key.0))
+				.collect::<std::collections::HashSet<_>>()
+				.into_iter()
+				.collect();
+			for pool in pools {
+				let key_hash = Ed25519KeyHash::from_bytes(pool.0.to_vec())
+					.map_err(|e| format!("invalid pool key hash: {e:?}"))?;
+				let bech32 = key_hash
+					.to_bech32("pool")
+					.map_err(|e| format!("failed to bech32-encode pool hash: {e:?}"))?;
+				// A pool's per-epoch `active_stake` equals db-sync's
+				// `SUM(epoch_stake.amount) GROUP BY pool` for that epoch (verified against
+				// the delegator listings). Reading it from the pool's history costs a few
+				// requests per pool instead of paging every delegator — the delegator lists
+				// run to hundreds of pages for large pools.
+				//
+				// The SDK honours `from`/`to` cursors only on the account, address and asset
+				// transaction endpoints and silently ignores them everywhere else, so the
+				// epoch cannot be selected server-side. Walk ascending and stop as soon as
+				// the row is found or the history passes `data_epoch`: a pool's history
+				// begins near the epochs a syncing node replays, so this is usually a
+				// single request. Descending would need the whole history for any epoch
+				// that is not close to the tip, which is the common case during sync.
+				let _t = Timer::new(format!("GET pools/{bech32}/history (epoch {data_epoch})"));
+				let mut entry = None;
+				for page in 1..=MAX_PAGES {
+					let rows = match deadline(
+						&format!("pools/{bech32}/history page={page}"),
+						self.client
+							.api
+							.pools_history(&bech32, Pagination::new(Order::Asc, page, PAGE_SIZE)),
+					)
+					.await?
+					{
+						Ok(rows) => rows,
+						Err(e) if is_404(&e) => vec![],
+						Err(e) => return Err(box_err(e)),
+					};
+					let last_page = rows.len() < PAGE_SIZE;
+					// Ascending order: a row beyond the target proves the epoch is absent.
+					let past_target = rows.iter().any(|r| r.epoch > data_epoch as i32);
+					entry = rows.into_iter().find(|r| r.epoch == data_epoch as i32);
+					if entry.is_some() || past_target || last_page {
+						break;
+					}
+				}
+				// An epoch missing from a pool's history means no stake in that epoch,
+				// which is the same as its absence from the SQL `GROUP BY` — the caller
+				// maps a missing entry to `Some(0)` when the epoch snapshot exists.
+				if let Some(entry) = entry {
+					let stake = entry
+						.active_stake
+						.parse::<u64>()
+						.map_err(|e| format!("invalid active_stake for {bech32}: {e}"))?;
+					stake_by_pool.insert(pool, StakeDelegation(stake));
+				}
+			}
+		}
+
+		let mut grouped: HashMap<StakePoolPublicKey, Vec<RegisteredCandidate>> = HashMap::new();
+		for candidate in registered {
+			grouped.entry(candidate.stake_pool_pub_key.clone()).or_default().push(candidate);
+		}
+		Ok(grouped
+			.into_iter()
+			.map(|(stake_pool_public_key, candidates)| CandidateRegistrations {
+				stake_pool_public_key: stake_pool_public_key.clone(),
+				registrations: candidates.into_iter().map(|c| c.registration_data).collect(),
+				stake_delegation: if epoch_has_stakes {
+					Some(
+						stake_by_pool
+							.get(&MainchainKeyHash::from_vkey(&stake_pool_public_key.0))
+							.cloned()
+							.unwrap_or(StakeDelegation(0)),
+					)
+				} else {
+					None
+				},
+			})
+			.collect())
+	}
+}
+
+struct RegisteredCandidate {
+	stake_pool_pub_key: StakePoolPublicKey,
+	registration_data: RegistrationData,
+}
+
+/// Mirrors `convert_utxos_to_candidates` for the V0/V1 datum variants.
+fn make_registered_candidate(
+	datum: RegisterValidatorDatum,
+	utxo_info: UtxoInfo,
+	tx_inputs: Vec<UtxoId>,
+) -> RegisteredCandidate {
+	match datum {
+		RegisterValidatorDatum::V0 {
+			stake_ownership,
+			sidechain_pub_key,
+			sidechain_signature,
+			registration_utxo,
+			own_pkh: _own_pkh,
+			aura_pub_key,
+			grandpa_pub_key,
+		} => RegisteredCandidate {
+			stake_pool_pub_key: stake_ownership.pub_key,
+			registration_data: RegistrationData {
+				registration_utxo,
+				sidechain_signature: sidechain_signature.clone(),
+				mainchain_signature: stake_ownership.signature,
+				// For now we use the same key for both cross chain and sidechain actions
+				cross_chain_signature: CrossChainSignature(sidechain_signature.0),
+				sidechain_pub_key: sidechain_pub_key.clone(),
+				cross_chain_pub_key: CrossChainPublicKey(sidechain_pub_key.0),
+				keys: CandidateKeys(vec![aura_pub_key.into(), grandpa_pub_key.into()]),
+				utxo_info,
+				tx_inputs,
+			},
+		},
+		RegisterValidatorDatum::V1 {
+			stake_ownership,
+			sidechain_pub_key,
+			sidechain_signature,
+			registration_utxo,
+			own_pkh: _own_pkh,
+			keys,
+		} => RegisteredCandidate {
+			stake_pool_pub_key: stake_ownership.pub_key,
+			registration_data: RegistrationData {
+				registration_utxo,
+				sidechain_signature: sidechain_signature.clone(),
+				mainchain_signature: stake_ownership.signature,
+				// For now we use the same key for both cross chain and sidechain actions
+				cross_chain_signature: CrossChainSignature(sidechain_signature.0),
+				sidechain_pub_key: sidechain_pub_key.clone(),
+				cross_chain_pub_key: CrossChainPublicKey(sidechain_pub_key.0),
+				keys,
+				utxo_info,
+				tx_inputs,
+			},
+		},
+	}
+}
+
+#[async_trait::async_trait]
+impl AuthoritySelectionDataSource for BlockfrostAuthoritySelectionDataSource {
+	async fn get_ariadne_parameters(
+		&self,
+		epoch: McEpochNumber,
+		_d_parameter_policy: PolicyId,
+		permissioned_candidate_policy: PolicyId,
+	) -> Result<AriadneParameters, BoxError> {
+		let _t = Timer::new(format!("get_ariadne_parameters[{}]", epoch.0));
+		let data_epoch = self.data_epoch_of(epoch)?;
+		let key = (data_epoch, permissioned_candidate_policy.clone());
+		let cacheable = self.can_cache(data_epoch).await;
+		if cacheable
+			&& let Ok(mut caches) = self.caches.lock()
+			&& let Some(cached) = caches.ariadne.get(&key)
+		{
+			return Ok(cached.clone());
+		}
+		let result = self
+			.get_ariadne_parameters_uncached(data_epoch, &permissioned_candidate_policy)
+			.await?;
+		if cacheable && let Ok(mut caches) = self.caches.lock() {
+			caches.ariadne.put(key, result.clone());
+		}
+		Ok(result)
+	}
+
+	async fn get_candidates(
+		&self,
+		epoch: McEpochNumber,
+		committee_candidate_address: MainchainAddress,
+	) -> Result<Vec<CandidateRegistrations>, BoxError> {
+		let _t = Timer::new(format!("get_candidates[{}]", epoch.0));
+		let data_epoch = self.data_epoch_of(epoch)?;
+		let key = (data_epoch, committee_candidate_address.to_string());
+		let cacheable = self.can_cache(data_epoch).await;
+		if cacheable
+			&& let Ok(mut caches) = self.caches.lock()
+			&& let Some(cached) = caches.candidates.get(&key)
+		{
+			return Ok(cached.clone());
+		}
+		let result = self.get_candidates_uncached(data_epoch, &committee_candidate_address).await?;
+		if cacheable && let Ok(mut caches) = self.caches.lock() {
+			caches.candidates.put(key, result.clone());
+		}
+		Ok(result)
+	}
+
+	async fn get_epoch_nonce(&self, epoch: McEpochNumber) -> Result<Option<EpochNonce>, BoxError> {
+		let _t = Timer::new(format!("get_epoch_nonce[{}]", epoch.0));
+		let nonce_timer = start_sub_query_timer(&self.metrics_opt, "candidates_get_epoch_nonce");
+		let data_epoch = self.data_epoch_of(epoch)?;
+		if let Ok(mut caches) = self.caches.lock()
+			&& let Some(cached) = caches.nonce.get(&data_epoch)
+		{
+			return Ok(Some(cached.clone()));
+		}
+		let params = {
+			let _t = Timer::new(format!("GET epochs/{data_epoch}/parameters"));
+			match deadline(
+				&format!("epochs/{data_epoch}/parameters"),
+				self.client.api.epochs_parameters(data_epoch as i32),
+			)
+			.await?
+			{
+				Ok(params) => Some(params),
+				Err(e) if is_404(&e) => None,
+				Err(e) => return Err(box_err(e)),
+			}
+		};
+		let nonce = params
+			.map(|p| Ok::<_, BoxError>(EpochNonce(hex::decode(p.nonce)?)))
+			.transpose()?;
+		// Stops here: `can_cache()` below issues its own requests and is not part of
+		// the db-sync query this label mirrors.
+		drop(nonce_timer);
+		// `None` nonces are never cached: the epoch data may simply not be there yet.
+		if let Some(nonce) = &nonce
+			&& self.can_cache(data_epoch).await
+			&& let Ok(mut caches) = self.caches.lock()
+		{
+			caches.nonce.put(data_epoch, nonce.clone());
+		}
+		Ok(nonce)
+	}
+
+	async fn data_epoch(&self, for_epoch: McEpochNumber) -> Result<McEpochNumber, BoxError> {
+		Ok(McEpochNumber(self.data_epoch_of(for_epoch)?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::testing::{Reply, client_at, fake_server};
+	use super::*;
+
+	#[tokio::test]
+	async fn sub_query_metrics_are_recorded_under_the_db_sync_label() {
+		use midnight_primitives_mainchain_follower::data_source::metrics::MetricsRegistry;
+
+		// A 404 for the epoch parameters is a valid "no data yet" answer, so this drives
+		// the method to completion with a single request.
+		let (url, _seen) = fake_server(vec![Reply::Json(404, "{}".into())]).await;
+		let registry = MetricsRegistry::new();
+		let metrics = MidnightDataSourceMetrics::register(&registry).expect("register");
+		let source = BlockfrostAuthoritySelectionDataSource::new(
+			Arc::new(client_at(&url)),
+			432,
+			Some(metrics),
+		);
+
+		let nonce = source.get_epoch_nonce(McEpochNumber(100)).await.expect("nonce query");
+		assert!(nonce.is_none(), "404 means the epoch has no data yet");
+
+		// The histogram must carry one observation under the same label the db-sync
+		// source uses, otherwise the two backends cannot be compared in one panel.
+		let families = registry.gather();
+		let family = families
+			.iter()
+			.find(|f| f.get_name() == "midnight_data_source_query_time_elapsed")
+			.expect("histogram registered");
+		let sample = family
+			.get_metric()
+			.iter()
+			.find(|m| {
+				m.get_label().iter().any(|l| {
+					l.get_name() == "query_name" && l.get_value() == "candidates_get_epoch_nonce"
+				})
+			})
+			.expect("a sample labelled candidates_get_epoch_nonce");
+		assert_eq!(sample.get_histogram().get_sample_count(), 1);
+	}
+}

--- a/node/src/blockfrost/block.rs
+++ b/node/src/blockfrost/block.rs
@@ -1,0 +1,329 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Block and mc-hash data source: stable-block selection and Cardano tip queries.
+
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use blockfrost::blockfrost_openapi::models::block_content::BlockContent;
+use lru::LruCache;
+use pallet_sidechain_rpc::SidechainRpcDataSource;
+use sidechain_domain::*;
+use sidechain_mc_hash::{McHashDataSource, StableBlockByHashResult};
+use sp_timestamp::Timestamp;
+
+use super::client::*;
+use super::convert::*;
+use super::support::*;
+
+fn mainchain_block(b: &BlockContent) -> Result<MainchainBlock, BoxError> {
+	Ok(MainchainBlock {
+		number: McBlockNumber(block_height(b)?),
+		hash: McBlockHash(decode_hash32(&b.hash)?),
+		epoch: McEpochNumber(u32::try_from(b.epoch.ok_or("block has no epoch")?)?),
+		slot: McSlotNumber(u64::try_from(b.slot.ok_or("block has no slot")?)?),
+		timestamp: u64::try_from(b.time)?,
+	})
+}
+
+fn block_time_ms(b: &BlockContent) -> i64 {
+	i64::from(b.time) * 1000
+}
+
+// ---------------------------------------------------------------------------
+// Block data source: McHashDataSource + SidechainRpcDataSource
+// ---------------------------------------------------------------------------
+
+/// Mirrors `BlockDataSourceImpl` from `partner-chains-db-sync-data-sources`.
+pub struct BlockfrostBlockDataSource {
+	client: Arc<BlockfrostClient>,
+	security_parameter: u32,
+	block_stability_margin: u32,
+	/// `security_parameter / active_slots_coeff` in milliseconds (`k/f`).
+	min_slot_boundary_ms: i64,
+	/// `3k/f` in milliseconds.
+	max_slot_boundary_ms: i64,
+	max_latest_block_age_seconds: u64,
+	/// Blocks classified stable by `get_stable_block_for`, for cheap re-verification.
+	stable_blocks: Mutex<LruCache<McBlockHash, MainchainBlock>>,
+}
+
+/// Pure stable-block classification, mirroring `get_stable_block_by_hash_from_db`:
+/// the timestamp-range check comes FIRST (final error) before the confirmation-count
+/// check (transient error).
+fn classify_stable(
+	block: MainchainBlock,
+	latest_height: u32,
+	reference_timestamp_ms: i64,
+	security_parameter: u32,
+	min_slot_boundary_ms: i64,
+	max_slot_boundary_ms: i64,
+) -> StableBlockByHashResult {
+	let block_time_ms = i64::try_from(block.timestamp).unwrap_or(i64::MAX) * 1000;
+	let min_allowed = reference_timestamp_ms - max_slot_boundary_ms;
+	let max_allowed = reference_timestamp_ms - min_slot_boundary_ms;
+	if !(min_allowed <= block_time_ms && block_time_ms <= max_allowed) {
+		return StableBlockByHashResult::BlockTimestampOutRange { info: block };
+	}
+	if block.number.0.saturating_add(security_parameter) > latest_height {
+		return StableBlockByHashResult::NotEnoughConfirmations { info: block };
+	}
+	StableBlockByHashResult::BlockStable { info: block }
+}
+
+impl BlockfrostBlockDataSource {
+	pub fn new(
+		client: Arc<BlockfrostClient>,
+		security_parameter: u32,
+		active_slots_coeff: f64,
+		block_stability_margin: u32,
+		slot_duration_millis: u64,
+	) -> Self {
+		let k: f64 = security_parameter.into();
+		let slot_ms = slot_duration_millis as f64;
+		let min_slot_boundary_ms = (slot_ms * k / active_slots_coeff).round() as i64;
+		let expected_block_interval_secs = ((slot_ms / 1000.0) / active_slots_coeff).round() as u64;
+		Self {
+			client,
+			security_parameter,
+			block_stability_margin,
+			min_slot_boundary_ms,
+			max_slot_boundary_ms: 3 * min_slot_boundary_ms,
+			max_latest_block_age_seconds: u64::from(block_stability_margin.max(1))
+				* expected_block_interval_secs,
+			stable_blocks: Mutex::new(LruCache::new(NonZeroUsize::new(100).unwrap())),
+		}
+	}
+
+	async fn latest(&self) -> Result<BlockContent, BoxError> {
+		let _t = Timer::new("GET blocks/latest");
+		deadline("blocks/latest", self.client.api.blocks_latest())
+			.await?
+			.map_err(box_err)
+	}
+
+	/// Highest block with height ≤ `max_height` and time ≤ `max_time_ms`.
+	///
+	/// Block timestamps are monotonically non-decreasing, so when the block at
+	/// `max_height` is too new, a binary search over heights finds the boundary
+	/// (≤ ~25 lookups; only happens when Cardano block production stalls).
+	async fn highest_block_at_or_before_time(
+		&self,
+		max_height: u32,
+		max_time_ms: i64,
+	) -> Result<Option<BlockContent>, BoxError> {
+		let Some(top) = self.client.block_by_id(&max_height.to_string()).await? else {
+			return Ok(None);
+		};
+		if block_time_ms(&top) <= max_time_ms {
+			return Ok(Some(top));
+		}
+		let mut lo: u32 = 0;
+		let mut hi: u32 = max_height; // invariant: block at `hi` is too new
+		let mut best: Option<BlockContent> = None;
+		while lo < hi {
+			let mid = lo + (hi - lo) / 2;
+			// A height with no block is the SQL's "no row", not a failure: on a young
+			// chain every block can be newer than the window, and `mid` reaches 0.
+			// Treat it as too-new so the search narrows upward instead of erroring.
+			let Some(block) = self.client.block_by_id(&mid.to_string()).await? else {
+				hi = mid;
+				continue;
+			};
+			if block_time_ms(&block) <= max_time_ms {
+				best = Some(block);
+				lo = mid + 1;
+			} else {
+				hi = mid;
+			}
+		}
+		Ok(best)
+	}
+
+	/// Mirrors `BlockDataSourceImpl::get_latest_block` (the `get_highest_block` SQL):
+	/// highest block ≤ `max_height` with time within
+	/// `[reference - 3k/f, reference - k/f]`.
+	async fn latest_block_in_window(
+		&self,
+		max_height: u32,
+		reference_timestamp_ms: i64,
+	) -> Result<Option<BlockContent>, BoxError> {
+		let max_time_ms = reference_timestamp_ms - self.min_slot_boundary_ms;
+		let min_time_ms = reference_timestamp_ms - self.max_slot_boundary_ms;
+		let candidate = self.highest_block_at_or_before_time(max_height, max_time_ms).await?;
+		Ok(candidate.filter(|b| block_time_ms(b) >= min_time_ms))
+	}
+
+	fn now_ms() -> i64 {
+		SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.map(|d| d.as_millis() as i64)
+			.unwrap_or_default()
+	}
+}
+
+#[async_trait::async_trait]
+impl McHashDataSource for BlockfrostBlockDataSource {
+	async fn get_latest_stable_block_for(
+		&self,
+		reference_timestamp: Timestamp,
+	) -> Result<Option<MainchainBlock>, BoxError> {
+		let _t = Timer::new(format!("get_latest_stable_block_for[{reference_timestamp:?}]"));
+		let latest = self.latest().await?;
+		let offset = self.security_parameter + self.block_stability_margin;
+		let stable_height = block_height(&latest)?.saturating_sub(offset);
+		let reference_ms = i64::try_from(reference_timestamp.as_millis())?;
+		let block = self.latest_block_in_window(stable_height, reference_ms).await?;
+		block.map(|b| mainchain_block(&b)).transpose()
+	}
+
+	async fn get_stable_block_for(
+		&self,
+		hash: McBlockHash,
+		reference_timestamp: Timestamp,
+	) -> Result<StableBlockByHashResult, BoxError> {
+		let _t = Timer::new(format!("get_stable_block_for[{hash}]"));
+		let reference_ms = i64::try_from(reference_timestamp.as_millis())?;
+		// A block classified stable once stays stable; only the timestamp window
+		// depends on the reference (mirrors the db-sync stable-block cache).
+		if let Ok(mut cache) = self.stable_blocks.lock()
+			&& let Some(block) = cache.get(&hash)
+		{
+			let time_ms = i64::try_from(block.timestamp).unwrap_or(i64::MAX) * 1000;
+			if reference_ms - self.max_slot_boundary_ms <= time_ms
+				&& time_ms <= reference_ms - self.min_slot_boundary_ms
+			{
+				return Ok(StableBlockByHashResult::BlockStable { info: block.clone() });
+			}
+		}
+		let Some(block) = self.client.block_by_id(&hex::encode(hash.0)).await? else {
+			return Ok(StableBlockByHashResult::BlockNotFound);
+		};
+		let latest = self.latest().await?;
+		let result = classify_stable(
+			mainchain_block(&block)?,
+			block_height(&latest)?,
+			reference_ms,
+			self.security_parameter,
+			self.min_slot_boundary_ms,
+			self.max_slot_boundary_ms,
+		);
+		if let StableBlockByHashResult::BlockStable { info } = &result
+			&& let Ok(mut cache) = self.stable_blocks.lock()
+		{
+			cache.put(hash, info.clone());
+		}
+		Ok(result)
+	}
+
+	async fn get_block_by_hash(
+		&self,
+		hash: McBlockHash,
+	) -> Result<Option<MainchainBlock>, BoxError> {
+		let _t = Timer::new(format!("get_block_by_hash[{hash}]"));
+		if let Ok(mut cache) = self.stable_blocks.lock()
+			&& let Some(block) = cache.get(&hash)
+		{
+			return Ok(Some(block.clone()));
+		}
+		let block = self.client.block_by_id(&hex::encode(hash.0)).await?;
+		block.map(|b| mainchain_block(&b)).transpose()
+	}
+
+	async fn is_cardano_tip_fresh(&self) -> Result<bool, BoxError> {
+		let _t = Timer::new("is_cardano_tip_fresh");
+		let latest = mainchain_block(&self.latest().await?)?;
+		let now_secs = (Self::now_ms() / 1000) as u64;
+		Ok(now_secs.saturating_sub(latest.timestamp) < self.max_latest_block_age_seconds)
+	}
+
+	async fn is_cardano_ok(&self) -> Result<bool, BoxError> {
+		let _t = Timer::new("is_cardano_ok");
+		let now_ms = Self::now_ms();
+		let latest = self.latest().await?;
+		// Praos chain quality rule check.
+		if now_ms - self.min_slot_boundary_ms > block_time_ms(&latest) {
+			return Ok(false);
+		}
+		let stable_height = block_height(&latest)?.saturating_sub(self.security_parameter);
+		// Praos chain growth rule.
+		Ok(self.latest_block_in_window(stable_height, now_ms).await?.is_some())
+	}
+}
+
+#[async_trait::async_trait]
+impl SidechainRpcDataSource for BlockfrostBlockDataSource {
+	async fn get_latest_block_info(&self) -> Result<MainchainBlock, BoxError> {
+		let _t = Timer::new("get_latest_block_info");
+		mainchain_block(&self.latest().await?)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn block(number: u32, timestamp: u64) -> MainchainBlock {
+		MainchainBlock {
+			number: McBlockNumber(number),
+			hash: McBlockHash([1; 32]),
+			epoch: McEpochNumber(1),
+			slot: McSlotNumber(u64::from(number)),
+			timestamp,
+		}
+	}
+
+	const K: u32 = 432;
+
+	const MIN_BOUNDARY_MS: i64 = 1_000_000;
+
+	const MAX_BOUNDARY_MS: i64 = 3_000_000;
+
+	fn classify(block_ts_secs: u64, block_no: u32, latest: u32) -> StableBlockByHashResult {
+		classify_stable(
+			block(block_no, block_ts_secs),
+			latest,
+			10_000_000,
+			K,
+			MIN_BOUNDARY_MS,
+			MAX_BOUNDARY_MS,
+		)
+	}
+
+	#[test]
+	fn classify_stable_checks_timestamp_before_confirmations() {
+		// Block too new for the window AND with too few confirmations: the timestamp
+		// error wins because it is final while NotEnoughConfirmations is transient.
+		assert!(matches!(
+			classify(9_500, 1000, 1000),
+			StableBlockByHashResult::BlockTimestampOutRange { .. }
+		));
+		// In window but too few confirmations.
+		assert!(matches!(
+			classify(8_000, 1000, 1000),
+			StableBlockByHashResult::NotEnoughConfirmations { .. }
+		));
+		// In window with enough confirmations.
+		assert!(matches!(
+			classify(8_000, 1000, 1000 + K),
+			StableBlockByHashResult::BlockStable { .. }
+		));
+		// Too old for the window (below reference - 3k/f).
+		assert!(matches!(
+			classify(6_000, 1000, 1000 + K),
+			StableBlockByHashResult::BlockTimestampOutRange { .. }
+		));
+	}
+}

--- a/node/src/blockfrost/bridge.rs
+++ b/node/src/blockfrost/bridge.rs
@@ -1,0 +1,409 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Token bridge data source: Cardano-to-Midnight transfers and their checkpoints.
+
+use std::sync::Arc;
+
+use blockfrost::BlockCursor;
+use partner_chains_plutus_data::bridge::TOKEN_TRANSFER_METADATUM_KEY;
+use sidechain_domain::*;
+use sp_partner_chains_bridge::{
+	BridgeDataCheckpoint, BridgeTransferV1, MainChainScripts, TokenBridgeDataSource,
+	TransferRecipient,
+};
+
+use super::client::*;
+use super::convert::*;
+use super::support::*;
+
+// ---------------------------------------------------------------------------
+// Token bridge
+// ---------------------------------------------------------------------------
+
+/// Per-tx bridge token flow totals, the Blockfrost equivalent of the db-sync
+/// `get_bridge_txs` row.
+#[derive(Debug, Clone, PartialEq)]
+struct BridgeTx {
+	block_number: u32,
+	tx_ix: u32,
+	tx_hash: McTxHash,
+	c2m_metadata: Option<serde_json::Value>,
+	bridge_in: u64,
+	bridge_out: u64,
+	reserve_in: u64,
+	reserve_out: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ResolvedCheckpoint {
+	Tx { block_number: u32, tx_ix: u32 },
+	Block { number: u32 },
+}
+
+impl ResolvedCheckpoint {
+	fn block_number(&self) -> u32 {
+		match self {
+			Self::Tx { block_number, .. } => *block_number,
+			Self::Block { number } => *number,
+		}
+	}
+
+	/// Strict comparison, mirroring the SQL `block.block_no > n` /
+	/// `(block.block_no, tx.block_index) > (b, ix)` checkpoint filters.
+	fn is_before(&self, block_number: u32, tx_ix: u32) -> bool {
+		match self {
+			Self::Block { number } => block_number > *number,
+			Self::Tx { block_number: cp_block, tx_ix: cp_ix } => {
+				(block_number, tx_ix) > (*cp_block, *cp_ix)
+			},
+		}
+	}
+}
+
+/// Mirrors `txs_to_transfers` from the db-sync bridge data source.
+fn txs_to_transfers<RecipientAddress>(
+	txs: Vec<BridgeTx>,
+	max_transfers: u32,
+	block_bound: u32,
+) -> (Vec<BridgeTransferV1<RecipientAddress>>, BridgeDataCheckpoint)
+where
+	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
+{
+	let mut transfers: Vec<BridgeTransferV1<RecipientAddress>> = vec![];
+	let mut checkpoint = BridgeDataCheckpoint::Block(McBlockNumber(block_bound));
+	// Add Cardano transaction transfers only if all of them fit into max_transfers
+	for tx in &txs {
+		let tx_transfers = tx_to_transfers::<RecipientAddress>(tx.clone());
+		// Would go over limit, return accumulated state from previous iteration
+		if transfers.len() + tx_transfers.len() > max_transfers as usize {
+			return (transfers, checkpoint);
+		}
+		transfers.extend(tx_transfers);
+		checkpoint = BridgeDataCheckpoint::Tx(tx.tx_hash)
+	}
+	let checkpoint = if transfers.len() == max_transfers as usize {
+		checkpoint
+	} else {
+		BridgeDataCheckpoint::Block(McBlockNumber(block_bound))
+	};
+	(transfers, checkpoint)
+}
+
+/// Mirrors `tx_to_transfers`: Reserve can unlock only to ICS — if the reserve shrank,
+/// the delta went to ICS; the rest of the ICS surplus is a user transfer.
+fn tx_to_transfers<RecipientAddress>(tx: BridgeTx) -> Vec<BridgeTransferV1<RecipientAddress>>
+where
+	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
+{
+	let mc_tx_hash = tx.tx_hash;
+	let reserve_debit: u64 = tx.reserve_in.saturating_sub(tx.reserve_out);
+	let ics_credit: u64 = tx.bridge_out.saturating_sub(tx.bridge_in);
+	let locked_amount = ics_credit.saturating_sub(reserve_debit);
+
+	let mut transfers = Vec::with_capacity(2);
+
+	if reserve_debit > 0 {
+		let recipient = TransferRecipient::Reserve;
+		transfers.push(BridgeTransferV1 { mc_tx_hash, amount: reserve_debit, recipient })
+	}
+
+	if locked_amount > 0 {
+		let recipient = metadata_to_recipient(tx.c2m_metadata);
+		transfers.push(BridgeTransferV1 { mc_tx_hash, amount: locked_amount, recipient })
+	}
+
+	transfers
+}
+
+/// Mirrors `metadata_to_recipient`: the metadata value must be `["0x<hex>"]`.
+fn metadata_to_recipient<RecipientAddress>(
+	metadata: Option<serde_json::Value>,
+) -> TransferRecipient<RecipientAddress>
+where
+	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
+{
+	match metadata {
+		Some(serde_json::Value::Array(values)) => match values.as_slice() {
+			[serde_json::Value::String(str)] => {
+				match str
+					.strip_prefix("0x")
+					.and_then(|str| hex::decode(str).ok())
+					.and_then(|bytes| RecipientAddress::try_from(&bytes).ok())
+				{
+					Some(recipient) => TransferRecipient::Address { recipient },
+					_ => TransferRecipient::Invalid,
+				}
+			},
+			_ => TransferRecipient::Invalid,
+		},
+		_ => TransferRecipient::Invalid,
+	}
+}
+
+/// Mirrors `TokenBridgeDataSourceImpl` from `partner-chains-db-sync-data-sources`.
+/// No lookahead cache: that is purely a sync-speed optimization on the db-sync path.
+pub struct BlockfrostTokenBridgeDataSource {
+	client: Arc<BlockfrostClient>,
+}
+
+impl BlockfrostTokenBridgeDataSource {
+	pub fn new(client: Arc<BlockfrostClient>) -> Self {
+		Self { client }
+	}
+}
+
+#[async_trait::async_trait]
+impl<RecipientAddress> TokenBridgeDataSource<RecipientAddress> for BlockfrostTokenBridgeDataSource
+where
+	RecipientAddress: std::fmt::Debug + Send + Sync,
+	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
+{
+	async fn get_transfers(
+		&self,
+		main_chain_scripts: MainChainScripts,
+		data_checkpoint: BridgeDataCheckpoint,
+		max_transfers: u32,
+		current_mc_block: McBlockHash,
+	) -> Result<(Vec<BridgeTransferV1<RecipientAddress>>, BridgeDataCheckpoint), BoxError> {
+		let _t = Timer::new(format!("get_transfers[{current_mc_block}]"));
+		let unit = format!(
+			"{}{}",
+			hex::encode(main_chain_scripts.token_policy_id.0),
+			hex::encode(&main_chain_scripts.token_asset_name.0[..])
+		);
+		let ics_address =
+			main_chain_scripts.illiquid_circulation_supply_validator_address.to_string();
+		let reserve_address = main_chain_scripts.reserve_validator_address.to_string();
+
+		let current_block = self
+			.client
+			.block_by_id(&hex::encode(current_mc_block.0))
+			.await?
+			.ok_or_else(|| format!("Could not find block for hash {current_mc_block:?}"))?;
+		let to_block = block_height(&current_block)?;
+
+		let checkpoint = match &data_checkpoint {
+			BridgeDataCheckpoint::Tx(tx_hash) => {
+				let _t = Timer::new(format!("GET txs/{}", hex::encode(tx_hash.0)));
+				let tx = deadline(
+					&format!("txs/{}", hex::encode(tx_hash.0)),
+					self.client.api.transaction_by_hash(&hex::encode(tx_hash.0)),
+				)
+				.await?
+				.map_err(|e| -> BoxError {
+					// An over-quota 402 here is not a missing checkpoint; keep the real reason.
+					if is_over_quota(&e) {
+						return box_err(e);
+					}
+					format!(
+						"Could not find block info for data checkpoint: {data_checkpoint:?} ({e})"
+					)
+					.into()
+				})?;
+				ResolvedCheckpoint::Tx {
+					block_number: u32::try_from(tx.block_height)?,
+					tx_ix: u32::try_from(tx.index)?,
+				}
+			},
+			BridgeDataCheckpoint::Block(number) => ResolvedCheckpoint::Block { number: number.0 },
+		};
+
+		let rows = self
+			.client
+			.range_txs(
+				TxSource::Address(&ics_address),
+				Some(BlockCursor::block(u64::from(checkpoint.block_number()))),
+				Some(BlockCursor::block(u64::from(to_block))),
+			)
+			.await?;
+
+		let mut bridge_txs: Vec<BridgeTx> = Vec::new();
+		for row in rows {
+			if !checkpoint.is_before(row.block_height, row.tx_index) {
+				continue;
+			}
+			let utxos = self.client.tx_utxos(&row.tx_hash).await?;
+			// db-sync sums these in `NUMERIC` columns that reject a value outside the
+			// token range, so an out-of-range total is an error here too rather than a
+			// silently truncated cast.
+			let sum_outputs = |address: &str| -> Result<u64, BoxError> {
+				let mut total: u128 = 0;
+				for output in utxos.outputs.iter().filter(|o| !o.collateral && o.address == address)
+				{
+					total = total
+						.checked_add(amount_of(&output.amount, &unit)?)
+						.ok_or("bridge output total overflowed u128")?;
+				}
+				Ok(u64::try_from(total)?)
+			};
+			let sum_inputs = |address: &str| -> Result<u64, BoxError> {
+				let mut total: u128 = 0;
+				for input in utxos
+					.inputs
+					.iter()
+					.filter(|i| !i.collateral && !i.reference.unwrap_or(false))
+					.filter(|i| i.address == address)
+				{
+					total = total
+						.checked_add(amount_of(&input.amount, &unit)?)
+						.ok_or("bridge input total overflowed u128")?;
+				}
+				Ok(u64::try_from(total)?)
+			};
+			let bridge_out = sum_outputs(&ics_address)?;
+			// Only txs that create a token output at the ICS address are relevant
+			// (the SQL `relevant_txs` CTE).
+			if bridge_out == 0 {
+				continue;
+			}
+			let bridge_in = sum_inputs(&ics_address)?;
+			let reserve_in = sum_inputs(&reserve_address)?;
+			let reserve_out = sum_outputs(&reserve_address)?;
+			if !(bridge_out > bridge_in || reserve_in > reserve_out) {
+				continue;
+			}
+			let c2m_metadata = self
+				.client
+				.tx_metadata_label(&row.tx_hash, &TOKEN_TRANSFER_METADATUM_KEY.to_string())
+				.await?;
+			bridge_txs.push(BridgeTx {
+				block_number: row.block_height,
+				tx_ix: row.tx_index,
+				tx_hash: McTxHash(decode_hash32(&row.tx_hash)?),
+				c2m_metadata,
+				bridge_in,
+				bridge_out,
+				reserve_in,
+				reserve_out,
+			});
+			// The SQL applies `LIMIT max_transfers` to candidate txs.
+			if bridge_txs.len() == max_transfers as usize {
+				break;
+			}
+		}
+
+		Ok(txs_to_transfers(bridge_txs, max_transfers, to_block))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sidechain_domain::byte_string::ByteString;
+
+	fn bridge_tx(block_number: u32, tx_ix: u32, seed: u8) -> BridgeTx {
+		BridgeTx {
+			block_number,
+			tx_ix,
+			tx_hash: McTxHash([seed; 32]),
+			c2m_metadata: Some(serde_json::json!(["0xabcd"])),
+			bridge_in: 0,
+			bridge_out: 100,
+			reserve_in: 0,
+			reserve_out: 0,
+		}
+	}
+
+	#[test]
+	fn metadata_to_recipient_accepts_only_single_hex_string_array() {
+		let ok = metadata_to_recipient::<ByteString>(Some(serde_json::json!(["0xabcd"])));
+		assert_eq!(ok, TransferRecipient::Address { recipient: ByteString(vec![0xab, 0xcd]) });
+		for invalid in [
+			None,
+			Some(serde_json::json!("0xabcd")),
+			Some(serde_json::json!(["abcd"])),
+			Some(serde_json::json!(["0xzz"])),
+			Some(serde_json::json!(["0xabcd", "0xabcd"])),
+			Some(serde_json::json!({"0": "0xabcd"})),
+		] {
+			assert_eq!(metadata_to_recipient::<ByteString>(invalid), TransferRecipient::Invalid);
+		}
+	}
+
+	#[test]
+	fn tx_to_transfers_splits_reserve_and_user_transfer() {
+		// Reserve released 100, ICS grew by 165: 100 reserve transfer + 65 user transfer.
+		let tx = BridgeTx {
+			bridge_in: 35,
+			bridge_out: 200,
+			reserve_in: 150,
+			reserve_out: 50,
+			..bridge_tx(8, 0, 8)
+		};
+		let transfers = tx_to_transfers::<ByteString>(tx.clone());
+		assert_eq!(
+			transfers,
+			vec![
+				BridgeTransferV1 {
+					mc_tx_hash: tx.tx_hash,
+					amount: 100,
+					recipient: TransferRecipient::Reserve
+				},
+				BridgeTransferV1 {
+					mc_tx_hash: tx.tx_hash,
+					amount: 65,
+					recipient: TransferRecipient::Address {
+						recipient: ByteString(vec![0xab, 0xcd])
+					}
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn txs_to_transfers_returns_block_checkpoint_when_under_limit() {
+		let (transfers, checkpoint) =
+			txs_to_transfers::<ByteString>(vec![bridge_tx(2, 0, 1), bridge_tx(2, 1, 2)], 10, 4);
+		assert_eq!(transfers.len(), 2);
+		assert_eq!(checkpoint, BridgeDataCheckpoint::Block(McBlockNumber(4)));
+	}
+
+	#[test]
+	fn txs_to_transfers_returns_tx_checkpoint_when_limit_reached() {
+		let (transfers, checkpoint) =
+			txs_to_transfers::<ByteString>(vec![bridge_tx(2, 0, 1), bridge_tx(2, 1, 2)], 1, 4);
+		assert_eq!(transfers.len(), 1);
+		assert_eq!(checkpoint, BridgeDataCheckpoint::Tx(McTxHash([1; 32])));
+	}
+
+	#[test]
+	fn txs_to_transfers_drops_tx_whose_transfers_would_exceed_limit() {
+		// The second tx produces two transfers (reserve + user); with a limit of 2 only
+		// the first tx fits, and the checkpoint points at it.
+		let two_transfer_tx = BridgeTx {
+			bridge_in: 0,
+			bridge_out: 165,
+			reserve_in: 100,
+			reserve_out: 0,
+			..bridge_tx(3, 0, 9)
+		};
+		let (transfers, checkpoint) =
+			txs_to_transfers::<ByteString>(vec![bridge_tx(2, 0, 1), two_transfer_tx], 2, 4);
+		assert_eq!(transfers.len(), 1);
+		assert_eq!(checkpoint, BridgeDataCheckpoint::Tx(McTxHash([1; 32])));
+	}
+
+	#[test]
+	fn checkpoint_comparisons_are_strict() {
+		let block_cp = ResolvedCheckpoint::Block { number: 2 };
+		assert!(!block_cp.is_before(2, 99));
+		assert!(block_cp.is_before(3, 0));
+
+		let tx_cp = ResolvedCheckpoint::Tx { block_number: 2, tx_ix: 5 };
+		assert!(!tx_cp.is_before(2, 5));
+		assert!(tx_cp.is_before(2, 6));
+		assert!(tx_cp.is_before(3, 0));
+		assert!(!tx_cp.is_before(1, 99));
+	}
+}

--- a/node/src/blockfrost/client.rs
+++ b/node/src/blockfrost/client.rs
@@ -1,0 +1,559 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The HTTP/SDK client: one `BlockfrostClient` wrapping the Blockfrost SDK plus a raw
+//! `reqwest` path for the one endpoint the SDK cannot model, with paging and cursors.
+
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use blockfrost::{
+	BlockCursor, BlockFrostSettings, BlockfrostAPI, Order, Pagination, RetrySettings,
+	blockfrost_openapi::models::{block_content::BlockContent, tx_content_utxo::TxContentUtxo},
+};
+use cardano_serialization_lib::{PlutusData, PlutusDatumSchema, encode_json_value_to_plutus_datum};
+use lru::LruCache;
+use sidechain_domain::*;
+
+use super::convert::*;
+use super::support::*;
+
+const USER_AGENT: &str = concat!("midnight-node/", env!("CARGO_PKG_VERSION"));
+
+/// One row of `/addresses/{addr}/transactions` or `/assets/{unit}/transactions`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct RangeTx {
+	pub(crate) tx_hash: String,
+	pub(crate) tx_index: u32,
+	pub(crate) block_height: u32,
+	pub(crate) block_time: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawTxMetadata {
+	label: String,
+	json_metadata: serde_json::Value,
+}
+
+/// Which transaction list to query.
+#[derive(Clone, Copy)]
+pub(crate) enum TxSource<'a> {
+	Address(&'a str),
+	Asset(&'a str),
+}
+
+impl std::fmt::Display for TxSource<'_> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TxSource::Address(address) => write!(f, "addresses/{address}"),
+			TxSource::Asset(asset) => write!(f, "assets/{asset}"),
+		}
+	}
+}
+
+fn range_tx(
+	tx_hash: String,
+	tx_index: i32,
+	block_height: i32,
+	block_time: i32,
+) -> Result<RangeTx, BoxError> {
+	Ok(RangeTx {
+		tx_hash,
+		tx_index: u32::try_from(tx_index)?,
+		block_height: u32::try_from(block_height)?,
+		block_time: u64::try_from(block_time)?,
+	})
+}
+
+/// Shared Blockfrost client: the typed SDK plus a raw `reqwest` client for the one
+/// endpoint the SDK cannot represent (array-shaped tx metadata).
+pub struct BlockfrostClient {
+	pub(crate) api: BlockfrostAPI,
+	http: reqwest::Client,
+	base_url: String,
+	security_parameter: u32,
+	/// Blocks fetched by hash, shared across all data sources.
+	///
+	/// Only blocks with at least `security_parameter` confirmations are cached. A
+	/// block's *contents* are immutable, but its membership in the canonical chain is
+	/// not: caching an unstable block would let a later stability check classify a
+	/// since-rolled-back block as stable, where db-sync reports it as unknown. Beyond
+	/// `k` confirmations a rollback is outside the security model — the same assumption
+	/// the db-sync block cache makes. By-number lookups are never cached (the block at
+	/// a given height can change on rollback).
+	blocks_by_hash: Mutex<LruCache<String, BlockContent>>,
+}
+
+impl BlockfrostClient {
+	pub fn new(
+		endpoint: &str,
+		project_id: Option<&str>,
+		security_parameter: u32,
+	) -> Result<Self, BoxError> {
+		// Parsed here so a malformed endpoint is a startup error. The SDK parses per
+		// request, so otherwise the node boots, reports the backend, then fails every
+		// Cardano read for the life of the process.
+		let base = endpoint.trim_end_matches('/').to_string();
+		let parsed = reqwest::Url::parse(&base)
+			.map_err(|e| format!("blockfrost_endpoint is not a valid URL ({e}): {base}"))?;
+		if !matches!(parsed.scheme(), "http" | "https") {
+			return Err(format!(
+				"blockfrost_endpoint must be an http(s) URL, got scheme `{}`: {base}",
+				parsed.scheme()
+			)
+			.into());
+		}
+		let mut settings = BlockFrostSettings::new();
+		settings.base_url = Some(base);
+		settings.retry_settings = RetrySettings::new(RETRY_AMOUNT, RETRY_DELAY);
+		settings.headers.insert("User-Agent".to_string(), USER_AGENT.to_string());
+
+		// Check the project id before the SDK sees it: the SDK builds a header from it
+		// with an `expect`, so a value that is not header-safe panics, and the panic
+		// message contains the id. Report the problem without echoing the secret.
+		let project_id = project_id.unwrap_or_default();
+		if !project_id.is_empty() && !project_id.bytes().all(|b| b.is_ascii_alphanumeric()) {
+			return Err("blockfrost_project_id must be ASCII alphanumeric".into());
+		}
+
+		// Our own client gets a deadline here; SDK calls get one from `deadline()` (its
+		// HTTP client is built by the crate itself, on a different reqwest version).
+		// Without a deadline a server that accepts the connection and then stalls blocks
+		// inherent creation or verification indefinitely.
+		let api = BlockfrostAPI::new(project_id, settings);
+
+		let mut headers = reqwest::header::HeaderMap::new();
+		if !project_id.is_empty() {
+			headers.insert("project_id", project_id.parse()?);
+		}
+		let http = reqwest::Client::builder()
+			.default_headers(headers)
+			.user_agent(USER_AGENT)
+			.timeout(HTTP_TIMEOUT)
+			.build()?;
+
+		Ok(Self {
+			api,
+			http,
+			base_url: endpoint.trim_end_matches('/').to_string(),
+			security_parameter,
+			blocks_by_hash: Mutex::new(LruCache::new(NonZeroUsize::new(1024).unwrap())),
+		})
+	}
+
+	/// Raw paged GET returning deserialized rows; treats 404 as an empty result
+	/// (unknown address/asset ≡ no db-sync rows) and retries on 429.
+	async fn get_paged<T: serde::de::DeserializeOwned>(
+		&self,
+		path_and_query: &str,
+		page: usize,
+	) -> Result<Vec<T>, BoxError> {
+		let sep = if path_and_query.contains('?') { '&' } else { '?' };
+		let url = format!("{}/{path_and_query}{sep}count={PAGE_SIZE}&page={page}", self.base_url);
+		let _t = Timer::new(format!("GET {path_and_query} page={page}"));
+		// The deadline covers the whole retry loop, not each attempt: `HTTP_TIMEOUT` is
+		// already the per-request bound on `self.http`, and `RETRY_AMOUNT` attempts of it
+		// would otherwise add up to minutes. This matches the SDK paths, where `deadline`
+		// also bounds the SDK's internal retries.
+		let fetch = async {
+			let mut attempts = 0;
+			loop {
+				let response = self.http.get(&url).send().await?;
+				match response.status().as_u16() {
+					404 => return Ok(vec![]),
+					402 => {
+						log::error!("{OVER_QUOTA_MESSAGE}");
+						return Err(OVER_QUOTA_MESSAGE.into());
+					},
+					// Same transient set the SDK's `RetrySettings` covers, so the raw path
+					// is no less resilient than every SDK call. 402 is deliberately absent:
+					// a quota does not clear inside a retry window.
+					408 | 429 | 500 | 502 | 503 | 504 if attempts < RETRY_AMOUNT => {
+						attempts += 1;
+						tokio::time::sleep(RETRY_DELAY).await;
+					},
+					status if !response.status().is_success() => {
+						return Err(format!("GET {url} failed with status {status}").into());
+					},
+					_ => return Ok(response.json().await?),
+				}
+			}
+		};
+		deadline::<Vec<T>, BoxError>(&format!("GET {path_and_query}"), fetch).await?
+	}
+
+	/// One page of a transaction list with optional server-side block-range cursors.
+	/// 404 (unknown address/asset) ≡ no db-sync rows: an empty page.
+	async fn txs_page(
+		&self,
+		source: TxSource<'_>,
+		pagination: Pagination,
+	) -> Result<Vec<RangeTx>, BoxError> {
+		let _t = Timer::new(format!(
+			"SDK {source}/transactions page={} from={:?} to={:?}",
+			pagination.page,
+			pagination.from.map(|c| c.to_string()),
+			pagination.to.map(|c| c.to_string()),
+		));
+		let label = format!("{source}/transactions");
+		let rows = match source {
+			TxSource::Address(address) => {
+				deadline(&label, self.api.addresses_transactions(address, pagination))
+					.await?
+					.map(|rows| {
+						rows.into_iter()
+							.map(|r| (r.tx_hash, r.tx_index, r.block_height, r.block_time))
+							.collect::<Vec<_>>()
+					})
+			},
+			TxSource::Asset(asset) => {
+				deadline(&label, self.api.assets_transactions(asset, pagination)).await?.map(
+					|rows| {
+						rows.into_iter()
+							.map(|r| (r.tx_hash, r.tx_index, r.block_height, r.block_time))
+							.collect::<Vec<_>>()
+					},
+				)
+			},
+		};
+		match rows {
+			Ok(rows) => rows
+				.into_iter()
+				.map(|(hash, tx_index, height, time)| range_tx(hash, tx_index, height, time))
+				.collect(),
+			Err(e) if is_404(&e) => Ok(vec![]),
+			Err(e) => Err(box_err(e)),
+		}
+	}
+
+	/// All transactions of `source` within the inclusive `from`/`to` block(-and-tx-index)
+	/// range, in ascending chain order.
+	///
+	/// The cursors are evaluated server-side; page-walking below a pinned `to` bound is
+	/// safe for consensus data because the chain below that bound is append-only.
+	pub(crate) async fn range_txs(
+		&self,
+		source: TxSource<'_>,
+		from: Option<BlockCursor>,
+		to: Option<BlockCursor>,
+	) -> Result<Vec<RangeTx>, BoxError> {
+		let mut rows: Vec<RangeTx> = Vec::new();
+		for page in 1..=MAX_PAGES {
+			let mut pagination = Pagination::new(Order::Asc, page, PAGE_SIZE);
+			pagination.from = from;
+			pagination.to = to;
+			let batch = self.txs_page(source, pagination).await?;
+			let last_page = batch.len() < PAGE_SIZE;
+			rows.extend(batch);
+			if last_page {
+				return Ok(rows);
+			}
+		}
+		Err(too_many_pages(&format!("{source}/transactions")))
+	}
+
+	/// One descending-order page of transactions of `source` up to `to_block` (inclusive).
+	pub(crate) async fn range_txs_desc_page(
+		&self,
+		source: TxSource<'_>,
+		to_block: u32,
+		page: usize,
+	) -> Result<Vec<RangeTx>, BoxError> {
+		let mut pagination = Pagination::new(Order::Desc, page, PAGE_SIZE);
+		pagination.to = Some(BlockCursor::block(u64::from(to_block)));
+		self.txs_page(source, pagination).await
+	}
+
+	/// The metadata value for `label`, via raw GET: the SDK's model cannot represent
+	/// array-shaped `json_metadata` (the shape used by bridge transfers).
+	///
+	/// Pages until the label is found. db-sync selects the row by key
+	/// (`tx_metadata.key = $5`), so stopping at page one would lose the transfer label
+	/// on a transaction carrying more than `PAGE_SIZE` labels — which the sender
+	/// controls, and which would make this backend disagree with db-sync on the block.
+	pub(crate) async fn tx_metadata_label(
+		&self,
+		tx_hash: &str,
+		label: &str,
+	) -> Result<Option<serde_json::Value>, BoxError> {
+		for page in 1..=MAX_PAGES {
+			let rows: Vec<RawTxMetadata> =
+				self.get_paged(&format!("txs/{tx_hash}/metadata"), page).await?;
+			let last_page = rows.len() < PAGE_SIZE;
+			if let Some(row) = rows.into_iter().find(|r| r.label == label) {
+				return Ok(Some(row.json_metadata));
+			}
+			if last_page {
+				return Ok(None);
+			}
+		}
+		Err(too_many_pages(&format!("txs/{tx_hash}/metadata")))
+	}
+
+	/// Hash of the block at `number`; `None` on 404. Used by the parity test to
+	/// resolve an anchor block by height.
+	pub async fn block_hash_by_number(&self, number: u32) -> Result<Option<McBlockHash>, BoxError> {
+		let block = self.block_by_id(&number.to_string()).await?;
+		block.map(|b| Ok(McBlockHash(decode_hash32(&b.hash)?))).transpose()
+	}
+
+	/// Block by hash or number; `None` on 404.
+	pub(crate) async fn block_by_id(&self, id: &str) -> Result<Option<BlockContent>, BoxError> {
+		let is_hash = id.len() == 64 && id.bytes().all(|b| b.is_ascii_hexdigit());
+		if is_hash
+			&& let Ok(mut cache) = self.blocks_by_hash.lock()
+			&& let Some(block) = cache.get(id)
+		{
+			return Ok(Some(block.clone()));
+		}
+		let _t = Timer::new(format!("GET blocks/{id}"));
+		match deadline(&format!("blocks/{id}"), self.api.blocks_by_id(id)).await? {
+			Ok(b) => {
+				let stable = u32::try_from(b.confirmations).unwrap_or(0) >= self.security_parameter;
+				if is_hash
+					&& stable && let Ok(mut cache) = self.blocks_by_hash.lock()
+				{
+					cache.put(id.to_string(), b.clone());
+				}
+				Ok(Some(b))
+			},
+			Err(e) if is_404(&e) => Ok(None),
+			Err(e) => Err(box_err(e)),
+		}
+	}
+
+	pub(crate) async fn tx_utxos(&self, tx_hash: &str) -> Result<TxContentUtxo, BoxError> {
+		let _t = Timer::new(format!("GET txs/{tx_hash}/utxos"));
+		deadline(&format!("txs/{tx_hash}/utxos"), self.api.transactions_utxos(tx_hash))
+			.await?
+			.map_err(box_err)
+	}
+
+	/// Resolve a Plutus datum: inline CBOR when present, otherwise `/scripts/datum/{hash}`.
+	///
+	/// The datum-by-hash path decodes the same detailed-schema JSON as db-sync's
+	/// `datum.value` JSONB, through the identical `encode_json_value_to_plutus_datum`
+	/// call, so all downstream datum parsers behave exactly as on the db-sync path.
+	pub(crate) async fn datum(
+		&self,
+		inline_datum: Option<&String>,
+		data_hash: Option<&String>,
+	) -> Result<Option<PlutusData>, BoxError> {
+		if let Some(cbor_hex) = inline_datum {
+			let datum = PlutusData::from_hex(cbor_hex)
+				.map_err(|e| format!("invalid inline datum CBOR: {e:?}"))?;
+			return Ok(Some(datum));
+		}
+		let Some(hash) = data_hash else {
+			return Ok(None);
+		};
+		let _t = Timer::new(format!("GET scripts/datum/{hash}"));
+		let value =
+			match deadline(&format!("scripts/datum/{hash}"), self.api.scripts_datum_hash(hash))
+				.await?
+			{
+				Ok(v) => v,
+				Err(e) if is_404(&e) => return Ok(None),
+				Err(e) => return Err(box_err(e)),
+			};
+		let json = value
+			.get("json_value")
+			.cloned()
+			.ok_or_else(|| format!("no json_value in datum response for {hash}"))?;
+		let datum = encode_json_value_to_plutus_datum(json, PlutusDatumSchema::DetailedSchema)
+			.map_err(|e| format!("invalid datum JSON for {hash}: {e:?}"))?;
+		Ok(Some(datum))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::testing::{
+		Reply, asset_txs_json, client_at, fake_server, over_quota_body, registration_datum_hex,
+	};
+	use super::*;
+	use cardano_serialization_lib::{
+		PlutusDatumSchema, decode_plutus_datum_to_json_value, encode_json_value_to_plutus_datum,
+	};
+
+	// These pin the mechanics the live parity test cannot reach without credentials:
+	// pagination termination, cursor forwarding, 404 handling, 429 retries and the
+	// deadline. Cursor forwarding matters most — the SDK honours `from`/`to` only on the
+	// account, address and asset transaction endpoints and drops them silently elsewhere,
+	// which an SDK upgrade could change without any compile error.
+
+	#[test]
+	fn detailed_schema_json_decodes_to_same_datum_as_inline_cbor() {
+		// The datum-by-hash path decodes Blockfrost's `json_value` (db-sync detailed
+		// schema JSON); it must yield the same PlutusData as the inline CBOR path.
+		let hex = registration_datum_hex([4u8; 28], [0xAB; 32]);
+		let from_cbor = PlutusData::from_hex(&hex).unwrap();
+		let json = decode_plutus_datum_to_json_value(&from_cbor, PlutusDatumSchema::DetailedSchema)
+			.unwrap();
+		let from_json =
+			encode_json_value_to_plutus_datum(json, PlutusDatumSchema::DetailedSchema).unwrap();
+		assert_eq!(from_cbor.to_hex(), from_json.to_hex());
+	}
+
+	#[tokio::test]
+	async fn raw_path_reports_over_quota_plainly() {
+		let (url, seen) = fake_server(vec![Reply::Json(402, over_quota_body())]).await;
+		let err = client_at(&url).tx_metadata_label("ab", "1").await.expect_err("402 must fail");
+		let message = err.to_string();
+		assert!(message.contains("over its request limit"), "{message}");
+		assert!(message.contains("402"), "{message}");
+		assert!(message.contains("will not progress"), "must explain the consequence: {message}");
+		assert_eq!(seen.lock().expect("seen").len(), 1, "402 must not be retried");
+	}
+
+	#[tokio::test]
+	async fn sdk_path_reports_over_quota_plainly() {
+		let (url, _seen) = fake_server(vec![Reply::Json(402, over_quota_body())]).await;
+		let err = client_at(&url)
+			.range_txs(TxSource::Asset("beef"), None, None)
+			.await
+			.expect_err("402 must fail");
+		let message = err.to_string();
+		assert!(message.contains("over its request limit"), "{message}");
+		assert!(
+			!message.contains("Blockfrost error:"),
+			"must not fall through to the generic error: {message}"
+		);
+	}
+
+	#[tokio::test]
+	async fn metadata_label_is_found_beyond_the_first_page() {
+		// A full page of unrelated labels, then the transfer label on page two. Stopping
+		// at page one would yield no recipient here while db-sync, which selects the row
+		// by key, still finds it — a divergence the sender can trigger at will.
+		let filler: Vec<String> = (0..PAGE_SIZE)
+			.map(|i| format!(r#"{{"label":"{i}","json_metadata":"x"}}"#))
+			.collect();
+		let page_one = format!("[{}]", filler.join(","));
+		let page_two = r#"[{"label":"6500973","json_metadata":["0xabcd"]}]"#.to_string();
+		let (url, seen) =
+			fake_server(vec![Reply::Json(200, page_one), Reply::Json(200, page_two)]).await;
+
+		let found = client_at(&url)
+			.tx_metadata_label("ab", "6500973")
+			.await
+			.expect("metadata lookup");
+
+		assert_eq!(found, Some(serde_json::json!(["0xabcd"])));
+		assert_eq!(seen.lock().expect("seen").len(), 2, "must walk to the second page");
+	}
+
+	#[tokio::test]
+	async fn paged_get_maps_404_to_empty_without_retrying() {
+		let (url, seen) = fake_server(vec![Reply::Json(404, "{}".into())]).await;
+		let found = client_at(&url)
+			.tx_metadata_label("ab", "1")
+			.await
+			.expect("404 is an empty result");
+		assert!(found.is_none());
+		assert_eq!(seen.lock().expect("seen").len(), 1, "a 404 must not be retried");
+	}
+
+	#[tokio::test]
+	async fn paged_get_retries_429_then_succeeds() {
+		let body = r#"[{"label":"1","json_metadata":"abc"}]"#;
+		let (url, seen) = fake_server(vec![
+			Reply::Json(429, "{}".into()),
+			Reply::Json(429, "{}".into()),
+			Reply::Json(200, body.into()),
+		])
+		.await;
+		let found = client_at(&url)
+			.tx_metadata_label("ab", "1")
+			.await
+			.expect("retried past the 429s");
+		assert_eq!(found, Some(serde_json::json!("abc")));
+		assert_eq!(seen.lock().expect("seen").len(), 3, "two 429s then the success");
+	}
+
+	#[tokio::test]
+	async fn paged_get_gives_up_after_the_retry_budget() {
+		let (url, seen) = fake_server(vec![Reply::Json(429, "{}".into())]).await;
+		let err = client_at(&url)
+			.tx_metadata_label("ab", "1")
+			.await
+			.expect_err("429 forever must fail");
+		assert!(err.to_string().contains("429"), "unexpected error: {err}");
+		assert_eq!(
+			seen.lock().expect("seen").len(),
+			RETRY_AMOUNT as usize + 1,
+			"the budget is attempts-after-the-first"
+		);
+	}
+
+	#[tokio::test]
+	async fn deadline_bounds_the_whole_retry_loop_not_each_attempt() {
+		// Each attempt answers just under the per-request bound, so only a loop-level
+		// deadline can stop the retries: per-attempt bounds alone would allow
+		// RETRY_AMOUNT of them to stack up.
+		let slow = || Reply::Slow(HTTP_TIMEOUT.mul_f32(0.75), 429, "{}".into());
+		let (url, seen) = fake_server(vec![slow(), slow(), slow(), slow()]).await;
+		let started = std::time::Instant::now();
+		let err = client_at(&url).tx_metadata_label("ab", "1").await.expect_err("must not run on");
+		let elapsed = started.elapsed();
+		assert!(err.to_string().contains("timed out"), "unexpected error: {err}");
+		assert!(elapsed < HTTP_TIMEOUT * 2, "not bounded by the deadline: {elapsed:?}");
+		assert!(
+			seen.lock().expect("seen").len() < RETRY_AMOUNT as usize,
+			"stopped before exhausting the retry budget"
+		);
+	}
+
+	#[tokio::test]
+	async fn range_txs_forwards_cursors_and_stops_on_a_short_page() {
+		let (url, seen) = fake_server(vec![
+			Reply::Json(200, asset_txs_json(PAGE_SIZE, 1)),
+			Reply::Json(200, asset_txs_json(2, PAGE_SIZE as u32 + 1)),
+		])
+		.await;
+		let rows = client_at(&url)
+			.range_txs(
+				TxSource::Asset("beef"),
+				Some(BlockCursor::block(10)),
+				Some(BlockCursor::block(999)),
+			)
+			.await
+			.expect("range_txs");
+
+		assert_eq!(rows.len(), PAGE_SIZE + 2, "rows from both pages are returned");
+		assert_eq!(rows[0].block_height, 1);
+		assert_eq!(rows[PAGE_SIZE + 1].block_height, PAGE_SIZE as u32 + 2);
+		let seen = seen.lock().expect("seen");
+		assert_eq!(seen.len(), 2, "stopped at the short page");
+		// The cursors must reach the wire: the SDK drops them for other endpoints.
+		assert!(seen[0].contains("from=10"), "`from` not forwarded: {}", seen[0]);
+		assert!(seen[0].contains("to=999"), "`to` not forwarded: {}", seen[0]);
+		assert!(seen[0].contains("order=asc"), "wrong order: {}", seen[0]);
+		assert!(seen[0].contains("/assets/beef/transactions"), "wrong path: {}", seen[0]);
+		assert!(seen[1].contains("page=2"), "second page not requested: {}", seen[1]);
+		assert!(seen[1].contains("from=10"), "cursor lost on page 2: {}", seen[1]);
+	}
+
+	#[tokio::test]
+	async fn range_txs_gives_up_when_the_pages_never_end() {
+		// A backend that ignores `page` and always answers with a full page: without the
+		// cap this walks for ever and grows `rows` without bound.
+		let (url, seen) = fake_server(vec![Reply::Json(200, asset_txs_json(PAGE_SIZE, 1))]).await;
+		let err = client_at(&url)
+			.range_txs(TxSource::Asset("beef"), None, None)
+			.await
+			.expect_err("must be bounded");
+		assert!(err.to_string().contains("without reaching the end"), "unexpected: {err}");
+		assert_eq!(seen.lock().expect("seen").len(), MAX_PAGES, "walked exactly the cap");
+	}
+}

--- a/node/src/blockfrost/cnight.rs
+++ b/node/src/blockfrost/cnight.rs
@@ -1,0 +1,912 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! cNIGHT observation data source: extracts registration, deregistration and token
+//! create/spend events from Cardano transactions, behind a sliding window cache.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use blockfrost::{
+	BlockCursor,
+	blockfrost_openapi::models::{block_content::BlockContent, tx_content_utxo::TxContentUtxo},
+};
+use cardano_serialization_lib::{
+	Address, BaseAddress, EnterpriseAddress, PlutusData, RewardAddress,
+};
+use midnight_primitives_cnight_observation as cnight;
+use midnight_primitives_cnight_observation::{CNightAddresses, CardanoPosition};
+use midnight_primitives_mainchain_follower::data_source::cnight_observation_bulk::truncate_to_tx_capacity;
+use midnight_primitives_mainchain_follower::data_source::metrics::{
+	MidnightDataSourceMetrics, start_sub_query_timer,
+};
+use midnight_primitives_mainchain_follower::{
+	MidnightCNightObservationDataSource, MidnightCNightObservationDataSourceImpl,
+};
+use sidechain_domain::*;
+
+use super::client::*;
+use super::convert::*;
+use super::support::*;
+
+/// Blockfrost block times are unix seconds; [CardanoPosition] carries milliseconds.
+fn cardano_position(b: &BlockContent) -> Result<CardanoPosition, BoxError> {
+	Ok(CardanoPosition {
+		block_hash: McBlockHash(decode_hash32(&b.hash)?),
+		block_number: block_height(b)?,
+		block_timestamp: cnight::TimestampUnixMillis(i64::from(b.time) * 1000),
+		tx_index_in_block: u32::try_from(b.tx_count)?,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// cNIGHT observation
+// ---------------------------------------------------------------------------
+
+/// Config-derived query inputs, mirroring the derivation in `bulk_pull`.
+struct CNightQueryConfig {
+	cardano_network: u8,
+	mapping_validator_address: String,
+	auth_unit: String,
+	cnight_unit: String,
+}
+
+impl CNightQueryConfig {
+	fn derive(config: &CNightAddresses) -> Result<Self, BoxError> {
+		let mapping_validator_address = Address::from_bech32(&config.mapping_validator_address)
+			.map_err(|e| format!("invalid mapping validator address: {e:?}"))?;
+		let cardano_network = mapping_validator_address
+			.network_id()
+			.map_err(|e| format!("failed to extract network id: {e:?}"))?;
+		let mapping_validator_policy_id =
+			EnterpriseAddress::from_address(&mapping_validator_address)
+				.ok_or("mapping validator address is not an EnterpriseAddress")?
+				.payment_cred()
+				.to_scripthash()
+				.ok_or("mapping validator address has no script hash")?;
+		Ok(Self {
+			cardano_network,
+			mapping_validator_address: config.mapping_validator_address.clone(),
+			auth_unit: format!(
+				"{}{}",
+				hex::encode(mapping_validator_policy_id.to_bytes()),
+				hex::encode(config.auth_token_asset_name.as_bytes())
+			),
+			cnight_unit: format!(
+				"{}{}",
+				hex::encode(config.cnight_policy_id),
+				hex::encode(config.cnight_asset_name.as_bytes())
+			),
+		})
+	}
+}
+
+/// Maps a bech32 holder address to the 29-byte reward address of its stake credential.
+/// Non-base addresses (enterprise, pointer, reward) carry no stake credential and are
+/// skipped, exactly like the db-sync implementation.
+fn holder_reward_address(
+	cardano_network: u8,
+	bech32_address: &str,
+) -> Option<cnight::CardanoRewardAddressBytes> {
+	let Ok(address) = Address::from_bech32(bech32_address) else {
+		log::debug!("Cardano address {bech32_address:?} not valid bech32 cardano address");
+		return None;
+	};
+	let base_address = BaseAddress::from_address(&address)?;
+	let reward_address = RewardAddress::new(cardano_network, &base_address.stake_cred());
+	// Unwrap here is OK - we know the reward_address is always 29 bytes
+	Some(cnight::CardanoRewardAddressBytes(
+		reward_address.to_address().to_bytes().try_into().unwrap(),
+	))
+}
+
+/// Decodes a registration datum into the reward-address + dust-key pair, reusing the
+/// db-sync decoder. Returns `None` (with an error log) on malformed datums — such
+/// events are skipped, not errors, to match db-sync behavior.
+fn registration_pair(
+	cardano_network: u8,
+	datum: &PlutusData,
+	context: &cnight::ObservedUtxoHeader,
+) -> Option<(cnight::CardanoRewardAddressBytes, cnight::DustPublicKeyBytes)> {
+	let Some(constr) = datum.as_constr_plutus_data() else {
+		log::error!("Plutus data for mapping validator not Constr ({context:?})");
+		return None;
+	};
+	let (credential, dust_public_key) =
+		match MidnightCNightObservationDataSourceImpl::decode_registration_datum(constr) {
+			Ok(pair) => pair,
+			Err(e) => {
+				log::error!("Failed to decode registration datum: {e:?} ({context:?})");
+				return None;
+			},
+		};
+	let reward_address = RewardAddress::new(cardano_network, &credential);
+	// Unwrap here is OK - we know the reward_address is always 29 bytes
+	let cardano_address = reward_address.to_address().to_bytes().try_into().unwrap();
+	Some((cnight::CardanoRewardAddressBytes(cardano_address), dust_public_key))
+}
+
+/// All cNIGHT observation events of a single transaction, mirroring the four db-sync
+/// range queries:
+/// - Registration: output at the mapping validator address holding **exactly 1** auth
+///   token, with a datum.
+/// - Deregistration: spent input at the mapping validator address with a datum
+///   (no token check — same as the SQL).
+/// - AssetCreate / AssetSpend: outputs / spent inputs carrying the cNIGHT asset.
+///
+/// Collateral outputs and collateral/reference inputs are excluded: db-sync's
+/// `tx_out`/`tx_in` tables only contain regular inputs and outputs.
+async fn tx_cnight_events(
+	client: &BlockfrostClient,
+	cfg: &CNightQueryConfig,
+	tx_position: &CardanoPosition,
+	utxos: &TxContentUtxo,
+) -> Result<Vec<cnight::ObservedUtxo>, BoxError> {
+	let tx_hash = McTxHash(decode_hash32(&utxos.hash)?);
+	let mut events = Vec::new();
+
+	for output in utxos.outputs.iter().filter(|o| !o.collateral) {
+		let utxo_index = cnight::UtxoIndexInTx(u16::try_from(output.output_index)?);
+		let header = cnight::ObservedUtxoHeader {
+			tx_position: tx_position.clone(),
+			tx_hash,
+			utxo_tx_hash: tx_hash,
+			utxo_index,
+		};
+		if output.address == cfg.mapping_validator_address
+			&& amount_of(&output.amount, &cfg.auth_unit)? == 1
+			&& (output.inline_datum.is_some() || output.data_hash.is_some())
+		{
+			let datum =
+				client.datum(output.inline_datum.as_ref(), output.data_hash.as_ref()).await?;
+			if let Some(datum) = datum
+				&& let Some((cardano_reward_address, dust_public_key)) =
+					registration_pair(cfg.cardano_network, &datum, &header)
+			{
+				events.push(cnight::ObservedUtxo {
+					header: header.clone(),
+					data: cnight::ObservedUtxoData::Registration(cnight::RegistrationData {
+						cardano_reward_address,
+						dust_public_key,
+					}),
+				});
+			}
+		}
+		let quantity = amount_of(&output.amount, &cfg.cnight_unit)?;
+		if quantity > 0
+			&& let Some(owner) = holder_reward_address(cfg.cardano_network, &output.address)
+		{
+			events.push(cnight::ObservedUtxo {
+				header,
+				data: cnight::ObservedUtxoData::AssetCreate(cnight::CreateData {
+					value: quantity,
+					owner,
+					utxo_tx_hash: tx_hash,
+					utxo_tx_index: utxo_index.0,
+				}),
+			});
+		}
+	}
+
+	for input in utxos.inputs.iter().filter(|i| !i.collateral && !i.reference.unwrap_or(false)) {
+		let utxo_tx_hash = McTxHash(decode_hash32(&input.tx_hash)?);
+		let utxo_index = cnight::UtxoIndexInTx(u16::try_from(input.output_index)?);
+		let header = cnight::ObservedUtxoHeader {
+			tx_position: tx_position.clone(),
+			tx_hash,
+			utxo_tx_hash,
+			utxo_index,
+		};
+		if input.address == cfg.mapping_validator_address
+			&& (input.inline_datum.is_some() || input.data_hash.is_some())
+		{
+			let datum = client.datum(input.inline_datum.as_ref(), input.data_hash.as_ref()).await?;
+			if let Some(datum) = datum
+				&& let Some((cardano_reward_address, dust_public_key)) =
+					registration_pair(cfg.cardano_network, &datum, &header)
+			{
+				events.push(cnight::ObservedUtxo {
+					header: header.clone(),
+					data: cnight::ObservedUtxoData::Deregistration(cnight::DeregistrationData {
+						cardano_reward_address,
+						dust_public_key,
+					}),
+				});
+			}
+		}
+		let quantity = amount_of(&input.amount, &cfg.cnight_unit)?;
+		if quantity > 0
+			&& let Some(owner) = holder_reward_address(cfg.cardano_network, &input.address)
+		{
+			events.push(cnight::ObservedUtxo {
+				header,
+				data: cnight::ObservedUtxoData::AssetSpend(cnight::SpendData {
+					value: quantity,
+					owner,
+					utxo_tx_hash,
+					utxo_tx_index: utxo_index.0,
+					spending_tx_hash: tx_hash,
+				}),
+			});
+		}
+	}
+
+	Ok(events)
+}
+
+/// Contiguous range of already-fetched observation events.
+///
+/// Events are complete for `[covered_from, covered_to_block]` (inclusive;
+/// `covered_to_block == None` means nothing fetched yet). Serving from the window
+/// is valid in exactly the two cases where the result provably equals a full
+/// `[start, tip]` fetch (see `get_utxos_up_to_capacity`).
+struct EventWindow {
+	// Query identity — reset the window if the runtime config ever changes.
+	mapping_validator_address: String,
+	auth_unit: String,
+	cnight_unit: String,
+	/// Exact `(block, tx_index)` lower bound of coverage.
+	covered_from: (u32, u32),
+	covered_to_block: Option<u32>,
+	/// All events in the covered range, sorted by `ObservedUtxo::Ord`.
+	events: Vec<cnight::ObservedUtxo>,
+}
+
+/// What the extension loop should fetch next, and whether the result may be
+/// cached (only ranges entirely at or below the stable height are immutable).
+#[derive(Debug, PartialEq)]
+enum FetchPlan {
+	/// Fetch `[from, to_block]` and append it to the cached window.
+	Cached { from: (u32, u32), to_block: u32 },
+	/// Remainder reaches above the stable height: fetch `[from, tip_block]` for
+	/// this call only, without caching.
+	Uncached { from: (u32, u32) },
+}
+
+/// Pure extension planning, factored out for testability.
+///
+/// `window_blocks` is `cnight_observation_window_size`: the Cardano blocks fetched per
+/// extension. Consumed events are pruned as `start` advances, so it is also roughly the
+/// retained history. Bigger means fewer but proportionally longer fetches — the total
+/// request count is unchanged, since each transaction is fetched exactly once either way.
+fn plan_extension(
+	covered_to_block: Option<u32>,
+	covered_from: (u32, u32),
+	tip_block: u32,
+	stable_height: u32,
+	window_blocks: u32,
+) -> FetchPlan {
+	let from = match covered_to_block {
+		None => covered_from,
+		// Never fetch below the (pruned) coverage bound: when `start` has advanced past
+		// stale coverage, the blocks in between hold nothing we would serve.
+		Some(covered) => (covered + 1, 0).max(covered_from),
+	};
+	let to_block = tip_block.min(from.0.saturating_add(window_blocks.saturating_sub(1)));
+	if to_block <= stable_height {
+		FetchPlan::Cached { from, to_block }
+	} else if from.0 <= stable_height {
+		FetchPlan::Cached { from, to_block: stable_height }
+	} else {
+		FetchPlan::Uncached { from }
+	}
+}
+
+fn event_key(event: &cnight::ObservedUtxo) -> (u32, u32) {
+	(event.header.tx_position.block_number, event.header.tx_position.tx_index_in_block)
+}
+
+/// Events within `[start, end)` — the bounds the db-sync SQL applies to its queries.
+///
+/// The cached window can legitimately hold events outside the requested range: its
+/// coverage may extend past a lower tip (sibling blocks referencing different Cardano
+/// tips) or start below `start` (coverage predating a position jump). Bounding here
+/// keeps the served set identical to a fresh `[start, end)` fetch regardless of how
+/// coverage was accumulated.
+fn bounded_events(
+	events: &[cnight::ObservedUtxo],
+	start: (u32, u32),
+	end: (u32, u32),
+) -> Vec<cnight::ObservedUtxo> {
+	events
+		.iter()
+		.filter(|e| {
+			let key = event_key(e);
+			key >= start && key < end
+		})
+		.cloned()
+		.collect()
+}
+
+/// Windowed cNIGHT observation source. Semantically identical to a per-call full
+/// `[start, tip]` fetch (which mirrors `MidnightCNightObservationDataSourceImpl`),
+/// but fetches the range in bounded windows and serves consecutive Midnight blocks
+/// from the accumulated events — the Blockfrost equivalent of the db-sync sliding
+/// window cache. Without this, a network whose cNIGHT genesis anchor lies far in
+/// the past (e.g. preview's block-0 anchor) re-scans the whole history per block.
+pub struct BlockfrostCNightObservationDataSource {
+	client: Arc<BlockfrostClient>,
+	security_parameter: u32,
+	/// `cnight_observation_window_size`: Cardano blocks per window extension.
+	window_blocks: u32,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
+	/// Async mutex: held across fetches, serializing observation calls the same
+	/// way the db-sync bulk cache single-flights its refreshes.
+	window: tokio::sync::Mutex<Option<EventWindow>>,
+}
+
+impl BlockfrostCNightObservationDataSource {
+	pub fn new(
+		client: Arc<BlockfrostClient>,
+		security_parameter: u32,
+		window_blocks: u32,
+		metrics_opt: Option<MidnightDataSourceMetrics>,
+	) -> Self {
+		Self {
+			client,
+			security_parameter,
+			window_blocks,
+			metrics_opt,
+			window: tokio::sync::Mutex::new(None),
+		}
+	}
+
+	/// Fetch and expand all observation events in the inclusive range
+	/// `[from.0:from.1, to_block]`, sorted.
+	async fn fetch_events(
+		&self,
+		cfg: &CNightQueryConfig,
+		from: (u32, u32),
+		to_block: u32,
+	) -> Result<Vec<cnight::ObservedUtxo>, BoxError> {
+		let _t = Timer::new(format!("fetch_events[{}:{} -> {to_block}]", from.0, from.1));
+		// The asset scan lists transactions that *produce* an output holding cNIGHT, so a
+		// transaction that burned cNIGHT outright would not appear here, while db-sync
+		// finds it through the spent output. This relies on the cNIGHT policy never
+		// burning; if that changes, burns have to be picked up from the asset's
+		// mint/burn history as well.
+		let from_cursor = Some(BlockCursor::tx(u64::from(from.0), from.1));
+		let to_cursor = Some(BlockCursor::block(u64::from(to_block)));
+		let (address_rows, asset_rows) = tokio::try_join!(
+			self.client.range_txs(
+				TxSource::Address(&cfg.mapping_validator_address),
+				from_cursor,
+				to_cursor,
+			),
+			self.client.range_txs(TxSource::Asset(&cfg.cnight_unit), from_cursor, to_cursor),
+		)?;
+
+		// One entry per distinct tx: a tx present in both scans produces all its event
+		// kinds in a single pass, which is equivalent to the four independent SQL scans.
+		let mut txs: HashMap<String, RangeTx> = HashMap::new();
+		for row in address_rows.into_iter().chain(asset_rows) {
+			txs.entry(row.tx_hash.clone()).or_insert(row);
+		}
+
+		// Block hash per height (the tx lists don't carry it).
+		let mut block_hashes: HashMap<u32, McBlockHash> = HashMap::new();
+		let mut events: Vec<cnight::ObservedUtxo> = Vec::new();
+		for row in txs.values() {
+			let block_hash = match block_hashes.get(&row.block_height) {
+				Some(hash) => hash.clone(),
+				None => {
+					let block = self
+						.client
+						.block_by_id(&row.block_height.to_string())
+						.await?
+						.ok_or_else(|| format!("block {} not found", row.block_height))?;
+					let hash = McBlockHash(decode_hash32(&block.hash)?);
+					block_hashes.insert(row.block_height, hash.clone());
+					hash
+				},
+			};
+			let tx_position = CardanoPosition {
+				block_hash,
+				block_number: row.block_height,
+				block_timestamp: cnight::TimestampUnixMillis(i64::try_from(row.block_time)? * 1000),
+				tx_index_in_block: row.tx_index,
+			};
+			let utxos = self.client.tx_utxos(&row.tx_hash).await?;
+			events.extend(tx_cnight_events(&self.client, cfg, &tx_position, &utxos).await?);
+		}
+
+		// Deterministic consensus ordering comes only from `ObservedUtxo::Ord`
+		// (tx position, create-before-spend, utxo identity) — never from API order.
+		events.sort();
+		Ok(events)
+	}
+}
+
+#[async_trait::async_trait]
+impl MidnightCNightObservationDataSource for BlockfrostCNightObservationDataSource {
+	async fn get_utxos_up_to_capacity(
+		&self,
+		config: &CNightAddresses,
+		start_position: &CardanoPosition,
+		current_tip: McBlockHash,
+		tx_capacity: usize,
+		// Deliberately unused, which matches the bulk cache: when
+		// `BulkCachedCNightObservationDataSource` serves from its window it applies only
+		// `truncate_to_tx_capacity` and never this bound, and its refresh pulls with a
+		// wide `LARGE_LIMIT` in place of it (`cnight_observation_bulk.rs`). The direct SQL
+		// path does apply it, as a per-category `LIMIT` across four queries, so the two
+		// upstream paths already diverge once it binds — one fat transaction with more
+		// than the bound's worth of outputs in a single category is enough. That
+		// truncation is also not reproducible: three of the four `ORDER BY` clauses are
+		// not total orders, so the rows kept at the boundary are whatever Postgres
+		// happens to return. We fetch the exact range instead.
+		_utxo_overestimate: usize,
+	) -> Result<cnight::ObservedUtxos, BoxError> {
+		let _t = Timer::new(format!(
+			"get_utxos_up_to_capacity[start={}:{}, tip={current_tip}]",
+			start_position.block_number, start_position.tx_index_in_block
+		));
+
+		let tip = {
+			let _sq_timer = start_sub_query_timer(&self.metrics_opt, "cnight_get_block_by_hash");
+			self.client
+				.block_by_id(&hex::encode(current_tip.0))
+				.await?
+				.ok_or_else(|| format!("missing reference for block hash `{current_tip}`"))?
+		};
+		// Historic replay semantics: query through the block's Cardano tip and only then
+		// truncate by tx capacity. Clipping the range earlier changes the inherent
+		// payload and breaks imports of already-authored blocks.
+		let end = cardano_position(&tip)?.increment();
+		let tip_block = block_height(&tip)?;
+		let cfg = CNightQueryConfig::derive(config)?;
+		let start_key = (start_position.block_number, start_position.tx_index_in_block);
+
+		let mut window_guard = self.window.lock().await;
+
+		// (Re)initialize when the window can't serve this query: first call, config
+		// change, or a start below current coverage (e.g. reorg or restart).
+		let usable = window_guard.as_ref().is_some_and(|w| {
+			w.mapping_validator_address == cfg.mapping_validator_address
+				&& w.auth_unit == cfg.auth_unit
+				&& w.cnight_unit == cfg.cnight_unit
+				&& w.covered_from <= start_key
+		});
+		if !usable {
+			*window_guard = Some(EventWindow {
+				mapping_validator_address: cfg.mapping_validator_address.clone(),
+				auth_unit: cfg.auth_unit.clone(),
+				cnight_unit: cfg.cnight_unit.clone(),
+				covered_from: start_key,
+				covered_to_block: None,
+				events: Vec::new(),
+			});
+		}
+		let window = window_guard.as_mut().expect("initialized above");
+
+		// `start` advances monotonically during sync: prune consumed events so the
+		// window holds at most one window's worth of history.
+		if start_key > window.covered_from {
+			window.events.retain(|e| event_key(e) >= start_key);
+			window.covered_from = start_key;
+		}
+
+		// Stable height resolved lazily — only extensions need it.
+		let mut stable_height: Option<u32> = None;
+
+		let end_key = (end.block_number, end.tx_index_in_block);
+		loop {
+			// Serving is valid in exactly two cases, both decided by the truncation
+			// helper over the covered events (bounded to the requested range):
+			// (a) capacity binds inside covered range: events past the cut point can't
+			//     affect the result, so unfetched range beyond coverage is irrelevant;
+			// (b) coverage reaches the tip: the event set is complete for [start, tip].
+			let (result, full_window) = truncate_to_tx_capacity(
+				bounded_events(&window.events, start_key, end_key),
+				tx_capacity,
+				start_position,
+				end.clone(),
+			);
+			if !full_window || window.covered_to_block.is_some_and(|c| c >= tip_block) {
+				return Ok(result);
+			}
+
+			if stable_height.is_none() {
+				let _t = Timer::new("GET blocks/latest (stable height)");
+				let latest = deadline("blocks/latest", self.client.api.blocks_latest())
+					.await?
+					.map_err(box_err)?;
+				stable_height =
+					Some(block_height(&latest)?.saturating_sub(self.security_parameter));
+			}
+
+			match plan_extension(
+				window.covered_to_block,
+				window.covered_from,
+				tip_block,
+				stable_height.expect("resolved above"),
+				self.window_blocks,
+			) {
+				FetchPlan::Cached { from, to_block } => {
+					let new_events = self.fetch_events(&cfg, from, to_block).await?;
+					window.events.extend(new_events);
+					window.events.sort();
+					window.covered_to_block = Some(to_block);
+				},
+				FetchPlan::Uncached { from } => {
+					// The remainder reaches above the stable height, where blocks can
+					// still be rolled back: serve it for this call without caching.
+					// (Rare: referenced tips are k-deep by the mc-hash stability rules.)
+					let overlay = self.fetch_events(&cfg, from, tip_block).await?;
+					let mut combined = window.events.clone();
+					combined.extend(overlay);
+					combined.sort();
+					let (result, _) = truncate_to_tx_capacity(
+						bounded_events(&combined, start_key, end_key),
+						tx_capacity,
+						start_position,
+						end,
+					);
+					return Ok(result);
+				},
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::testing::registration_datum_hex;
+	use super::*;
+	use blockfrost::blockfrost_openapi::models::tx_content_output_amount_inner::TxContentOutputAmountInner;
+	use blockfrost::blockfrost_openapi::models::{
+		tx_content_utxo_inputs_inner::TxContentUtxoInputsInner,
+		tx_content_utxo_outputs_inner::TxContentUtxoOutputsInner,
+	};
+	use cardano_serialization_lib::{Credential, Ed25519KeyHash, ScriptHash};
+
+	const NETWORK: u8 = 0;
+
+	fn script_hash() -> ScriptHash {
+		ScriptHash::from_bytes(vec![7u8; 28]).unwrap()
+	}
+
+	fn mapping_validator_address() -> String {
+		EnterpriseAddress::new(NETWORK, &Credential::from_scripthash(&script_hash()))
+			.to_address()
+			.to_bech32(None)
+			.unwrap()
+	}
+
+	fn holder_stake_cred() -> Credential {
+		Credential::from_keyhash(&Ed25519KeyHash::from_bytes(vec![2u8; 28]).unwrap())
+	}
+
+	fn holder_base_address() -> String {
+		BaseAddress::new(
+			NETWORK,
+			&Credential::from_keyhash(&Ed25519KeyHash::from_bytes(vec![1u8; 28]).unwrap()),
+			&holder_stake_cred(),
+		)
+		.to_address()
+		.to_bech32(None)
+		.unwrap()
+	}
+
+	fn holder_enterprise_address() -> String {
+		EnterpriseAddress::new(
+			NETWORK,
+			&Credential::from_keyhash(&Ed25519KeyHash::from_bytes(vec![3u8; 28]).unwrap()),
+		)
+		.to_address()
+		.to_bech32(None)
+		.unwrap()
+	}
+
+	fn cnight_addresses() -> CNightAddresses {
+		CNightAddresses {
+			mapping_validator_address: mapping_validator_address(),
+			auth_token_asset_name: "auth".into(),
+			cnight_policy_id: [9u8; 28],
+			cnight_asset_name: "cNIGHT".into(),
+		}
+	}
+
+	fn query_config() -> CNightQueryConfig {
+		CNightQueryConfig::derive(&cnight_addresses()).unwrap()
+	}
+
+	fn amount(unit: &str, quantity: &str) -> TxContentOutputAmountInner {
+		TxContentOutputAmountInner { unit: unit.into(), quantity: quantity.into() }
+	}
+
+	fn output(
+		address: &str,
+		index: i32,
+		amounts: Vec<TxContentOutputAmountInner>,
+		inline_datum: Option<String>,
+		collateral: bool,
+	) -> TxContentUtxoOutputsInner {
+		TxContentUtxoOutputsInner {
+			address: address.into(),
+			amount: amounts,
+			output_index: index,
+			data_hash: None,
+			inline_datum,
+			collateral,
+			reference_script_hash: None,
+			consumed_by_tx: None,
+		}
+	}
+
+	fn input(
+		address: &str,
+		tx_hash: &str,
+		index: i32,
+		amounts: Vec<TxContentOutputAmountInner>,
+		inline_datum: Option<String>,
+		collateral: bool,
+		reference: bool,
+	) -> TxContentUtxoInputsInner {
+		TxContentUtxoInputsInner {
+			address: address.into(),
+			amount: amounts,
+			tx_hash: tx_hash.into(),
+			output_index: index,
+			data_hash: None,
+			inline_datum,
+			reference_script_hash: None,
+			collateral,
+			reference: Some(reference),
+		}
+	}
+
+	fn test_client() -> BlockfrostClient {
+		// Never contacted: the tests only use inline datums.
+		BlockfrostClient::new("http://127.0.0.1:1", None, 432).unwrap()
+	}
+
+	fn test_position() -> CardanoPosition {
+		CardanoPosition {
+			block_hash: McBlockHash([0xBB; 32]),
+			block_number: 100,
+			block_timestamp: cnight::TimestampUnixMillis(1_700_000_000_000),
+			tx_index_in_block: 3,
+		}
+	}
+
+	fn expected_holder_reward_address() -> cnight::CardanoRewardAddressBytes {
+		cnight::CardanoRewardAddressBytes(
+			RewardAddress::new(NETWORK, &holder_stake_cred())
+				.to_address()
+				.to_bytes()
+				.try_into()
+				.unwrap(),
+		)
+	}
+
+	const TX_HASH_HEX: &str = "c000000000000000000000000000000000000000000000000000000000000002";
+
+	const SPENT_TX_HASH_HEX: &str =
+		"c000000000000000000000000000000000000000000000000000000000000001";
+
+	#[tokio::test]
+	async fn cnight_events_from_a_tx() {
+		let cfg = query_config();
+		let dust_key = [0xAB; 32];
+		let datum_hex = registration_datum_hex([4u8; 28], dust_key);
+		let utxos = TxContentUtxo {
+			hash: TX_HASH_HEX.into(),
+			inputs: vec![
+				// deregistration: spent mapping-validator UTXO with datum
+				input(
+					&cfg.mapping_validator_address,
+					SPENT_TX_HASH_HEX,
+					1,
+					vec![amount(&cfg.auth_unit, "1")],
+					Some(datum_hex.clone()),
+					false,
+					false,
+				),
+				// cNIGHT spend from a base address
+				input(
+					&holder_base_address(),
+					SPENT_TX_HASH_HEX,
+					2,
+					vec![amount("lovelace", "2000000"), amount(&cfg.cnight_unit, "500")],
+					None,
+					false,
+					false,
+				),
+				// collateral input carrying cNIGHT: must be ignored
+				input(
+					&holder_base_address(),
+					SPENT_TX_HASH_HEX,
+					3,
+					vec![amount(&cfg.cnight_unit, "77")],
+					None,
+					true,
+					false,
+				),
+				// reference input carrying cNIGHT: must be ignored
+				input(
+					&holder_base_address(),
+					SPENT_TX_HASH_HEX,
+					4,
+					vec![amount(&cfg.cnight_unit, "88")],
+					None,
+					false,
+					true,
+				),
+			],
+			outputs: vec![
+				// registration: exactly 1 auth token + datum at the mapping validator
+				output(
+					&cfg.mapping_validator_address,
+					0,
+					vec![amount(&cfg.auth_unit, "1")],
+					Some(datum_hex.clone()),
+					false,
+				),
+				// auth quantity != 1: not a registration
+				output(
+					&cfg.mapping_validator_address,
+					1,
+					vec![amount(&cfg.auth_unit, "2")],
+					Some(datum_hex.clone()),
+					false,
+				),
+				// cNIGHT create at a base address
+				output(
+					&holder_base_address(),
+					2,
+					vec![amount(&cfg.cnight_unit, "500")],
+					None,
+					false,
+				),
+				// cNIGHT at an enterprise address: no stake credential, skipped
+				output(
+					&holder_enterprise_address(),
+					3,
+					vec![amount(&cfg.cnight_unit, "10")],
+					None,
+					false,
+				),
+				// collateral output carrying cNIGHT: must be ignored
+				output(&holder_base_address(), 4, vec![amount(&cfg.cnight_unit, "20")], None, true),
+			],
+		};
+
+		let mut events =
+			tx_cnight_events(&test_client(), &cfg, &test_position(), &utxos).await.unwrap();
+		events.sort();
+
+		let tx_hash = McTxHash(decode_hash32(TX_HASH_HEX).unwrap());
+		let spent_tx_hash = McTxHash(decode_hash32(SPENT_TX_HASH_HEX).unwrap());
+		let expected_registration_reward_address = cnight::CardanoRewardAddressBytes(
+			RewardAddress::new(
+				NETWORK,
+				&Credential::from_keyhash(&Ed25519KeyHash::from_bytes(vec![4u8; 28]).unwrap()),
+			)
+			.to_address()
+			.to_bytes()
+			.try_into()
+			.unwrap(),
+		);
+
+		assert_eq!(events.len(), 4);
+		let kinds: Vec<&cnight::ObservedUtxoData> = events.iter().map(|e| &e.data).collect();
+		match &kinds[..] {
+			[
+				cnight::ObservedUtxoData::Registration(registration),
+				cnight::ObservedUtxoData::AssetCreate(create),
+				cnight::ObservedUtxoData::Deregistration(deregistration),
+				cnight::ObservedUtxoData::AssetSpend(spend),
+			] => {
+				assert_eq!(&registration.dust_public_key.0[..], &dust_key[..]);
+				assert_eq!(
+					registration.cardano_reward_address,
+					expected_registration_reward_address
+				);
+				assert_eq!(create.value, 500);
+				assert_eq!(create.owner, expected_holder_reward_address());
+				assert_eq!(create.utxo_tx_hash, tx_hash);
+				assert_eq!(create.utxo_tx_index, 2);
+				assert_eq!(&deregistration.dust_public_key.0[..], &dust_key[..]);
+				assert_eq!(spend.value, 500);
+				assert_eq!(spend.owner, expected_holder_reward_address());
+				assert_eq!(spend.utxo_tx_hash, spent_tx_hash);
+				assert_eq!(spend.utxo_tx_index, 2);
+				assert_eq!(spend.spending_tx_hash, tx_hash);
+			},
+			other => panic!("unexpected events: {other:?}"),
+		}
+
+		// Deregistration header points at the spent UTXO, positioned at the spending tx.
+		let deregistration = &events[2];
+		assert_eq!(deregistration.header.tx_hash, tx_hash);
+		assert_eq!(deregistration.header.utxo_tx_hash, spent_tx_hash);
+		assert_eq!(deregistration.header.utxo_index.0, 1);
+		assert_eq!(deregistration.header.tx_position, test_position());
+	}
+
+	fn event_at(block: u32, tx_index: u32) -> cnight::ObservedUtxo {
+		cnight::ObservedUtxo {
+			header: cnight::ObservedUtxoHeader {
+				tx_position: CardanoPosition {
+					block_hash: McBlockHash([0xAA; 32]),
+					block_number: block,
+					block_timestamp: cnight::TimestampUnixMillis(0),
+					tx_index_in_block: tx_index,
+				},
+				tx_hash: McTxHash([1; 32]),
+				utxo_tx_hash: McTxHash([1; 32]),
+				utxo_index: cnight::UtxoIndexInTx(0),
+			},
+			data: cnight::ObservedUtxoData::AssetCreate(cnight::CreateData {
+				value: 1,
+				owner: expected_holder_reward_address(),
+				utxo_tx_hash: McTxHash([1; 32]),
+				utxo_tx_index: 0,
+			}),
+		}
+	}
+
+	#[test]
+	fn bounded_events_applies_sql_range_bounds() {
+		let events: Vec<_> = [(100, 0), (200, 5), (300, 0), (300, 7), (400, 0)]
+			.map(|(b, i)| event_at(b, i))
+			.into();
+		// A cached window wider than the request on both sides serves only [start, end).
+		let served = bounded_events(&events, (200, 5), (300, 8));
+		assert_eq!(
+			served.iter().map(event_key).collect::<Vec<_>>(),
+			vec![(200, 5), (300, 0), (300, 7)]
+		);
+		// Start bound is inclusive, end bound exclusive.
+		assert_eq!(bounded_events(&events, (200, 6), (300, 7)).len(), 1);
+		// A tip below all coverage serves nothing (sibling block with a lower tip).
+		assert!(bounded_events(&events, (100, 0), (100, 0)).is_empty());
+	}
+
+	#[test]
+	fn plan_extension_windows_and_stable_clamp() {
+		// Any span works; this was the hard-coded value before it came from config.
+		const SPAN: u32 = 50_000;
+		// Fresh window: fetch starts at the exact (block, tx_index) coverage bound.
+		assert_eq!(
+			plan_extension(None, (100, 3), 1_000, 1_000_000, SPAN),
+			FetchPlan::Cached { from: (100, 3), to_block: 1_000 }
+		);
+		// Extension continues at covered+1, index 0, clamped to the window span.
+		assert_eq!(
+			plan_extension(Some(1_000), (100, 3), 1_000_000, 2_000_000, SPAN),
+			FetchPlan::Cached { from: (1_001, 0), to_block: 1_000 + SPAN }
+		);
+		// Tip clamps below the window size.
+		assert_eq!(
+			plan_extension(Some(1_000), (100, 3), 20_000, 2_000_000, SPAN),
+			FetchPlan::Cached { from: (1_001, 0), to_block: 20_000 }
+		);
+		// Range crossing the stable height caches only the stable part.
+		assert_eq!(
+			plan_extension(Some(1_000), (100, 3), 40_000, 30_000, SPAN),
+			FetchPlan::Cached { from: (1_001, 0), to_block: 30_000 }
+		);
+		// Entirely above the stable height: fetch without caching.
+		assert_eq!(
+			plan_extension(Some(30_000), (100, 3), 40_000, 30_000, SPAN),
+			FetchPlan::Uncached { from: (30_001, 0) }
+		);
+		// `start` advanced past stale coverage: never fetch below the coverage bound.
+		assert_eq!(
+			plan_extension(Some(200), (300, 0), 1_000, 1_000_000, SPAN),
+			FetchPlan::Cached { from: (300, 0), to_block: 1_000 }
+		);
+	}
+}

--- a/node/src/blockfrost/convert.rs
+++ b/node/src/blockfrost/convert.rs
@@ -1,0 +1,59 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Small pure conversions shared by more than one data source. No I/O here.
+
+use blockfrost::blockfrost_openapi::models::{
+	block_content::BlockContent, tx_content_output_amount_inner::TxContentOutputAmountInner,
+};
+
+use super::support::BoxError;
+
+pub(crate) fn decode_hash32(hex_str: &str) -> Result<[u8; 32], BoxError> {
+	let bytes = hex::decode(hex_str)?;
+	bytes
+		.try_into()
+		.map_err(|_| format!("expected 32-byte hash, got {hex_str}").into())
+}
+
+pub(crate) fn block_height(b: &BlockContent) -> Result<u32, BoxError> {
+	Ok(u32::try_from(b.height.ok_or("block has no height")?)?)
+}
+
+/// Whether the amount list carries `unit` at all. Cardano outputs never hold a
+/// zero quantity of an asset, so presence is equivalent to a positive amount, and
+/// this avoids parsing a quantity that is not needed.
+pub(crate) fn has_unit(amounts: &[TxContentOutputAmountInner], unit: &str) -> bool {
+	amounts.iter().any(|a| a.unit == unit)
+}
+
+/// Sum of `unit` in an amount list. A unit appears at most once per input/output,
+/// but summing is harmless and matches SQL `SUM(quantity)` semantics.
+///
+/// A quantity that does not parse is an error rather than a zero: db-sync rejects
+/// such a value, so silently dropping it here would put different data into the
+/// inherent than a db-sync backed node produces.
+pub(crate) fn amount_of(
+	amounts: &[TxContentOutputAmountInner],
+	unit: &str,
+) -> Result<u128, BoxError> {
+	let mut total: u128 = 0;
+	for amount in amounts.iter().filter(|a| a.unit == unit) {
+		let quantity: u128 = amount
+			.quantity
+			.parse()
+			.map_err(|e| format!("invalid quantity {:?} for unit {unit}: {e}", amount.quantity))?;
+		total = total.checked_add(quantity).ok_or("asset quantity sum overflowed u128")?;
+	}
+	Ok(total)
+}

--- a/node/src/blockfrost/federated_authority.rs
+++ b/node/src/blockfrost/federated_authority.rs
@@ -1,0 +1,289 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Federated authority observation data source: reads the council and technical
+//! committee governance UTXOs.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use blockfrost::BlockCursor;
+use cardano_serialization_lib::PlutusData;
+use lru::LruCache;
+use midnight_primitives_federated_authority_observation::{
+	AuthoritiesData, FederatedAuthorityData, FederatedAuthorityObservationConfig,
+};
+use midnight_primitives_mainchain_follower::data_source::metrics::{
+	MidnightDataSourceMetrics, start_sub_query_timer,
+};
+use midnight_primitives_mainchain_follower::{
+	FederatedAuthorityObservationDataSource, FederatedAuthorityObservationDataSourceImpl,
+};
+use sidechain_domain::*;
+
+use super::client::*;
+use super::convert::*;
+use super::support::*;
+
+const FEDAUTH_CACHE_SIZE: usize = 1000;
+
+// ---------------------------------------------------------------------------
+// Federated authority observation
+// ---------------------------------------------------------------------------
+
+type FedAuthCacheKey = (McBlockHash, String, PolicyId, String, PolicyId);
+
+/// Where the current governance answer for one body came from, so later queries can
+/// reuse it after a single "anything new at this address?" range check.
+#[derive(Clone)]
+struct GovernanceMemo {
+	/// Block height of the tx providing the winning UTXO (None = no UTXO existed).
+	found_at: Option<u32>,
+	/// Highest block up to which the address is known to have no newer transactions.
+	checked_up_to: u32,
+	result: AuthoritiesData,
+}
+
+/// Mirrors `FederatedAuthorityObservationDataSourceImpl`, including its LRU keyed by
+/// Cardano block hash *and* the governance config.
+pub struct BlockfrostFederatedAuthorityObservationDataSource {
+	client: Arc<BlockfrostClient>,
+	cache: Mutex<LruCache<FedAuthCacheKey, FederatedAuthorityData>>,
+	governance_memo: Mutex<HashMap<(String, PolicyId), GovernanceMemo>>,
+	metrics_opt: Option<MidnightDataSourceMetrics>,
+}
+
+impl BlockfrostFederatedAuthorityObservationDataSource {
+	pub fn new(
+		client: Arc<BlockfrostClient>,
+		metrics_opt: Option<MidnightDataSourceMetrics>,
+	) -> Self {
+		let cap = NonZeroUsize::new(FEDAUTH_CACHE_SIZE).unwrap();
+		Self {
+			client,
+			cache: Mutex::new(LruCache::new(cap)),
+			governance_memo: Mutex::new(HashMap::new()),
+			metrics_opt,
+		}
+	}
+
+	/// The most recent (block desc, tx index desc) output at the governance body address
+	/// holding any asset under `policy_id`, with a datum, created at or before `block`.
+	/// Spent-ness is deliberately not checked: spending a governance UTXO is always a
+	/// replacement, never a removal (same as the db-sync query).
+	///
+	/// Incremental caching: "latest matching output ≤ N" can only change if a new tx
+	/// appears at the address, so once computed, a single range query over the
+	/// yet-unchecked blocks decides whether the memoized answer still stands. This
+	/// avoids re-discovering the same governance UTXO for every imported block.
+	async fn governance_body_authorities(
+		&self,
+		address: &str,
+		policy_id: &PolicyId,
+		block: u32,
+	) -> Result<AuthoritiesData, BoxError> {
+		let memo_key = (address.to_string(), policy_id.clone());
+		let prior =
+			self.governance_memo.lock().ok().and_then(|memos| memos.get(&memo_key).cloned());
+		if let Some(memo) = &prior {
+			// Served directly when the winning tx is at or below the queried block and
+			// no newer tx can exist below it either (block ≤ checked_up_to).
+			if block <= memo.checked_up_to && memo.found_at.is_none_or(|found| found <= block) {
+				return Ok(memo.result.clone());
+			}
+			if block > memo.checked_up_to {
+				let new_txs = self
+					.client
+					.range_txs(
+						TxSource::Address(address),
+						Some(BlockCursor::block(u64::from(memo.checked_up_to + 1))),
+						Some(BlockCursor::block(u64::from(block))),
+					)
+					.await?;
+				if new_txs.is_empty() {
+					// Only extend the entry we actually validated. A concurrent call may
+					// have replaced it while `range_txs` was in flight, and stamping this
+					// `checked_up_to` onto that one would bless a result never checked to
+					// this height — later fast-path hits would return stale authorities.
+					if let Ok(mut memos) = self.governance_memo.lock()
+						&& memos.get(&memo_key).is_some_and(|current| {
+							current.found_at == memo.found_at
+								&& current.checked_up_to == memo.checked_up_to
+						}) {
+						memos.insert(
+							memo_key,
+							GovernanceMemo {
+								found_at: memo.found_at,
+								checked_up_to: block,
+								result: memo.result.clone(),
+							},
+						);
+					}
+					return Ok(memo.result.clone());
+				}
+			}
+		}
+
+		let (result, found_at) = self.scan_governance_body(address, policy_id, block).await?;
+		if let Ok(mut memos) = self.governance_memo.lock() {
+			memos.insert(
+				memo_key,
+				GovernanceMemo { found_at, checked_up_to: block, result: result.clone() },
+			);
+		}
+		Ok(result)
+	}
+
+	/// Full descending scan for the governance UTXO; returns the authorities and the
+	/// block height of the winning tx (None when no matching UTXO exists).
+	async fn scan_governance_body(
+		&self,
+		address: &str,
+		policy_id: &PolicyId,
+		block: u32,
+	) -> Result<(AuthoritiesData, Option<u32>), BoxError> {
+		let empty = AuthoritiesData { authorities: vec![], round: 0 };
+		let policy_hex = hex::encode(policy_id.0);
+		let mut found: Option<(Option<PlutusData>, u32)> = None;
+		let mut reached_end = false;
+		'pages: for page in 1..=MAX_PAGES {
+			let batch =
+				self.client.range_txs_desc_page(TxSource::Address(address), block, page).await?;
+			let last_page = batch.len() < PAGE_SIZE;
+			for row in &batch {
+				let utxos = self.client.tx_utxos(&row.tx_hash).await?;
+				let mut outputs: Vec<_> = utxos
+					.outputs
+					.iter()
+					.filter(|o| {
+						!o.collateral
+							&& o.address == address
+							&& (o.inline_datum.is_some() || o.data_hash.is_some())
+							&& o.amount.iter().any(|a| a.unit.starts_with(&policy_hex))
+					})
+					.collect();
+				outputs.sort_by_key(|o| o.output_index);
+				for output in outputs {
+					// An output whose datum can't be resolved (datum hash whose body was
+					// never revealed) is skipped, not treated as an empty answer: the SQL
+					// `INNER JOIN datum` excludes such rows and keeps scanning older ones.
+					if let Some(datum) = self
+						.client
+						.datum(output.inline_datum.as_ref(), output.data_hash.as_ref())
+						.await?
+					{
+						found = Some((Some(datum), row.block_height));
+						break 'pages;
+					}
+					log::debug!(
+						"Governance output {}#{} at {address} has an unresolvable datum; skipping",
+						row.tx_hash,
+						output.output_index,
+					);
+				}
+			}
+			if last_page {
+				reached_end = true;
+				break;
+			}
+		}
+		// Scanning the whole history without a hit is a legitimate answer (empty list
+		// below); exhausting the page cap is not, so it must not be reported as one.
+		if found.is_none() && !reached_end {
+			return Err(too_many_pages(&format!("address {address}/transactions")));
+		}
+		let Some((Some(datum), found_at)) = found else {
+			log::warn!(
+				"No governance body UTXO found for Cardano block {block} (address: {address}, policy_id: {policy_id}). Using empty list.",
+			);
+			return Ok((empty, found.map(|(_, height)| height)));
+		};
+		let result =
+			match FederatedAuthorityObservationDataSourceImpl::decode_governance_datum(&datum) {
+				Ok(datums) => AuthoritiesData::from(datums),
+				Err(e) => {
+					log::warn!("Failed to decode governance datum: {e}. Using empty list.");
+					empty
+				},
+			};
+		Ok((result, Some(found_at)))
+	}
+}
+
+#[async_trait::async_trait]
+impl FederatedAuthorityObservationDataSource for BlockfrostFederatedAuthorityObservationDataSource {
+	async fn get_federated_authority_data(
+		&self,
+		config: &FederatedAuthorityObservationConfig,
+		mc_block_hash: &McBlockHash,
+	) -> Result<FederatedAuthorityData, BoxError> {
+		let _t = Timer::new(format!("get_federated_authority_data[{mc_block_hash}]"));
+		let key: FedAuthCacheKey = (
+			mc_block_hash.clone(),
+			config.council.address.clone(),
+			config.council.policy_id.clone(),
+			config.technical_committee.address.clone(),
+			config.technical_committee.policy_id.clone(),
+		);
+		if let Ok(mut cache) = self.cache.lock()
+			&& let Some(cached) = cache.get(&key)
+		{
+			return Ok(cached.clone());
+		}
+
+		let block = {
+			let _sq_timer = start_sub_query_timer(&self.metrics_opt, "fedauth_get_block_by_hash");
+			self.client
+				.block_by_id(&hex::encode(mc_block_hash.0))
+				.await?
+				.ok_or_else(|| format!("Block not found for hash: {mc_block_hash:?}"))?
+		};
+		let block_number = block_height(&block)?;
+
+		let (council_authorities, technical_committee_authorities) = tokio::try_join!(
+			async {
+				let _sq_timer =
+					start_sub_query_timer(&self.metrics_opt, "fedauth_get_council_utxo");
+				self.governance_body_authorities(
+					&config.council.address,
+					&config.council.policy_id,
+					block_number,
+				)
+				.await
+			},
+			async {
+				let _sq_timer = start_sub_query_timer(
+					&self.metrics_opt,
+					"fedauth_get_technical_committee_utxo",
+				);
+				self.governance_body_authorities(
+					&config.technical_committee.address,
+					&config.technical_committee.policy_id,
+					block_number,
+				)
+				.await
+			},
+		)?;
+
+		let result = FederatedAuthorityData {
+			council_authorities,
+			technical_committee_authorities,
+			mc_block_hash: mc_block_hash.clone(),
+		};
+		if let Ok(mut cache) = self.cache.lock() {
+			cache.put(key, result.clone());
+		}
+		Ok(result)
+	}
+}

--- a/node/src/blockfrost/mod.rs
+++ b/node/src/blockfrost/mod.rs
@@ -1,0 +1,113 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Blockfrost-backed implementations of the main chain follower data sources.
+//!
+//! When `blockfrost_endpoint` is configured, [create_blockfrost_data_sources] builds all six
+//! data sources from a Blockfrost-compatible API instead of the db-sync Postgres database.
+//! Every implementation replicates the corresponding db-sync SQL semantics exactly — the
+//! results are consensus-critical inherent data and must match byte-for-byte what
+//! db-sync-backed nodes produce.
+//!
+//! Not covered here (still Postgres-only): the CLI/genesis helpers in `main_chain_follower.rs`
+//! (`create_ics_genesis_pool` and friends).
+//!
+//! Timing: every trait method and every HTTP call logs its duration under the `blockfrost`
+//! log target (`-l blockfrost=debug`) so latencies can be compared with the db-sync
+//! Prometheus histograms.
+
+mod authority_selection;
+mod block;
+mod bridge;
+mod client;
+mod cnight;
+mod convert;
+mod federated_authority;
+mod support;
+#[cfg(test)]
+mod testing;
+
+pub use authority_selection::BlockfrostAuthoritySelectionDataSource;
+pub use block::BlockfrostBlockDataSource;
+pub use bridge::BlockfrostTokenBridgeDataSource;
+pub use client::BlockfrostClient;
+pub use cnight::BlockfrostCNightObservationDataSource;
+pub use federated_authority::BlockfrostFederatedAuthorityObservationDataSource;
+
+use std::sync::Arc;
+
+use midnight_primitives_cnight_observation::{CNightAddresses, CardanoPosition};
+use midnight_primitives_mainchain_follower::data_source::metrics::MidnightDataSourceMetrics;
+
+use self::support::*;
+use crate::cfg::midnight_cfg::MidnightCfg;
+use crate::main_chain_follower::DataSources;
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+/// Builds all six main chain follower data sources backed by the configured
+/// Blockfrost-compatible endpoint.
+pub async fn create_blockfrost_data_sources(
+	cfg: MidnightCfg,
+	// Unused: the per-call implementation needs no cache anchor.
+	_cnight_follower_genesis: Option<(CNightAddresses, CardanoPosition)>,
+	midnight_metrics_opt: Option<MidnightDataSourceMetrics>,
+) -> Result<DataSources, BoxError> {
+	let endpoint = cfg.blockfrost_endpoint.as_deref().ok_or("blockfrost_endpoint not set")?;
+	let security_parameter =
+		cfg.cardano_security_parameter.ok_or("Missing cardano_security_parameter")?;
+	let active_slots_coeff =
+		cfg.cardano_active_slots_coeff.ok_or("Missing cardano_active_slots_coeff")?;
+	let block_stability_margin =
+		cfg.block_stability_margin.ok_or("Missing block_stability_margin")?;
+
+	let client = Arc::new(BlockfrostClient::new(
+		endpoint,
+		cfg.blockfrost_project_id.as_deref(),
+		security_parameter,
+	)?);
+	log::info!("Main chain follower backend: Blockfrost ({endpoint})");
+
+	let block_source = Arc::new(BlockfrostBlockDataSource::new(
+		client.clone(),
+		security_parameter,
+		active_slots_coeff,
+		block_stability_margin,
+		cfg.mc_slot_duration_millis,
+	));
+
+	Ok(DataSources {
+		mc_hash: block_source.clone(),
+		sidechain_rpc: block_source,
+		authority_selection: Arc::new(BlockfrostAuthoritySelectionDataSource::new(
+			client.clone(),
+			security_parameter,
+			midnight_metrics_opt.clone(),
+		)),
+		cnight_observation: Arc::new(BlockfrostCNightObservationDataSource::new(
+			client.clone(),
+			security_parameter,
+			cfg.cnight_observation_window_size,
+			midnight_metrics_opt.clone(),
+		)),
+		federated_authority_observation: Arc::new(
+			BlockfrostFederatedAuthorityObservationDataSource::new(
+				client.clone(),
+				midnight_metrics_opt,
+			),
+		),
+		bridge: Arc::new(BlockfrostTokenBridgeDataSource::new(client)),
+	})
+}

--- a/node/src/blockfrost/support.rs
+++ b/node/src/blockfrost/support.rs
@@ -1,0 +1,118 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared plumbing: elapsed-time logging, the request deadline, the tuning bounds,
+//! and the error/status-code helpers every other module in this backend uses.
+
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use blockfrost::BlockfrostError;
+
+pub(crate) type BoxError = Box<dyn Error + Send + Sync>;
+
+pub(crate) const RETRY_AMOUNT: u64 = 10;
+pub(crate) const PAGE_SIZE: usize = 100;
+
+// The timing and page-count bounds are shortened under `cfg(test)` so the fake-server
+// tests can reach them in milliseconds instead of minutes. Only the `not(test)` values
+// ever ship; the tests assert the behaviour at the bound, not the bound itself.
+#[cfg(not(test))]
+pub(crate) const RETRY_DELAY: Duration = Duration::from_secs(1);
+#[cfg(test)]
+pub(crate) const RETRY_DELAY: Duration = Duration::from_millis(50);
+
+/// Per-request deadline for both HTTP clients, and the bound on a whole retry loop.
+#[cfg(not(test))]
+pub(crate) const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(test)]
+pub(crate) const HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Backstop for the page-walking loops, which otherwise only stop on a short
+/// page. Blockfrost returns an empty page past the end, but a backend that
+/// ignores `page` and keeps answering with full pages would spin forever and
+/// grow memory without bound. Far above any real result set: 1M rows.
+#[cfg(not(test))]
+pub(crate) const MAX_PAGES: usize = 10_000;
+#[cfg(test)]
+pub(crate) const MAX_PAGES: usize = 3;
+
+/// Logs the elapsed time of the enclosing scope under the `blockfrost` log target on drop.
+pub(crate) struct Timer {
+	label: String,
+	start: Instant,
+}
+
+impl Timer {
+	pub(crate) fn new(label: impl Into<String>) -> Self {
+		Self { label: label.into(), start: Instant::now() }
+	}
+}
+
+impl Drop for Timer {
+	fn drop(&mut self) {
+		log::debug!(target: "blockfrost", "{}: {}ms", self.label, self.start.elapsed().as_millis());
+	}
+}
+
+pub(crate) fn is_404(e: &BlockfrostError) -> bool {
+	matches!(e, BlockfrostError::Response { reason, .. } if reason.status_code == 404)
+}
+
+/// Blockfrost answers 402 once a project passes its request limit. Nothing recovers by
+/// itself until the quota resets, so the node would otherwise sit there retrying forever
+/// behind a bare status code. Say what happened and what it means for sync.
+pub(crate) const OVER_QUOTA_MESSAGE: &str = "Blockfrost project is over its request limit (HTTP 402). Cardano main chain data \
+	 cannot be read, so block import and authoring will not progress until the daily \
+	 quota resets or the project's plan is upgraded.";
+
+pub(crate) fn is_over_quota(e: &BlockfrostError) -> bool {
+	matches!(e, BlockfrostError::Response { reason, .. } if reason.status_code == 402)
+}
+
+pub(crate) fn box_err(e: BlockfrostError) -> BoxError {
+	// Logged as well as returned: the inherent data providers retry every block, and the
+	// returned error is not always surfaced where an operator will see it.
+	if is_over_quota(&e) {
+		log::error!("{OVER_QUOTA_MESSAGE}");
+		return OVER_QUOTA_MESSAGE.into();
+	}
+	format!("Blockfrost error: {e}").into()
+}
+
+/// Applies the deadline to one Blockfrost call, preserving the inner error so callers
+/// can still treat a 404 as an empty result. The SDK builds its HTTP client internally,
+/// on a different `reqwest` version, so the deadline cannot be configured there; without
+/// one a stalled server blocks the caller indefinitely. Wrapping a call that retries
+/// internally bounds the retries too, which is why the raw path uses it as well.
+pub(crate) async fn deadline<T, E>(
+	label: &str,
+	fut: impl Future<Output = Result<T, E>>,
+) -> Result<Result<T, E>, BoxError> {
+	match tokio::time::timeout(HTTP_TIMEOUT, fut).await {
+		Ok(result) => Ok(result),
+		Err(_) => {
+			Err(format!("Blockfrost request timed out after {}s: {label}", HTTP_TIMEOUT.as_secs())
+				.into())
+		},
+	}
+}
+
+/// Error for a page-walk that hit [`MAX_PAGES`] without seeing a short page.
+pub(crate) fn too_many_pages(what: &str) -> BoxError {
+	format!(
+		"Blockfrost returned {MAX_PAGES} full pages for {what} without reaching the end; \
+		 the backend may not honor the `page` parameter"
+	)
+	.into()
+}

--- a/node/src/blockfrost/testing.rs
+++ b/node/src/blockfrost/testing.rs
@@ -1,0 +1,110 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared test scaffolding: a minimal HTTP server built on `tokio::net` so the client
+//! tests need no mocking crate, plus fixtures used by more than one module's tests.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use cardano_serialization_lib::{BigNum, ConstrPlutusData, PlutusData, PlutusList};
+
+use super::client::BlockfrostClient;
+
+/// One canned reply from the fake server.
+pub(crate) enum Reply {
+	Json(u16, String),
+	/// Reply only after a delay, to exercise a deadline across several attempts.
+	Slow(Duration, u16, String),
+}
+
+/// Serves `replies` in order (repeating the last once exhausted) and records the
+/// request line of everything it received. Built on `tokio::net`, which the workspace
+/// already depends on, so this needs no HTTP-mocking crate.
+pub(crate) async fn fake_server(replies: Vec<Reply>) -> (String, Arc<Mutex<Vec<String>>>) {
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+	let addr = listener.local_addr().expect("local addr");
+	let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+	let recorder = seen.clone();
+	tokio::spawn(async move {
+		use tokio::io::{AsyncReadExt, AsyncWriteExt};
+		let mut served = 0usize;
+		while let Ok((mut socket, _)) = listener.accept().await {
+			let mut buf = [0u8; 8192];
+			let read = socket.read(&mut buf).await.unwrap_or(0);
+			let request = String::from_utf8_lossy(&buf[..read]).to_string();
+			recorder
+				.lock()
+				.expect("recorder")
+				.push(request.lines().next().unwrap_or_default().to_string());
+			let reply = match replies.get(served).or_else(|| replies.last()) {
+				Some(reply) => reply,
+				None => return,
+			};
+			served += 1;
+			let (status, body) = match reply {
+				Reply::Json(status, body) => (*status, body.clone()),
+				Reply::Slow(delay, status, body) => {
+					tokio::time::sleep(*delay).await;
+					(*status, body.clone())
+				},
+			};
+			// `connection: close` keeps one request per connection, so the recorded
+			// count is the number of requests the client actually made.
+			let response = format!(
+				"HTTP/1.1 {status} S\r\ncontent-type: application/json\r\n\
+				 content-length: {}\r\nconnection: close\r\n\r\n{body}",
+				body.len()
+			);
+			let _ = socket.write_all(response.as_bytes()).await;
+		}
+	});
+	(format!("http://{addr}"), seen)
+}
+
+pub(crate) fn client_at(url: &str) -> BlockfrostClient {
+	BlockfrostClient::new(url, None, 432).expect("client")
+}
+
+/// `count` asset-transaction rows, ascending from `first_block`.
+pub(crate) fn asset_txs_json(count: usize, first_block: u32) -> String {
+	let rows: Vec<String> = (0..count)
+		.map(|i| {
+			let height = first_block as usize + i;
+			format!(
+				r#"{{"tx_hash":"{:064x}","tx_index":0,"block_height":{height},"block_time":{height}}}"#,
+				height
+			)
+		})
+		.collect();
+	format!("[{}]", rows.join(","))
+}
+
+/// Blockfrost's documented error body shape.
+pub(crate) fn over_quota_body() -> String {
+	r#"{"status_code":402,"error":"Payment Required","message":"Usage is over limit."}"#.to_string()
+}
+
+/// `[Credential(key hash), DustPublicKey]` registration datum, as inline CBOR hex.
+pub(crate) fn registration_datum_hex(owner_key_hash: [u8; 28], dust_key: [u8; 32]) -> String {
+	let mut credential_fields = PlutusList::new();
+	credential_fields.add(&PlutusData::new_bytes(owner_key_hash.to_vec()));
+	let credential = PlutusData::new_constr_plutus_data(&ConstrPlutusData::new(
+		&BigNum::zero(),
+		&credential_fields,
+	));
+	let mut fields = PlutusList::new();
+	fields.add(&credential);
+	fields.add(&PlutusData::new_bytes(dust_key.to_vec()));
+	PlutusData::new_constr_plutus_data(&ConstrPlutusData::new(&BigNum::zero(), &fields)).to_hex()
+}

--- a/node/src/cfg/midnight_cfg/mod.rs
+++ b/node/src/cfg/midnight_cfg/mod.rs
@@ -92,6 +92,20 @@ pub struct MidnightCfg {
 	#[doc_tag(secret)]
 	pub db_sync_postgres_connection_string: Option<String>,
 
+	/// Base URL of a Blockfrost-compatible API (e.g. https://cardano-preview.blockfrost.io/api/v0
+	/// or a self-hosted blockfrost-backend-ryo instance). When set, all main chain follower
+	/// data is read from this API instead of the db-sync Postgres database.
+	///
+	/// This covers running a node only. The genesis generation subcommands read Cardano
+	/// data directly from db-sync SQL, so they still require
+	/// `db_sync_postgres_connection_string` even when this is set.
+	pub blockfrost_endpoint: Option<String>,
+
+	/// Blockfrost project id, sent as the `project_id` header with every request.
+	/// Optional: self-hosted blockfrost-backend-ryo instances ignore it.
+	#[doc_tag(secret)]
+	pub blockfrost_project_id: Option<String>,
+
 	/// see partner-chains CandidateDataSourceCacheConfig and DbSyncBlockDataSourceConfig
 	pub cardano_security_parameter: Option<u32>,
 
@@ -164,8 +178,8 @@ fn main_chain_follower_vars(cfg: &MidnightCfg) -> Result<(), validation::Error> 
 			));
 		}
 	} else {
-		if cfg.db_sync_postgres_connection_string.is_none() {
-			return Err(missing("db_sync_postgres_connection_string"));
+		if cfg.db_sync_postgres_connection_string.is_none() && cfg.blockfrost_endpoint.is_none() {
+			return Err(missing("db_sync_postgres_connection_string or blockfrost_endpoint"));
 		}
 		if cfg.cardano_security_parameter.is_none() {
 			return Err(missing("cardano_security_parameter"));
@@ -284,6 +298,34 @@ mod tests {
 		let mut cfg = good_cfg();
 		cfg.mc_slot_duration_millis = 2000;
 		assert!(mainchain_epoch_invariants(&cfg).is_err());
+	}
+
+	/// A non-mock config with the Cardano observability parameters set, but no backend.
+	fn follower_cfg() -> MidnightCfg {
+		let mut cfg = good_cfg();
+		cfg.cardano_security_parameter = Some(432);
+		cfg.cardano_active_slots_coeff = Some(0.05);
+		cfg.block_stability_margin = Some(10);
+		cfg
+	}
+
+	#[test]
+	fn follower_requires_db_sync_or_blockfrost() {
+		assert!(main_chain_follower_vars(&follower_cfg()).is_err());
+	}
+
+	#[test]
+	fn follower_accepts_db_sync_backend() {
+		let mut cfg = follower_cfg();
+		cfg.db_sync_postgres_connection_string = Some("postgres://localhost/cexplorer".into());
+		assert!(main_chain_follower_vars(&cfg).is_ok());
+	}
+
+	#[test]
+	fn follower_accepts_blockfrost_backend() {
+		let mut cfg = follower_cfg();
+		cfg.blockfrost_endpoint = Some("https://cardano-preview.blockfrost.io/api/v0".into());
+		assert!(main_chain_follower_vars(&cfg).is_ok());
 	}
 
 	#[test]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -18,6 +18,7 @@ mod aura_to_babe_migration_keystore;
 pub mod backend;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
+pub mod blockfrost;
 pub mod cfg;
 pub mod chain_spec;
 pub mod cli;

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -82,6 +82,22 @@ pub(crate) async fn create_cached_main_chain_follower_data_sources(
 		})?;
 
 		Ok(mock)
+	} else if cfg.blockfrost_endpoint.is_some() {
+		// `mc_metrics_opt` is not passed on: `McFollowerMetrics`' accessors and the macro
+		// that records into them are `pub(crate)` in `partner-chains-db-sync-data-sources`,
+		// so a data source outside that crate cannot report into it. The Midnight-side
+		// handle is wired through, with the same sub-query labels the db-sync sources use.
+		crate::blockfrost::create_blockfrost_data_sources(
+			cfg,
+			cnight_follower_genesis,
+			midnight_metrics_opt,
+		)
+		.await
+		.map_err(|err| {
+			ServiceError::Application(
+				format!("Failed to create Blockfrost main chain follower: {err}").into(),
+			)
+		})
 	} else {
 		create_cached_data_sources(
 			cfg,
@@ -518,8 +534,7 @@ pub async fn create_cnight_observation_data_source(
 ) -> Result<Arc<dyn MidnightCNightObservationDataSource>, Box<dyn Error + Send + Sync + 'static>> {
 	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
-		&cfg.db_sync_postgres_connection_string
-			.ok_or(missing("db_sync_postgres_connection_string"))?,
+		&db_sync_connection_string(&cfg)?,
 		CNIGHT_OBSERVATION_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
 	)
@@ -539,8 +554,7 @@ pub async fn create_federated_authority_observation_data_source(
 {
 	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
-		&cfg.db_sync_postgres_connection_string
-			.ok_or(missing("db_sync_postgres_connection_string"))?,
+		&db_sync_connection_string(&cfg)?,
 		FEDERATED_AUTHORITY_OBSERVATION_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
 	)
@@ -570,8 +584,7 @@ pub async fn create_authority_selection_data_source_with_pool(
 > {
 	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
-		&cfg.db_sync_postgres_connection_string
-			.ok_or(missing("db_sync_postgres_connection_string"))?,
+		&db_sync_connection_string(&cfg)?,
 		CANDIDATES_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
 	)
@@ -590,8 +603,7 @@ pub async fn create_ics_genesis_pool(
 ) -> Result<sqlx::PgPool, Box<dyn Error + Send + Sync + 'static>> {
 	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
-		&cfg.db_sync_postgres_connection_string
-			.ok_or(missing("db_sync_postgres_connection_string"))?,
+		&db_sync_connection_string(&cfg)?,
 		ICS_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
 	)
@@ -655,9 +667,63 @@ fn missing(field: &str) -> sc_service::Error {
 	ServiceError::Application(format!("Missing {field}. Check configuration.").into())
 }
 
+/// Connection string for the helpers that read Cardano data straight from db-sync SQL
+/// instead of going through a `DataSources` trait object: the genesis generators and the
+/// single-source CLI helpers. A node configured for Blockfrost has no PostgreSQL to fall
+/// back on, and reporting only the absent setting would blame the wrong thing, so that
+/// case gets its own message.
+fn db_sync_connection_string(
+	cfg: &MidnightCfg,
+) -> Result<String, Box<dyn Error + Send + Sync + 'static>> {
+	match (&cfg.db_sync_postgres_connection_string, &cfg.blockfrost_endpoint) {
+		(Some(connection_string), _) => Ok(connection_string.clone()),
+		(None, Some(endpoint)) => Err(Box::new(ServiceError::Application(
+			format!(
+				"This command reads Cardano data directly from db-sync and needs \
+				 db_sync_postgres_connection_string. The configured Blockfrost endpoint \
+				 ({endpoint}) backs node operation only; genesis generation from Blockfrost \
+				 is not supported."
+			)
+			.into(),
+		))),
+		(None, None) => Err(Box::new(missing("db_sync_postgres_connection_string"))),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn blockfrost_only_cfg() -> MidnightCfg {
+		MidnightCfg {
+			blockfrost_endpoint: Some("https://example.invalid/api/v0".to_string()),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn blockfrost_only_config_is_told_genesis_needs_db_sync() {
+		let error = db_sync_connection_string(&blockfrost_only_cfg())
+			.expect_err("no postgres is configured");
+		let message = error.to_string();
+		assert!(
+			message.contains("genesis generation from Blockfrost is not supported"),
+			"must name the real limitation, not just the absent setting: {message}"
+		);
+		assert!(
+			message.contains("db_sync_postgres_connection_string"),
+			"must still name the setting to add: {message}"
+		);
+	}
+
+	#[test]
+	fn config_without_any_backend_names_the_connection_string() {
+		let error = db_sync_connection_string(&MidnightCfg::default())
+			.expect_err("no backend is configured");
+		let message = error.to_string();
+		assert!(message.contains("Missing db_sync_postgres_connection_string"), "{message}");
+		assert!(!message.contains("Blockfrost"), "no Blockfrost is configured: {message}");
+	}
 
 	#[test]
 	fn connection_error_redacts_infrastructure_details() {

--- a/node/tests/blockfrost_parity.rs
+++ b/node/tests/blockfrost_parity.rs
@@ -1,0 +1,427 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Live 1:1 parity test between the db-sync and Blockfrost main chain follower backends.
+//!
+//! Requires live instances of both backends, synced to the same network:
+//!
+//! ```text
+//! DB_SYNC_POSTGRES_CONNECTION_STRING=postgres://... \
+//! BLOCKFROST_ENDPOINT=https://cardano-preview.blockfrost.io/api/v0 \
+//! BLOCKFROST_PROJECT_ID=preview... \
+//! cargo test -p midnight-node --test blockfrost_parity -- --ignored --nocapture
+//! ```
+//!
+//! Network parameters default to the testnet values from `res/cfg/default.toml` and can
+//! be overridden with `CARDANO_SECURITY_PARAMETER`, `CARDANO_ACTIVE_SLOTS_COEFF`,
+//! `BLOCK_STABILITY_MARGIN`, `MC__SLOT_DURATION_MILLIS`, `MC__FIRST_EPOCH_TIMESTAMP_MILLIS`,
+//! `MC__EPOCH_DURATION_MILLIS`, `MC__FIRST_EPOCH_NUMBER`, `MC__FIRST_SLOT_NUMBER`.
+//!
+//! Every domain below must be configured or the test fails, so that a pass means all six
+//! data sources were compared. `PARITY_ALLOW_PARTIAL=1` accepts a run covering only some
+//! of them. Inputs per domain:
+//! - cNIGHT observation: `CNIGHT_MAPPING_VALIDATOR_ADDRESS`, `CNIGHT_AUTH_TOKEN_ASSET_NAME`,
+//!   `CNIGHT_POLICY_ID` (hex), `CNIGHT_ASSET_NAME`
+//! - candidates: `COMMITTEE_CANDIDATE_ADDRESS`, `PERMISSIONED_CANDIDATE_POLICY_ID` (hex)
+//! - federated authority: `FEDAUTH_COUNCIL_ADDRESS`, `FEDAUTH_COUNCIL_POLICY_ID` (hex),
+//!   `FEDAUTH_TECHNICAL_COMMITTEE_ADDRESS`, `FEDAUTH_TECHNICAL_COMMITTEE_POLICY_ID` (hex)
+//! - bridge: `BRIDGE_TOKEN_POLICY_ID`, `BRIDGE_TOKEN_ASSET_NAME`,
+//!   `ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR_ADDRESS`, `RESERVE_VALIDATOR_ADDRESS`
+//!   (the same env names `MainChainScripts::read_from_env` uses)
+//!
+//! `PARITY_WINDOW_BLOCKS` (default 1000) sets the look-back window for the cNIGHT and
+//! bridge comparisons. All queries are anchored at `db-sync tip - (k + margin)` so both
+//! backends read identical, immutable chain state.
+
+use authority_selection_inherents::AuthoritySelectionDataSource;
+use midnight_node::blockfrost::{
+	BlockfrostAuthoritySelectionDataSource, BlockfrostBlockDataSource,
+	BlockfrostCNightObservationDataSource, BlockfrostClient,
+	BlockfrostFederatedAuthorityObservationDataSource, BlockfrostTokenBridgeDataSource,
+};
+use midnight_primitives::BridgeRecipient;
+use midnight_primitives_cnight_observation::{CNightAddresses, CardanoPosition};
+use midnight_primitives_federated_authority_observation::{
+	AuthBodyConfig, FederatedAuthorityObservationConfig,
+};
+use midnight_primitives_mainchain_follower::{
+	CandidatesDataSourceImpl, FederatedAuthorityObservationDataSource,
+	FederatedAuthorityObservationDataSourceImpl, MidnightCNightObservationDataSource,
+	MidnightCNightObservationDataSourceImpl,
+};
+use partner_chains_db_sync_data_sources::{
+	BlockDataSourceImpl, DbSyncBlockDataSourceConfig, McHashDataSourceImpl,
+	TokenBridgeDataSourceImpl,
+};
+use sidechain_domain::mainchain_epoch::{Duration, MainchainEpochConfig, Timestamp};
+use sidechain_domain::*;
+use sidechain_mc_hash::McHashDataSource;
+use sp_partner_chains_bridge::{BridgeDataCheckpoint, MainChainScripts, TokenBridgeDataSource};
+use std::future::Future;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Transaction capacity used for the cNIGHT comparison: high enough not to truncate a
+/// realistic window, low enough that `tx_capacity * 64` stays well inside `usize`.
+const CAPACITY: usize = 100_000;
+
+fn env(name: &str) -> Option<String> {
+	std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+/// For values where the empty string is meaningful — an asset name is empty for the
+/// unnamed asset of a policy — so "set but empty" must not read as "unset".
+fn env_allow_empty(name: &str) -> Option<String> {
+	std::env::var(name).ok()
+}
+
+fn env_or<T: FromStr>(name: &str, default: T) -> T
+where
+	T::Err: std::fmt::Debug,
+{
+	env(name).map(|v| v.parse().expect(name)).unwrap_or(default)
+}
+
+fn policy_id(hex_str: &str) -> PolicyId {
+	PolicyId(hex::decode(hex_str).expect("valid policy id hex").try_into().expect("28 bytes"))
+}
+
+/// Runs the same query against both backends, prints the timings, and returns both results.
+async fn compare<T, FA, FB>(label: &str, db_sync: FA, blockfrost: FB) -> (T, T)
+where
+	FA: Future<Output = T>,
+	FB: Future<Output = T>,
+{
+	let start = Instant::now();
+	let db_result = db_sync.await;
+	let db_elapsed = start.elapsed();
+	let start = Instant::now();
+	let bf_result = blockfrost.await;
+	let bf_elapsed = start.elapsed();
+	eprintln!(
+		"{label}: db-sync {}ms, blockfrost {}ms",
+		db_elapsed.as_millis(),
+		bf_elapsed.as_millis()
+	);
+	(db_result, bf_result)
+}
+
+#[tokio::test]
+#[ignore = "requires live db-sync and Blockfrost instances (see module docs)"]
+async fn backends_return_identical_results() {
+	let postgres_url =
+		env("DB_SYNC_POSTGRES_CONNECTION_STRING").expect("DB_SYNC_POSTGRES_CONNECTION_STRING");
+	let blockfrost_endpoint = env("BLOCKFROST_ENDPOINT").expect("BLOCKFROST_ENDPOINT");
+	let blockfrost_project_id = env("BLOCKFROST_PROJECT_ID");
+
+	let security_parameter: u32 = env_or("CARDANO_SECURITY_PARAMETER", 432);
+	let active_slots_coeff: f64 = env_or("CARDANO_ACTIVE_SLOTS_COEFF", 0.05);
+	let block_stability_margin: u32 = env_or("BLOCK_STABILITY_MARGIN", 10);
+	let slot_duration_millis: u64 = env_or("MC__SLOT_DURATION_MILLIS", 1000);
+	let window_blocks: u32 = env_or("PARITY_WINDOW_BLOCKS", 1000);
+
+	let mc_epoch_config = MainchainEpochConfig {
+		first_epoch_timestamp_millis: Timestamp::from_unix_millis(env_or(
+			"MC__FIRST_EPOCH_TIMESTAMP_MILLIS",
+			1666656000000,
+		)),
+		epoch_duration_millis: Duration::from_millis(env_or("MC__EPOCH_DURATION_MILLIS", 86400000)),
+		first_epoch_number: env_or("MC__FIRST_EPOCH_NUMBER", 0),
+		first_slot_number: env_or("MC__FIRST_SLOT_NUMBER", 0),
+		slot_duration_millis: Duration::from_millis(slot_duration_millis),
+	};
+
+	// --- backends -------------------------------------------------------------------
+	let pool = sqlx::postgres::PgPoolOptions::new()
+		.max_connections(5)
+		.connect(&postgres_url)
+		.await
+		.expect("db-sync connection");
+
+	let db_block_source = Arc::new(BlockDataSourceImpl::from_config(
+		pool.clone(),
+		DbSyncBlockDataSourceConfig {
+			cardano_security_parameter: security_parameter,
+			cardano_active_slots_coeff: active_slots_coeff,
+			block_stability_margin,
+		},
+		&mc_epoch_config,
+	));
+	let db_mc_hash = McHashDataSourceImpl::new(db_block_source.clone(), None);
+
+	let client = Arc::new(
+		BlockfrostClient::new(
+			&blockfrost_endpoint,
+			blockfrost_project_id.as_deref(),
+			security_parameter,
+		)
+		.expect("blockfrost client"),
+	);
+	let bf_block_source = BlockfrostBlockDataSource::new(
+		client.clone(),
+		security_parameter,
+		active_slots_coeff,
+		block_stability_margin,
+		slot_duration_millis,
+	);
+
+	// --- anchor ---------------------------------------------------------------------
+	// A block deep enough below both backends' tips to be immutable and identical.
+	let db_tip = db_block_source.get_latest_block_info().await.expect("db-sync tip");
+	let anchor_height = db_tip.number.0.saturating_sub(security_parameter + block_stability_margin);
+	// Resolve the anchor hash via Blockfrost (db-sync has no public by-number getter).
+	let anchor_hash = client
+		.block_hash_by_number(anchor_height)
+		.await
+		.expect("blockfrost anchor lookup")
+		.expect("anchor block exists");
+	let anchor = McHashDataSource::get_block_by_hash(&bf_block_source, anchor_hash)
+		.await
+		.expect("anchor block info")
+		.expect("anchor block exists");
+	eprintln!(
+		"anchor: block {} ({}) at epoch {}",
+		anchor.number.0,
+		hex::encode(anchor.hash.0),
+		anchor.epoch.0
+	);
+
+	// --- block source ---------------------------------------------------------------
+	let (db, bf) = compare(
+		"get_block_by_hash(anchor)",
+		McHashDataSource::get_block_by_hash(&db_mc_hash, anchor.hash.clone()),
+		McHashDataSource::get_block_by_hash(&bf_block_source, anchor.hash.clone()),
+	)
+	.await;
+	assert_eq!(db.expect("db-sync"), bf.expect("blockfrost"), "get_block_by_hash mismatch");
+
+	// Reference timestamp placed inside the Praos window relative to the anchor:
+	// [anchor_time + k/f, anchor_time + 3k/f].
+	let min_boundary_ms = (slot_duration_millis as f64 * security_parameter as f64
+		/ active_slots_coeff)
+		.round() as u64;
+	let reference = sp_timestamp::Timestamp::new(anchor.timestamp * 1000 + 2 * min_boundary_ms);
+	let (db, bf) = compare(
+		"get_stable_block_for(anchor)",
+		db_mc_hash.get_stable_block_for(anchor.hash.clone(), reference),
+		bf_block_source.get_stable_block_for(anchor.hash.clone(), reference),
+	)
+	.await;
+	assert_eq!(db.expect("db-sync"), bf.expect("blockfrost"), "get_stable_block_for mismatch");
+
+	// Domains whose inputs were not supplied. Checked at the end: a pass has to mean
+	// "every domain was compared", otherwise a run with only the two connection strings
+	// set compares the block source alone and still reports success.
+	let mut skipped: Vec<&str> = Vec::new();
+
+	// --- cNIGHT observation ---------------------------------------------------------
+	if let Some(mapping_validator_address) = env("CNIGHT_MAPPING_VALIDATOR_ADDRESS") {
+		let config = CNightAddresses {
+			mapping_validator_address,
+			auth_token_asset_name: env_allow_empty("CNIGHT_AUTH_TOKEN_ASSET_NAME")
+				.expect("CNIGHT_AUTH_TOKEN_ASSET_NAME"),
+			cnight_policy_id: hex::decode(env("CNIGHT_POLICY_ID").expect("CNIGHT_POLICY_ID"))
+				.expect("valid policy hex")
+				.try_into()
+				.expect("28 bytes"),
+			cnight_asset_name: env_allow_empty("CNIGHT_ASSET_NAME").unwrap_or_default(),
+		};
+		let db_source = MidnightCNightObservationDataSourceImpl::new(pool.clone(), None, 1000);
+		let bf_source = BlockfrostCNightObservationDataSource::new(
+			client.clone(),
+			security_parameter,
+			midnight_primitives_mainchain_follower::data_source::DEFAULT_WINDOW_SIZE,
+			None,
+		);
+		// Only `(block_number, tx_index_in_block)` of the start position act as range
+		// bounds; hash and timestamp are placeholders on both backends alike.
+		let start = CardanoPosition::min_for_block(anchor.number.0.saturating_sub(window_blocks));
+		let (db, bf) = compare(
+			"get_utxos_up_to_capacity",
+			db_source.get_utxos_up_to_capacity(
+				&config,
+				&start,
+				anchor.hash.clone(),
+				// Effectively unbounded, but small enough that the helper's
+				// `tx_capacity * 64` capacity hint cannot overflow.
+				CAPACITY,
+				10_000_000,
+			),
+			bf_source.get_utxos_up_to_capacity(
+				&config,
+				&start,
+				anchor.hash.clone(),
+				// Effectively unbounded, but small enough that the helper's
+				// `tx_capacity * 64` capacity hint cannot overflow.
+				CAPACITY,
+				10_000_000,
+			),
+		)
+		.await;
+		let db = db.expect("db-sync");
+		let bf = bf.expect("blockfrost");
+		assert_eq!(db.start, bf.start, "cNIGHT start mismatch");
+		assert_eq!(db.end, bf.end, "cNIGHT end mismatch");
+		assert_eq!(db.utxos, bf.utxos, "cNIGHT events mismatch");
+		eprintln!("cNIGHT events compared: {}", db.utxos.len());
+	} else {
+		skipped.push("cNIGHT (CNIGHT_MAPPING_VALIDATOR_ADDRESS)");
+	}
+
+	// --- authority selection ---------------------------------------------------------
+	if let Some(committee_address) = env("COMMITTEE_CANDIDATE_ADDRESS") {
+		let permissioned_policy = policy_id(
+			&env("PERMISSIONED_CANDIDATE_POLICY_ID").expect("PERMISSIONED_CANDIDATE_POLICY_ID"),
+		);
+		let db_source = CandidatesDataSourceImpl::new(pool.clone(), None)
+			.await
+			.expect("candidates source");
+		let bf_source =
+			BlockfrostAuthoritySelectionDataSource::new(client.clone(), security_parameter, None);
+		let epoch = McEpochNumber(anchor.epoch.0);
+		let address = MainchainAddress::from_str(&committee_address).expect("valid address");
+
+		let (db, bf) = compare(
+			"get_epoch_nonce",
+			db_source.get_epoch_nonce(epoch),
+			bf_source.get_epoch_nonce(epoch),
+		)
+		.await;
+		assert_eq!(db.expect("db-sync"), bf.expect("blockfrost"), "epoch nonce mismatch");
+
+		let (db, bf) = compare(
+			"get_ariadne_parameters",
+			db_source.get_ariadne_parameters(
+				epoch,
+				permissioned_policy.clone(),
+				permissioned_policy.clone(),
+			),
+			bf_source.get_ariadne_parameters(
+				epoch,
+				permissioned_policy.clone(),
+				permissioned_policy,
+			),
+		)
+		.await;
+		assert_eq!(
+			format!("{:?}", db.expect("db-sync")),
+			format!("{:?}", bf.expect("blockfrost")),
+			"ariadne parameters mismatch"
+		);
+
+		let (db, bf) = compare(
+			"get_candidates",
+			db_source.get_candidates(epoch, address.clone()),
+			bf_source.get_candidates(epoch, address),
+		)
+		.await;
+		let mut db = db.expect("db-sync");
+		let mut bf = bf.expect("blockfrost");
+		// Both backends group by stake pool key with unordered maps; sort for comparison.
+		db.sort_by_key(|c| c.stake_pool_public_key.0);
+		bf.sort_by_key(|c| c.stake_pool_public_key.0);
+		assert_eq!(format!("{db:?}"), format!("{bf:?}"), "candidate registrations mismatch");
+		eprintln!("candidates compared: {}", db.len());
+	} else {
+		skipped.push("candidates (COMMITTEE_CANDIDATE_ADDRESS)");
+	}
+
+	// --- federated authority ----------------------------------------------------------
+	if let Some(council_address) = env("FEDAUTH_COUNCIL_ADDRESS") {
+		let config = FederatedAuthorityObservationConfig {
+			council: AuthBodyConfig {
+				address: council_address,
+				policy_id: policy_id(
+					&env("FEDAUTH_COUNCIL_POLICY_ID").expect("FEDAUTH_COUNCIL_POLICY_ID"),
+				),
+				// Genesis-only fields; they don't affect the query.
+				members: vec![],
+				members_mainchain: vec![],
+			},
+			technical_committee: AuthBodyConfig {
+				address: env("FEDAUTH_TECHNICAL_COMMITTEE_ADDRESS")
+					.expect("FEDAUTH_TECHNICAL_COMMITTEE_ADDRESS"),
+				policy_id: policy_id(
+					&env("FEDAUTH_TECHNICAL_COMMITTEE_POLICY_ID")
+						.expect("FEDAUTH_TECHNICAL_COMMITTEE_POLICY_ID"),
+				),
+				members: vec![],
+				members_mainchain: vec![],
+			},
+		};
+		let db_source = FederatedAuthorityObservationDataSourceImpl::new(pool.clone(), None, 1000);
+		let bf_source =
+			BlockfrostFederatedAuthorityObservationDataSource::new(client.clone(), None);
+		let (db, bf) = compare(
+			"get_federated_authority_data",
+			db_source.get_federated_authority_data(&config, &anchor.hash),
+			bf_source.get_federated_authority_data(&config, &anchor.hash),
+		)
+		.await;
+		assert_eq!(
+			format!("{:?}", db.expect("db-sync")),
+			format!("{:?}", bf.expect("blockfrost")),
+			"federated authority data mismatch"
+		);
+	} else {
+		skipped.push("federated authority (FEDAUTH_COUNCIL_ADDRESS)");
+	}
+
+	// --- bridge ------------------------------------------------------------------------
+	if env("ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR_ADDRESS").is_some() {
+		let scripts = MainChainScripts::read_from_env().expect("bridge script env vars");
+		let db_source = TokenBridgeDataSourceImpl::new(pool.clone(), None);
+		let bf_source = BlockfrostTokenBridgeDataSource::new(client.clone());
+		let checkpoint = BridgeDataCheckpoint::Block(McBlockNumber(
+			anchor.number.0.saturating_sub(window_blocks),
+		));
+		let (db, bf) = compare(
+			"get_transfers",
+			TokenBridgeDataSource::<BridgeRecipient>::get_transfers(
+				&db_source,
+				scripts.clone(),
+				checkpoint.clone(),
+				100,
+				anchor.hash.clone(),
+			),
+			TokenBridgeDataSource::<BridgeRecipient>::get_transfers(
+				&bf_source,
+				scripts,
+				checkpoint,
+				100,
+				anchor.hash.clone(),
+			),
+		)
+		.await;
+		let db = db.expect("db-sync");
+		let bf = bf.expect("blockfrost");
+		assert_eq!(db.0, bf.0, "bridge transfers mismatch");
+		assert_eq!(db.1, bf.1, "bridge checkpoint mismatch");
+		eprintln!("bridge transfers compared: {}", db.0.len());
+	} else {
+		skipped.push("bridge (ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR_ADDRESS)");
+	}
+
+	// Fail rather than pass a partial comparison. `eprintln!` notes above are swallowed by
+	// libtest on a passing test unless `--nocapture` is given, so a skip would otherwise be
+	// invisible as well as silent.
+	if !skipped.is_empty() && env("PARITY_ALLOW_PARTIAL").is_none() {
+		panic!(
+			"only the block data source was fully compared; these domains were not: {}. \
+			 Supply their env vars (see the module docs) or set PARITY_ALLOW_PARTIAL=1 to \
+			 accept a partial run.",
+			skipped.join(", ")
+		);
+	}
+}

--- a/primitives/mainchain-follower/src/data_source/cnight_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/cnight_observation.rs
@@ -138,7 +138,7 @@ impl MidnightCNightObservationDataSource for MidnightCNightObservationDataSource
 );
 
 impl MidnightCNightObservationDataSourceImpl {
-	fn decode_registration_datum(
+	pub fn decode_registration_datum(
 		datum: ConstrPlutusData,
 	) -> Result<(Credential, DustPublicKeyBytes), RegistrationDatumDecodeError> {
 		// We use a Vec here because the `get` method on `PlutusList` can panic

--- a/primitives/mainchain-follower/src/data_source/federated_authority_observation.rs
+++ b/primitives/mainchain-follower/src/data_source/federated_authority_observation.rs
@@ -199,7 +199,7 @@ impl FederatedAuthorityObservationDataSourceImpl {
 	///   and Sr25519Keys is a 32-byte public key
 	///
 	/// Returns a GovernanceAuthorityDatums enum containing the authorities and round
-	fn decode_governance_datum(
+	pub fn decode_governance_datum(
 		datum: &PlutusData,
 	) -> Result<GovernanceAuthorityDatums, Box<dyn std::error::Error + Send + Sync>> {
 		// The new format uses @list annotation, so VersionedMultisig is a list: [data, logic_round]


### PR DESCRIPTION
# Overview

A node can now follow the Cardano main chain through a Blockfrost-compatible HTTP API instead of a cardano-db-sync PostgreSQL database. Setting `blockfrost_endpoint` switches all six main chain follower data sources to that backend. Leaving it unset changes nothing: the db-sync path is untouched and remains the default.

## Approach

The db-sync SQL is the specification throughout, and no SQL was modified. Each Blockfrost data source mirrors the query it replaces.

Two behaviours are not literal translations and are worth calling out. Per-pool stake is read from `/pools/{id}/history` (`active_stake` for the data epoch) rather than by paging every delegator through `/epochs/{n}/stakes`; the two were verified equal against db-sync's `SUM(epoch_stake.amount) GROUP BY pool`, and the delegator listing costs roughly 300x more requests. And cNIGHT observation uses a sliding window cache over already-fetched events, in the spirit of `BulkCachedCNightObservationDataSource`, because a per-call implementation is not viable when the observation anchor is far behind the Cardano tip.

## Configuration

Two new optional settings: `blockfrost_endpoint` (base URL of a Blockfrost-compatible API) and `blockfrost_project_id`. Config validation now requires db-sync **or** Blockfrost rather than db-sync unconditionally.

## Performance

Per-call latency, measured by the parity test calling both backends through the same trait on the same anchor block (mainnet, 1,000-block window).

| Data source call | db-sync | Blockfrost | |
|---|---|---|---|
| `get_transfers` (bridge) | ~31,000 ms | **38 ms** | **~800x faster** |
| `get_candidates` | ~1,600 ms | **59 ms** | **~27x faster** |
| `get_stable_block_for` | ~490 ms | **29 ms** | **~17x faster** |
| `get_ariadne_parameters` | ~510 ms | **155 ms** | **~3x faster** |
| `get_federated_authority_data` | ~185 ms | **73 ms** | **~2.5x faster** |
| `get_epoch_nonce` | **~60 ms** | 150 ms | ~2.5x slower |
| `get_utxos_up_to_capacity` (cold cache) | **~2,980 ms** | 25,486 ms | ~8.5x slower |

The two large wins are execution time, not latency: 31 s and 1.6 s are what those queries cost Postgres. The one significant loss is the cold cNIGHT range walk, which is dominated by request count. Running the same comparison against a **self-hosted Dolos on the same machine** over a 400,000-block preview window puts that call at **9,822 ms** against hosted Blockfrost's **423,304 ms** and db-sync's 1,667 ms so co-locating the backend makes it ~43x faster, taking it from roughly 250x slower than db-sync to about 6x. At tip the same call is served from the in-memory window with a median of 0 ms regardless of backend, so this cost applies only to catch-up.

## Operating cost

| | Midnight blocks | Bootstrap requests | Bootstrap time | At tip, 24 h |
|---|---|---|---|---|
| preview | ~226,000 | ~0.5M | ~12 h | 20,000-33,000 |
| preprod | ~1,910,000 | ~4.0M | ~1.6 days | ~30,000 |
| mainnet | ~1,948,000 | ~4.05M | ~2.4 days | ~30,000 |

Note: if you need a trial of the Blockfrost developer plan, shoot an email to support@blockfrost.io with your Blockfrost account email and we will upgrade you. Free tier is fine for following all chains.

## What this does not cover

- **Genesis generation still requires db-sync.** Those subcommands read Cardano data directly through SQL rather than via a data source. They now fail with a message naming that explicitly instead of reporting a missing connection string, and the `blockfrost_endpoint` doc comment says so.
- **The cNIGHT window bounds fetch chunk size, not per-call work.** A single call extends until transaction capacity binds or coverage reaches the tip, so `cnight_observation_window_size` sets how a walk is chunked rather than capping one call. This matches current behaviour; tightening it (background pre-warming, as the db-sync bulk cache does) is a separate change to a consensus-serving path.


## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

**Live parity against db-sync.** `node/tests/blockfrost_parity.rs` drives both backends through the same trait against the same anchor block and asserts equality on the returned structures. Run against live db-sync instances for all three networks, plus an independent Blockfrost implementation:

| Domain | preview | preprod | mainnet | preview via Dolos |
|---|---|---|---|---|
| Block by hash | identical | identical | identical | identical |
| Stable block resolution | identical | identical | identical | identical |
| cNIGHT observation | 6,153 events | 927 events | 967 events | 6,131 events |
| Epoch nonce | identical | identical | identical | identical |
| Ariadne parameters | identical | identical | identical | identical |
| Federated authority | identical | identical | identical | identical |
| Bridge transfers | none on chain | none on chain | 1 transfer + checkpoint | none in window |
| Candidate registrations | none on chain | address unused | address unused | none on chain |

**Independent implementation.** Also verified against Dolos on preview: all ten endpoints this backend calls return 200, and the `from`/`to` cursors behave identically to hosted Blockfrost including inclusive bounds.

**Unit tests.** 21 tests, including a fake HTTP server built on `tokio::net` (no new dependency): pagination termination and the page cap, cursor forwarding, 404 to empty, 429 retry and retry budget, 402 over-quota on both the SDK and raw paths, the deadline bounding a whole retry loop rather than each attempt, metadata paging past page one, and that a sub-query metric is recorded under the expected label.

**CI gates reproduced locally:** `cargo fmt --all -- --check` clean and `cargo clippy --workspace --all-targets --features runtime-benchmarks,try-runtime -- -D warnings` clean.

**Live nodes**, all against hosted Blockfrost with no Cardano node and no db-sync: preview at tip, preprod and mainnet syncing, and [a Raspberry Pi 4 (4 GB)](https://marek.mahut.dev/post/midnight-node-raspberry-pi-dolos/) following preview at tip at roughly 1 GB RSS with `cnight_observation_window_size` at its 100k default.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
