### PR TITLE
fix(local-env): confirm runtime upgrade by spec_version, not upgrade-block events

### DIFF
--- a/changes/node/changed/local-env-runtime-upgrade-success-check.md
+++ b/changes/node/changed/local-env-runtime-upgrade-success-check.md
@@ -18,4 +18,5 @@ and treats a changed `spec_version` as success. It falls back to the
 `System.CodeUpdated` event only when `spec_version` is unchanged (the
 `--allow-same-version` path, where the event shape cannot have changed).
 
+PR: https://github.com/midnightntwrk/midnight-node/pull/1973
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1960

--- a/changes/node/changed/local-env-runtime-upgrade-success-check.md
+++ b/changes/node/changed/local-env-runtime-upgrade-success-check.md
@@ -1,0 +1,21 @@
+#node #fix
+# Confirm governance runtime upgrades by spec_version, not by decoding the upgrade block's events
+
+`federatedRuntimeUpgrade` in `local-environment` previously decided success by
+decoding the applying block's events and asserting `System.CodeUpdated` was
+present. At an upgrade block the events are encoded by the parent (pre-upgrade)
+runtime, while clients resolve metadata at the block's own (post-upgrade) hash;
+when the event shape changes across the upgrade (as it does at the ledger v8->v9
+hardfork, where `CodeUpdated` gains a hash field) that decode fails and the event
+reads as absent. The tool then reported a hard failure on an upgrade that had
+actually executed, which is intermittent (a race on when the client refreshes
+metadata) and misleading enough that an operator might retry a successful upgrade.
+
+The success check now confirms the upgrade by reading the runtime `spec_version`
+before applying and at the applied block via `state_getRuntimeVersion` (which
+decodes `Core_version`, not the events storage, so it is immune to the mismatch),
+and treats a changed `spec_version` as success. It falls back to the
+`System.CodeUpdated` event only when `spec_version` is unchanged (the
+`--allow-same-version` path, where the event shape cannot have changed).
+
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1960

--- a/local-environment/src/commands/federatedRuntimeUpgrade.ts
+++ b/local-environment/src/commands/federatedRuntimeUpgrade.ts
@@ -16,6 +16,7 @@ import type { ApiPromise, WsProvider } from "@polkadot/api";
 import { FederatedRuntimeUpgradeOptions } from "../lib/types";
 import {
   disconnectApi,
+  getSpecVersion,
   hasEvent,
   signAndWait,
 } from "../lib/runtimeUpgradeUtils";
@@ -53,6 +54,14 @@ export async function federatedRuntimeUpgrade(
 
     await executeFederatedMotion(api, authorizeUpgradeCall, signers);
 
+    // Capture the runtime spec_version before applying, so we can confirm the
+    // upgrade by the version actually changing rather than by decoding the
+    // applying block's events. At the upgrade block, events are encoded by the
+    // parent (pre-upgrade) runtime, but clients resolve metadata at the block's
+    // own (post-upgrade) hash, so `System.CodeUpdated` can fail to decode there
+    // and read as absent even though the upgrade executed (see #1960).
+    const specVersionBefore = await getSpecVersion(api);
+
     console.log("Applying authorized upgrade...");
     const applyResult = await signAndWait(
       api.tx.system.applyAuthorizedUpgrade(wasm.hex),
@@ -60,13 +69,30 @@ export async function federatedRuntimeUpgrade(
       "system.applyAuthorizedUpgrade",
     );
 
-    if (!hasEvent(applyResult, "system", "CodeUpdated")) {
+    const appliedBlockHash = applyResult.status.asInBlock;
+    const specVersionAfter = await getSpecVersion(api, appliedBlockHash);
+
+    if (specVersionAfter !== specVersionBefore) {
+      console.log(
+        `Runtime upgrade completed successfully ` +
+          `(spec_version ${specVersionBefore} -> ${specVersionAfter}).`,
+      );
+    } else if (hasEvent(applyResult, "system", "CodeUpdated")) {
+      // spec_version did not change (e.g. --allow-same-version, or a code change
+      // that does not bump spec_version). The event shape is unchanged in that
+      // case, so decoding the applying block's events is reliable here and
+      // System.CodeUpdated is a valid confirmation.
+      console.log(
+        `Runtime upgrade completed successfully ` +
+          `(System.CodeUpdated at spec_version ${specVersionAfter}).`,
+      );
+    } else {
       throw new Error(
-        "Runtime upgrade executed but System.CodeUpdated event not found.",
+        `Runtime upgrade executed but could not be confirmed: spec_version did ` +
+          `not change (still ${specVersionAfter}) and System.CodeUpdated was not ` +
+          `found in block ${appliedBlockHash.toHex()}.`,
       );
     }
-
-    console.log("Runtime upgrade completed successfully.");
   } finally {
     await disconnectApi(api, provider);
   }

--- a/local-environment/src/lib/runtimeUpgradeUtils.ts
+++ b/local-environment/src/lib/runtimeUpgradeUtils.ts
@@ -206,3 +206,20 @@ export function hasEvent(
       evt.event.method === method,
   );
 }
+
+// Read the runtime `spec_version`, optionally at a specific block hash.
+//
+// `state_getRuntimeVersion` decodes the runtime's `Core_version` result, not the
+// block's events storage, so it is immune to the metadata-resolution mismatch at
+// an upgrade block (where a client resolves post-upgrade metadata for events that
+// were encoded by the parent runtime). This makes it a reliable signal for
+// confirming that a runtime upgrade actually took effect.
+export async function getSpecVersion(
+  api: ApiPromise,
+  at?: Uint8Array | string,
+): Promise<number> {
+  const version = at
+    ? await api.rpc.state.getRuntimeVersion(at)
+    : await api.rpc.state.getRuntimeVersion();
+  return version.specVersion.toNumber();
+}


### PR DESCRIPTION
# Overview

Fixes the `governance-runtime-upgrade` (`federatedRuntimeUpgrade`) command in
`local-environment` reporting a **false failure on a successful runtime upgrade**
(issue #1960, Consequence 1).

The command decided success by decoding the applying block's events and asserting
`System.CodeUpdated` was present. At an upgrade block the events are encoded by
the **parent** (pre-upgrade) runtime, while polkadot-js resolves metadata at the
block's **own** (post-upgrade) hash. When the event shape changes across the
upgrade — as it does at the ledger v8->v9 hardfork, where `CodeUpdated` goes from
no fields to carrying a hash — that decode fails and the event reads as absent,
so the tool threw `Runtime upgrade executed but System.CodeUpdated event not found`
even though the upgrade had executed. This is intermittent (a race on when the
client refreshes metadata) and operationally risky: an operator may retry a
successful upgrade.

The success check now confirms the upgrade by the runtime **`spec_version`
actually changing**, read via `state_getRuntimeVersion` (which decodes
`Core_version`, not the events storage, so it is immune to the mismatch), before
applying and at the applied block. A changed `spec_version` is treated as success.
It falls back to the existing `System.CodeUpdated` event check only when
`spec_version` is unchanged — the `--allow-same-version` path, where the event
shape cannot have changed and the decode is reliable.

`federatedRuntimeUpgrade.ts` is the only command doing this event-based success
check, so the change is localized.

**Out of scope (kept for separate/upstream follow-up):** Consequence 2 (subxt /
polkadot-js resolving metadata at the block's own hash, and the chain-indexer
exiting on the upgrade block), and the open question of whether the node should
expose something that lets clients resolve the correct metadata for an upgrade
block. The metadata-resolution behaviour lives in the client libraries rather
than this repo.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Please describe any additional testing aside from CI:

- **Typecheck:** `npx tsc --noEmit -p tsconfig.json` in `local-environment` — clean
  (confirms the polkadot-js usage: `api.rpc.state.getRuntimeVersion(at?)`,
  `version.specVersion.toNumber()`, `applyResult.status.asInBlock`).
- **Lint:** `eslint` + `prettier --check` on the changed files — clean.
- **Live RPC check** against `midnightntwrk/midnight-node:latest-main`
  (`specVersion 2001000`): confirmed `state_getRuntimeVersion` resolves and
  returns a numeric `specVersion` both at the chain head **and at a specific block
  hash** (genesis and a mid-chain block) — this is exactly the
  `getSpecVersion(api, appliedBlockHash)` path the fix relies on, and it is the
  same RPC the issue used to show the version bump `1000000 -> 2001000`.
- **Not run locally:** the full, intermittent v8->v9 governance-upgrade
  reproduction, which needs the pre-fork `node-1.0.0` image alongside a post-fork
  build. The failure mechanism is well understood and this change implements the
  approach suggested in the issue (confirm via the `state_getRuntimeVersion`
  spec-version change rather than by inspecting the applying block's events).

- [ ] Additional tests are provided (if possible)

<!-- The local-environment package has no test runner configured (package.json
`test` is a stub and there are no *.test.ts files), so no unit test was added
rather than introducing a test framework in this fix. -->

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: `local-environment` (midnight-up) developer/operator tooling only — no
  on-chain, runtime, or node-client behavior changes. Only the success/failure
  reporting of the upgrade command changes.

## Links

Addresses #1960 (Consequence 1 — the `governance-runtime-upgrade` false failure).
Not using "Closes" since Consequence 2 (client metadata resolution / chain-indexer)
is out of scope here and largely upstream; maintainers can decide whether to close
#1960 on merge or keep it open to track that part.
