### PR TITLE
chore update toolkit to 2.1.0

### DIFF
--- a/.github/workflows/archive-changes.yml
+++ b/.github/workflows/archive-changes.yml
@@ -197,8 +197,12 @@ jobs:
             RPATCH="${DIGITS:6:3}"
             NEW_RPATCH=$(printf '%03d' $(( 10#$RPATCH + 1 )))
             NEW_SPEC="${RMAJOR}_${RMINOR}_${NEW_RPATCH}"
+            NEW_RUNTIME_VERSION="$((10#$RMAJOR)).$((10#$RMINOR)).$((10#$NEW_RPATCH))"
             sed -i "s/spec_version: ${SPEC_RAW}/spec_version: ${NEW_SPEC}/" runtime/src/lib.rs
+            sed -i "0,/^version = \"$RUNTIME_VERSION\"/s//version = \"$NEW_RUNTIME_VERSION\"/" runtime/Cargo.toml
+            sed -i '/^name = "midnight-node-runtime"/{n;s/version = "'"$RUNTIME_VERSION"'"/version = "'"$NEW_RUNTIME_VERSION"'"/;}' Cargo.lock
             echo "Bumped runtime spec_version: $SPEC_RAW -> $NEW_SPEC"
+            echo "Bumped runtime Cargo.toml version: $RUNTIME_VERSION -> $NEW_RUNTIME_VERSION"
           fi
 
       # Create a signed commit on a new branch and open a PR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8177,7 +8177,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-node-runtime"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "authority-selection-inherents",
  "binary-merkle-tree",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "midnight-node-toolkit"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/docs/tests/docs_tests.rs
+++ b/docs/tests/docs_tests.rs
@@ -98,6 +98,22 @@ fn check_spec_version_matches_node_version() {
 }
 
 #[test]
+fn check_runtime_package_version_matches_spec_version() {
+	let runtime_manifest_str = std::fs::read_to_string("../runtime/Cargo.toml").unwrap();
+	let runtime_manifest: Manifest =
+		toml::from_str(&runtime_manifest_str).expect("Failed to parse runtime Cargo.toml");
+
+	let runtime_spec_version = get_runtime_spec_version();
+	let v: Vec<u32> = runtime_spec_version.split('_').map(|s| s.parse().unwrap()).collect();
+	let spec_version = format!("{}.{}.{}", v[0], v[1], v[2]);
+
+	assert_eq!(
+		runtime_manifest.package.version, spec_version,
+		"runtime/Cargo.toml version must match runtime/src/lib.rs spec_version"
+	);
+}
+
+#[test]
 fn check_toolkit_supports_new_node_version() {
 	let toolkit_runtimes_src =
 		std::fs::read_to_string("../util/toolkit/src/fetcher/runtimes.rs").unwrap();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-node-runtime"
-version = "2.0.0"
+version = "2.1.0"
 description = "A fresh FRAME-based Substrate node, ready for hacking."
 authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
 edition = "2024"

--- a/util/toolkit/Cargo.toml
+++ b/util/toolkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-node-toolkit"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 license-file.workspace = true
 


### PR DESCRIPTION
## Summary
- Bump toolkit and runtime crate versions from `2.0.0` → `2.1.0` to match node / `spec_version` `002_001_000`
- Keep `runtime/Cargo.toml` in sync on post-release bumps, and add a docs test so it can’t drift again

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
