### PR TITLE
fix(rpc): serve ledger state reads at the ledger-hardfork set_code block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10566,13 +10566,18 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "jsonrpsee",
+ "midnight-node-ledger",
+ "midnight-primitives-ledger",
  "pallet-midnight",
+ "parity-scale-codec",
  "sc-client-api",
  "schemars 0.8.22",
  "serde",
  "sp-api",
  "sp-blockchain",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2606)",
  "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]

--- a/changes/node/changed/hardfork-skew-block-rpc-reads.md
+++ b/changes/node/changed/hardfork-skew-block-rpc-reads.md
@@ -25,5 +25,5 @@ Not covered: `chain-indexer` reads `get_zswap_state_root` through a raw `state_c
 API rather than the `midnight_*` RPCs, so it is unaffected by this fix and still needs either
 to switch to `midnight_zswapStateRoot` or its own skip/fallback at that block.
 
-PR: https://github.com/midnightntwrk/midnight-node/pull/TBD
+PR: https://github.com/midnightntwrk/midnight-node/pull/1982
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1959

--- a/changes/node/changed/hardfork-skew-block-rpc-reads.md
+++ b/changes/node/changed/hardfork-skew-block-rpc-reads.md
@@ -1,0 +1,29 @@
+#node #rpc
+# Serve ledger state RPCs at the ledger-hardfork `set_code` block
+
+On a chain that hardforks ledger 8 -> 9 via a governance `set_code`, exactly one historical
+block was permanently unreadable through `midnight_zswapStateRoot`, `midnight_ledgerStateRoot`
+and `midnight_contractState` (`-32602`, underlying `Deserialization(TypedArenaKey)`). The
+pre-fork runtime shipped `system_version: 1`, so `frame_system` overwrote `:code` *inside* the
+`set_code` block while pallet-midnight's v8 -> v9 state translation only ran in the next block's
+`initialize_block`. That block's committed state therefore pairs ledger-9 `:code` with a
+ledger-8 `StateKey` forever, and any read at that hash executes ledger-9 WASM against a
+ledger-8 arena root.
+
+The node's RPC layer now reads `Midnight::StateKey` straight from the state backend and checks
+its tagged-serialization header. If the key belongs to the older ledger version, the read is
+served by calling that version's host functions natively against the same process-global arena;
+otherwise the existing runtime-API path is used unchanged. The `StateKey` tag is the signal
+rather than the pallet storage version, because the 2.0.0 runtime already ran ledger 9 while
+still reporting pallet-midnight storage version 1.
+
+Behaviour note: at the `set_code` block `midnight_ledgerStateRoot` now returns a **v8-tagged**
+root — correct, since that block's state *is* v8 — so consumers walking the fork see the tag
+flip at the migration block rather than a hole.
+
+Not covered: `chain-indexer` reads `get_zswap_state_root` through a raw `state_call` runtime
+API rather than the `midnight_*` RPCs, so it is unaffected by this fix and still needs either
+to switch to `midnight_zswapStateRoot` or its own skip/fallback at that block.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/TBD
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1959

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -203,6 +203,22 @@ pub fn init_ledger_storage_unified<
 	}
 }
 
+/// Returns true if `state_key` is a ledger-8 arena root, i.e. a tagged-serialized
+/// `TypedArenaKey<ledger_8::api::Ledger<_>, _>`.
+#[cfg(feature = "std")]
+pub fn is_ledger_8_state_key(state_key: &[u8]) -> bool {
+	use ledger_storage_ledger_8::{DefaultDB, arena::TypedArenaKey, db::DB};
+	use midnight_serialize::Tagged;
+
+	type Ledger8Root = TypedArenaKey<ledger_8::api::Ledger<DefaultDB>, <DefaultDB as DB>::Hasher>;
+
+	let expected = <Ledger8Root as Tagged>::tag();
+	match midnight_serialize::peek_tag(&mut std::io::Cursor::new(state_key)) {
+		Ok(tag) => tag.as_str() == expected.as_ref(),
+		Err(_) => false,
+	}
+}
+
 mod common;
 
 pub mod types {
@@ -247,12 +263,12 @@ mod tests {
 		assert!(try_get_default_storage::<ParityDb>().is_none());
 	}
 
-	/// `state_key_matches_this_version` is what the node's RPC layer dispatches on
-	/// to read the `set_code` block of a ledger hardfork, whose `StateKey` is one
-	/// version behind its `:code` (GH #1959). It has to tell v8 and v9 arena roots
-	/// apart from the header tag alone.
+	/// `is_ledger_8_state_key` is what the node's RPC layer dispatches on to read the
+	/// `set_code` block of the 8->9 hardfork, whose `StateKey` is one version behind
+	/// its `:code` (GH #1959). It has to tell a ledger-8 arena root from a ledger-9
+	/// one from the header tag alone.
 	#[test]
-	fn state_key_tag_discriminates_ledger_versions() {
+	fn ledger_8_state_key_tag_is_recognised() {
 		use ledger_storage_ledger_8::DefaultDB;
 		use midnight_serialize::{GLOBAL_TAG, Tagged};
 
@@ -266,14 +282,12 @@ mod tests {
 		let v9 = header::<mn_ledger_9::structure::LedgerState<DefaultDB>>();
 		assert_ne!(v8, v9, "v8 and v9 ledger states must not share a tag");
 
-		assert!(super::ledger_8::storage::state_key_matches_this_version(&v8));
-		assert!(!super::ledger_8::storage::state_key_matches_this_version(&v9));
-		assert!(super::ledger_9::storage::state_key_matches_this_version(&v9));
-		assert!(!super::ledger_9::storage::state_key_matches_this_version(&v8));
+		assert!(super::is_ledger_8_state_key(&v8));
+		assert!(!super::is_ledger_8_state_key(&v9));
 
-		// An unset `StateKey`, or anything else untagged, is not a v8 root: the RPC
-		// layer must fall through to the runtime API rather than guess.
-		assert!(!super::ledger_8::storage::state_key_matches_this_version(&[]));
-		assert!(!super::ledger_8::storage::state_key_matches_this_version(b"not-tagged-at-all"));
+		// An unset `StateKey`, or anything else untagged, is not a ledger-8 root: the
+		// RPC layer must fall through to the runtime API rather than guess.
+		assert!(!super::is_ledger_8_state_key(&[]));
+		assert!(!super::is_ledger_8_state_key(b"not-tagged-at-all"));
 	}
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -246,4 +246,34 @@ mod tests {
 		unsafe_drop_default_storage::<ParityDb>();
 		assert!(try_get_default_storage::<ParityDb>().is_none());
 	}
+
+	/// `state_key_matches_this_version` is what the node's RPC layer dispatches on
+	/// to read the `set_code` block of a ledger hardfork, whose `StateKey` is one
+	/// version behind its `:code` (GH #1959). It has to tell v8 and v9 arena roots
+	/// apart from the header tag alone.
+	#[test]
+	fn state_key_tag_discriminates_ledger_versions() {
+		use ledger_storage_ledger_8::DefaultDB;
+		use midnight_serialize::{GLOBAL_TAG, Tagged};
+
+		// A `StateKey` is `tagged_serialize(&Sp<Ledger<D>, D>::as_typed_key())`, and
+		// `TypedArenaKey`'s tag wraps its referent's — which for `Ledger` is just
+		// `LedgerState`'s. Only the header matters here; `peek_tag` never reads the body.
+		fn header<T: Tagged>() -> Vec<u8> {
+			format!("{GLOBAL_TAG}storage-key({}):", T::tag()).into_bytes()
+		}
+		let v8 = header::<mn_ledger_8::structure::LedgerState<DefaultDB>>();
+		let v9 = header::<mn_ledger_9::structure::LedgerState<DefaultDB>>();
+		assert_ne!(v8, v9, "v8 and v9 ledger states must not share a tag");
+
+		assert!(super::ledger_8::storage::state_key_matches_this_version(&v8));
+		assert!(!super::ledger_8::storage::state_key_matches_this_version(&v9));
+		assert!(super::ledger_9::storage::state_key_matches_this_version(&v9));
+		assert!(!super::ledger_9::storage::state_key_matches_this_version(&v8));
+
+		// An unset `StateKey`, or anything else untagged, is not a v8 root: the RPC
+		// layer must fall through to the runtime API rather than guess.
+		assert!(!super::ledger_8::storage::state_key_matches_this_version(&[]));
+		assert!(!super::ledger_8::storage::state_key_matches_this_version(b"not-tagged-at-all"));
+	}
 }

--- a/ledger/src/versions/common/storage.rs
+++ b/ledger/src/versions/common/storage.rs
@@ -93,6 +93,24 @@ pub fn genesis_matches_this_version(genesis_state: &[u8]) -> bool {
 	}
 }
 
+/// Returns true if `state_key` is a tagged-serialized arena root
+/// (`TypedArenaKey<Ledger<_>, _>`) of *this* ledger version.
+#[cfg(feature = "std")]
+pub fn state_key_matches_this_version(state_key: &[u8]) -> bool {
+	use super::api::Ledger;
+	use super::ledger_storage_local::{DefaultDB, arena::TypedArenaKey};
+
+	// `TypedArenaKey`'s tag wraps its referent's: `storage-key(ledger-state[vN])`.
+	// The hasher parameter contributes nothing to the tag, so `DefaultDB`'s hasher
+	// gives the right answer for both storage modes.
+	let expected = <TypedArenaKey<Ledger<DefaultDB>, <DefaultDB as DB>::Hasher> as Tagged>::tag();
+	// `peek_tag` reads the serialized header tag without deserializing the body.
+	match super::midnight_serialize_local::peek_tag(&mut std::io::Cursor::new(state_key)) {
+		Ok(tag) => tag.as_str() == expected.as_ref(),
+		Err(_) => false,
+	}
+}
+
 pub fn get_root(state: &[u8], network_id: Option<&str>) -> Result<Vec<u8>, GetRootError> {
 	// Get empty state key
 	use super::api::Ledger;

--- a/ledger/src/versions/common/storage.rs
+++ b/ledger/src/versions/common/storage.rs
@@ -93,24 +93,6 @@ pub fn genesis_matches_this_version(genesis_state: &[u8]) -> bool {
 	}
 }
 
-/// Returns true if `state_key` is a tagged-serialized arena root
-/// (`TypedArenaKey<Ledger<_>, _>`) of *this* ledger version.
-#[cfg(feature = "std")]
-pub fn state_key_matches_this_version(state_key: &[u8]) -> bool {
-	use super::api::Ledger;
-	use super::ledger_storage_local::{DefaultDB, arena::TypedArenaKey};
-
-	// `TypedArenaKey`'s tag wraps its referent's: `storage-key(ledger-state[vN])`.
-	// The hasher parameter contributes nothing to the tag, so `DefaultDB`'s hasher
-	// gives the right answer for both storage modes.
-	let expected = <TypedArenaKey<Ledger<DefaultDB>, <DefaultDB as DB>::Hasher> as Tagged>::tag();
-	// `peek_tag` reads the serialized header tag without deserializing the body.
-	match super::midnight_serialize_local::peek_tag(&mut std::io::Cursor::new(state_key)) {
-		Ok(tag) => tag.as_str() == expected.as_ref(),
-		Err(_) => false,
-	}
-}
-
 pub fn get_root(state: &[u8], network_id: Option<&str>) -> Result<Vec<u8>, GetRootError> {
 	// Get empty state key
 	use super::api::Ledger;

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -25,6 +25,7 @@ use midnight_node_runtime::{
 	AccountId, BlockNumber, CrossChainPublic, Hash, Nonce,
 	opaque::{Block, SessionKeys},
 };
+use midnight_primitives_ledger::LedgerStorage;
 use sc_client_api::{BlockBackend, BlockchainEvents};
 use sc_consensus_grandpa::{
 	FinalityProofProvider, GrandpaJustificationStream, SharedAuthoritySet, SharedVoterState,
@@ -108,6 +109,9 @@ pub struct FullDeps<C, P, B, T, AuthorityId: AuthorityIdBound> {
 	pub main_chain_epoch_config: MainchainEpochConfig,
 	/// Backend used by the node.
 	pub backend: Arc<B>,
+	/// Ledger storage configuration, used by the Midnight RPCs to read historical
+	/// blocks whose ledger state predates the v8->v9 hardfork translation.
+	pub ledger_storage: LedgerStorage,
 	/// Network service for peer reputation queries.
 	pub network: Arc<dyn NetworkPeers + Send + Sync>,
 	/// Channel for system RPC requests (used to query connected peers).
@@ -126,6 +130,7 @@ where
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
 	C: BlockBackend<Block>,
 	C: BlockchainEvents<Block>,
+	C: sc_client_api::StorageProvider<Block, B>,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: BlockBuilder<Block>,
@@ -163,6 +168,7 @@ where
 		time_source,
 		main_chain_epoch_config,
 		backend,
+		ledger_storage,
 		network,
 		system_rpc_tx,
 		subscription_tracker,
@@ -242,7 +248,7 @@ where
 	));
 
 	module.merge(SessionValidatorManagementRpc::new(session_validator_query.clone()).into_rpc())?;
-	module.merge(Midnight::new(client.clone()).into_rpc())?;
+	module.merge(Midnight::<_, Block, B>::new(client.clone(), ledger_storage).into_rpc())?;
 	module.merge(SystemParametersRpc::new(client, session_validator_query).into_rpc())?;
 	module.merge(PeerInfoRpc::new(network, system_rpc_tx).into_rpc())?;
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -258,6 +258,7 @@ type MidnightService = sc_service::PartialComponents<
 		sc_consensus_beefy::BeefyRPCLinks<Block, BeefyId>,
 		Option<Telemetry>,
 		DataSources,
+		LedgerStorage,
 	),
 >;
 
@@ -391,7 +392,7 @@ pub fn new_partial(
 		.execution_extensions()
 		.set_extensions_factory(ExtensionsFactory::<Block>::new(
 			Arc::new(Mutex::new(ledger_metrics)),
-			ledger_storage,
+			ledger_storage.clone(),
 			TBlockCorrection::from(&midnight_cfg),
 		));
 
@@ -504,6 +505,7 @@ pub fn new_partial(
 			beefy_rpc_links,
 			telemetry,
 			data_sources,
+			ledger_storage,
 		),
 	};
 
@@ -544,6 +546,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 				beefy_rpc_links,
 				mut telemetry,
 				data_sources,
+				ledger_storage,
 			),
 	} = new_partial_components;
 
@@ -667,6 +670,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		let network_for_rpc = network.clone();
 		let system_rpc_tx_for_rpc = system_rpc_tx.clone();
 		let subscription_tracker = subscription_tracker.clone();
+		let ledger_storage_for_rpc = ledger_storage;
 
 		#[allow(clippy::result_large_err)]
 		move |subscription_executor: SubscriptionTaskExecutor| {
@@ -696,6 +700,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 				time_source: Arc::new(SystemTimeSource),
 				main_chain_epoch_config: epoch_config.clone(),
 				backend: backend.clone(),
+				ledger_storage: ledger_storage_for_rpc.clone(),
 				network: network_for_rpc.clone(),
 				system_rpc_tx: system_rpc_tx_for_rpc.clone(),
 				subscription_tracker: subscription_tracker.clone(),

--- a/pallets/midnight/rpc/Cargo.toml
+++ b/pallets/midnight/rpc/Cargo.toml
@@ -15,13 +15,23 @@ sc-client-api.workspace = true
 sp-api.workspace = true
 sp-runtime.workspace = true
 sp-blockchain.workspace = true
+sp-crypto-hashing.workspace = true
+sp-state-machine.workspace = true
+parity-scale-codec.workspace = true
 pallet-midnight.workspace = true
+midnight-node-ledger.workspace = true
+midnight-primitives-ledger.workspace = true
 
 [features]
 default = ["std"]
 std = [
+    "midnight-node-ledger/std",
+    "midnight-primitives-ledger/std",
+    "parity-scale-codec/std",
     "sp-api/std",
+    "sp-crypto-hashing/std",
     "sp-runtime/std",
+    "sp-state-machine/std",
     "pallet-midnight/std"
 ]
 

--- a/pallets/midnight/rpc/src/lib.rs
+++ b/pallets/midnight/rpc/src/lib.rs
@@ -21,11 +21,19 @@ use jsonrpsee::{
 	types::error::{ErrorObject, ErrorObjectOwned, INVALID_PARAMS_CODE},
 };
 
+use midnight_node_ledger::{
+	host_api::ledger_8::ledger_8_bridge,
+	ledger_8::{self, types::LedgerApiError as Ledger8ApiError},
+};
+use midnight_primitives_ledger::{LedgerStorage, LedgerStorageExt};
 use pallet_midnight::{LedgerApiError, MidnightRuntimeApi};
-use sc_client_api::{BlockBackend, BlockchainEvents};
+use parity_scale_codec::Decode;
+use sc_client_api::{Backend, BlockBackend, BlockchainEvents, StorageKey, StorageProvider};
 use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
+use sp_crypto_hashing::twox_128;
 use sp_runtime::traits::Block as BlockT;
+use sp_state_machine::BasicExternalities;
 use std::sync::Arc;
 
 pub const API_VERSIONS: [u32; 1] = [2];
@@ -238,16 +246,58 @@ pub struct RpcBlock<Header> {
 	pub transactions_index: Vec<(String, String)>,
 }
 
-pub struct Midnight<C, Block> {
+pub struct Midnight<C, Block, B> {
 	/// Shared reference to the client.
 	client: Arc<C>,
+	/// The node's ledger storage configuration. Needed to build an externalities
+	/// scope for native ledger host calls, see [`Midnight::with_ledger_storage`].
+	ledger_storage: LedgerStorage,
 	//todo do I need this one?
-	_marker: std::marker::PhantomData<Block>,
+	_marker: std::marker::PhantomData<(Block, B)>,
 }
 
-impl<C, Block> Midnight<C, Block> {
-	pub fn new(client: Arc<C>) -> Self {
-		Self { client, _marker: Default::default() }
+impl<C, Block, B> Midnight<C, Block, B> {
+	pub fn new(client: Arc<C>, ledger_storage: LedgerStorage) -> Self {
+		Self { client, ledger_storage, _marker: Default::default() }
+	}
+}
+
+impl<C, Block, B> Midnight<C, Block, B>
+where
+	Block: BlockT,
+	B: Backend<Block>,
+	C: StorageProvider<Block, B>,
+{
+	/// The ledger-8 arena root at `at`, if this block predates the v8->v9 ledger
+	/// state translation.
+	///
+	/// `None` — i.e. "use the runtime API as usual" — when the state is
+	/// unavailable, `StateKey` is unset, or the key is already ledger-9.
+	///
+	/// `StateKey` is read straight from the state backend rather than through the
+	/// runtime API on purpose: at the `set_code` block of the hardfork the runtime
+	/// API is precisely what cannot read it (the block's committed state pairs
+	/// ledger-9 `:code` with a ledger-8 `StateKey`).
+	fn maybe_ledger_8_state_key(&self, at: Block::Hash) -> Option<Vec<u8>> {
+		// Same derivation as `util/toolkit/src/client.rs`: the storage key is
+		// twox_128("Midnight") ++ twox_128("StateKey").
+		let key = StorageKey([twox_128(b"Midnight"), twox_128(b"StateKey")].concat());
+		let raw = self.client.storage(at, &key).ok().flatten()?;
+		let state_key = Vec::<u8>::decode(&mut &raw.0[..]).ok()?;
+		ledger_8::storage::state_key_matches_this_version(&state_key).then_some(state_key)
+	}
+
+	/// Run a ledger host function natively, inside a minimal externalities scope
+	/// carrying the node's `LedgerStorageExt`.
+	///
+	/// `#[runtime_interface]` host functions take `&mut self` and so require an
+	/// externalities environment. The ledger ones use it only to read
+	/// `LedgerStorageExt` and pick the storage mode; without the extension they
+	/// silently assume `Separate`, which would panic on a unified-storage node.
+	fn with_ledger_storage<R>(&self, f: impl FnOnce() -> R) -> R {
+		let mut ext = BasicExternalities::new_empty();
+		ext.register_extension(LedgerStorageExt::new(self.ledger_storage.clone()));
+		ext.execute_with(f)
 	}
 }
 
@@ -269,14 +319,16 @@ where
 		.ok_or(sp_api::ApiError::UsingSameInstanceForDifferentBlocks)
 }
 
-impl<C, Block> MidnightApiServer<<Block as BlockT>::Hash> for Midnight<C, Block>
+impl<C, Block, B> MidnightApiServer<<Block as BlockT>::Hash> for Midnight<C, Block, B>
 where
 	Block: BlockT,
+	B: Backend<Block> + 'static,
 	C: Send + Sync + 'static,
 	C: ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block>,
 	C: BlockBackend<Block>,
 	C: BlockchainEvents<Block>,
+	C: StorageProvider<Block, B>,
 	C::Api: MidnightRuntimeApi<Block>,
 {
 	fn get_state(
@@ -295,6 +347,21 @@ where
 
 		let api_version = get_api_version::<C, Block>(&api, at)
 			.map_err(|_| StateRpcError::UnableToGetContractState)?;
+
+		if let Some(state_key) = self.maybe_ledger_8_state_key(at) {
+			let result = self
+				.with_ledger_storage(|| ledger_8_bridge::get_contract_state(&state_key, &dehexed))
+				.map_err(|e| match e {
+					// Same legacy contract as below: api_version < 2 predates
+					// ContractNotPresent and must keep seeing the generic error.
+					Ledger8ApiError::ContractNotPresent if api_version >= 2 => {
+						StateRpcError::ContractNotPresent
+					},
+					_ => StateRpcError::UnableToGetContractState,
+				})?;
+
+			return Ok(hex::encode(result));
+		}
 
 		let result = if api_version < 2 {
 			// Legacy path: v1 of the RPC contract predates ContractNotPresent,
@@ -323,6 +390,12 @@ where
 	) -> Result<Vec<u8>, StateRpcError> {
 		let at = at.unwrap_or_else(|| self.client.info().best_hash);
 
+		if let Some(state_key) = self.maybe_ledger_8_state_key(at) {
+			return self
+				.with_ledger_storage(|| ledger_8_bridge::get_zswap_state_root(&state_key))
+				.map_err(|_| StateRpcError::UnableToGetZSwapStateRoot);
+		}
+
 		let root = self
 			.client
 			.runtime_api()
@@ -340,6 +413,12 @@ where
 		at: Option<<Block as BlockT>::Hash>,
 	) -> Result<Vec<u8>, StateRpcError> {
 		let at = at.unwrap_or_else(|| self.client.info().best_hash);
+
+		if let Some(state_key) = self.maybe_ledger_8_state_key(at) {
+			return self
+				.with_ledger_storage(|| ledger_8_bridge::get_ledger_state_root(&state_key))
+				.map_err(|_| StateRpcError::UnableToGetLedgerStateRoot);
+		}
 
 		let root = self
 			.client

--- a/pallets/midnight/rpc/src/lib.rs
+++ b/pallets/midnight/rpc/src/lib.rs
@@ -22,8 +22,8 @@ use jsonrpsee::{
 };
 
 use midnight_node_ledger::{
-	host_api::ledger_8::ledger_8_bridge,
-	ledger_8::{self, types::LedgerApiError as Ledger8ApiError},
+	host_api::ledger_8::ledger_8_bridge, is_ledger_8_state_key,
+	ledger_8::types::LedgerApiError as Ledger8ApiError,
 };
 use midnight_primitives_ledger::{LedgerStorage, LedgerStorageExt};
 use pallet_midnight::{LedgerApiError, MidnightRuntimeApi};
@@ -284,7 +284,7 @@ where
 		let key = StorageKey([twox_128(b"Midnight"), twox_128(b"StateKey")].concat());
 		let raw = self.client.storage(at, &key).ok().flatten()?;
 		let state_key = Vec::<u8>::decode(&mut &raw.0[..]).ok()?;
-		ledger_8::storage::state_key_matches_this_version(&state_key).then_some(state_key)
+		is_ledger_8_state_key(&state_key).then_some(state_key)
 	}
 
 	/// Run a ledger host function natively, inside a minimal externalities scope

--- a/util/toolkit/tests/hardfork_e2e.rs
+++ b/util/toolkit/tests/hardfork_e2e.rs
@@ -19,6 +19,7 @@ use clap::Parser;
 use common::{test_image, wait_for_node::wait_for_finalized_block};
 use midnight_node_toolkit::cli::{Cli, run_command};
 use std::{process::Command, time::Duration};
+use subxt::rpcs::{RpcClient, rpc_params};
 use testcontainers::{
 	GenericImage, ImageExt,
 	core::{ContainerPort, WaitFor},
@@ -51,6 +52,89 @@ async fn run_cli(args: &[&str]) {
 		panic!("CLI command failed: {e}");
 	}
 	eprintln!("[hardfork_e2e] CLI command succeeded");
+}
+
+/// Hash of the block at `height`, hex-encoded.
+async fn block_hash_at(rpc: &RpcClient, height: u64) -> String {
+	let hash: serde_json::Value = rpc
+		.request("chain_getBlockHash", rpc_params![height])
+		.await
+		.unwrap_or_else(|e| panic!("chain_getBlockHash({height}) failed: {e}"));
+	hash.as_str()
+		.unwrap_or_else(|| panic!("no block at height {height}"))
+		.to_owned()
+}
+
+/// The runtime `specVersion` *stored at* `hash`.
+///
+/// Raw `state_getRuntimeVersion` rather than subxt's typed metadata on purpose:
+/// across a runtime upgrade the client's metadata follows the new runtime, so
+/// anything the old runtime encoded decodes unreliably. See
+/// `midnight_node_toolkit::commands::runtime_upgrade`.
+async fn spec_version_at(rpc: &RpcClient, hash: &str) -> u64 {
+	let version: serde_json::Value = rpc
+		.request("state_getRuntimeVersion", rpc_params![hash])
+		.await
+		.unwrap_or_else(|e| panic!("state_getRuntimeVersion({hash}) failed: {e}"));
+	version
+		.get("specVersion")
+		.and_then(|v| v.as_u64())
+		.unwrap_or_else(|| panic!("no specVersion in runtime version at {hash}"))
+}
+
+async fn finalized_height(rpc: &RpcClient) -> u64 {
+	let hash: serde_json::Value = rpc
+		.request("chain_getFinalizedHead", rpc_params![])
+		.await
+		.expect("chain_getFinalizedHead failed");
+	let header: serde_json::Value = rpc
+		.request("chain_getHeader", rpc_params![hash])
+		.await
+		.expect("chain_getHeader failed");
+	header
+		.get("number")
+		.and_then(|n| n.as_str())
+		.and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+		.expect("no number in finalized header")
+}
+
+/// Locate the block that applied the new runtime code — the one whose committed
+/// state pairs the *new* `:code` with the *old* ledger version's `StateKey`.
+///
+/// `frame_system` overwrites `:code` inside that block (the pre-fork runtime ships
+/// `system_version: 1`, so the code is not staged in `:pending_code`), while
+/// pallet-midnight's v8->v9 state translation only runs in the next block's
+/// `initialize_block`. Executing a read at that hash therefore runs ledger-9 WASM
+/// against a ledger-8 arena root, which is what GH #1959 reports.
+///
+/// `state_getRuntimeVersion` reports the code stored at a block, so the first
+/// height reporting the new spec is exactly that block. spec_version is monotonic
+/// along the chain, so binary-search for it.
+async fn find_code_applied_block(rpc: &RpcClient, head: u64, old_spec: u64) -> u64 {
+	let (mut lo, mut hi) = (1u64, head);
+	while lo < hi {
+		let mid = lo + (hi - lo) / 2;
+		let hash = block_hash_at(rpc, mid).await;
+		if spec_version_at(rpc, &hash).await > old_spec {
+			hi = mid;
+		} else {
+			lo = mid + 1;
+		}
+	}
+	lo
+}
+
+/// Both ledger state-root RPCs must answer at `height`.
+async fn assert_state_roots_readable(rpc: &RpcClient, height: u64, label: &str) {
+	let hash = block_hash_at(rpc, height).await;
+	for method in ["midnight_zswapStateRoot", "midnight_ledgerStateRoot"] {
+		let root: Vec<u8> = rpc
+			.request(method, rpc_params![&hash])
+			.await
+			.unwrap_or_else(|e| panic!("{method} failed at {label} (#{height}, {hash}): {e}"));
+		assert!(!root.is_empty(), "{method} returned an empty root at {label} (#{height})");
+	}
+	eprintln!("[hardfork_e2e] state roots readable at {label} (#{height})");
 }
 
 #[test_log::test(tokio::test)]
@@ -140,7 +224,34 @@ async fn hardfork_single_tx() {
 	])
 	.await;
 
-	// 5. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
+	// 5. GH #1959: the whole fork boundary must stay readable. The block that
+	//    applied the new code carries a ledger-8 `StateKey` under ledger-9 `:code`,
+	//    so the RPC layer has to detect that and fall back to the ledger-8 host
+	//    functions; the block after it is already translated to v9 and must keep
+	//    taking the ordinary runtime-API path.
+	let rpc = RpcClient::from_insecure_url(&url).await.expect("failed to open raw RPC client");
+	let pre_fork_spec = {
+		let hash = block_hash_at(&rpc, 1).await;
+		spec_version_at(&rpc, &hash).await
+	};
+	let head = finalized_height(&rpc).await;
+	let applied = find_code_applied_block(&rpc, head, pre_fork_spec).await;
+	eprintln!(
+		"[hardfork_e2e] new runtime code applied at #{applied} \
+		 (pre-fork spec {pre_fork_spec}, finalized head #{head})"
+	);
+	assert!(applied > 1, "expected the code-applying block to be past #1, got #{applied}");
+	assert!(applied < head, "expected the code-applying block to be below the finalized head");
+
+	// `runtime-upgrade` already waits for finality to pass `applied`, but the
+	// assertion below needs `applied + 1` to exist regardless.
+	wait_for_finalized_block(&url, applied + 1, Duration::from_secs(60)).await;
+
+	assert_state_roots_readable(&rpc, applied - 1, "pre-fork").await;
+	assert_state_roots_readable(&rpc, applied, "code-applied block").await;
+	assert_state_roots_readable(&rpc, applied + 1, "post-migration").await;
+
+	// 6. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
 	run_cli(&[
 		"generate-txs",
 		"--fetch-cache",


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

At the block where a runtime upgrade `set_code` is run, storage migrations have not yet been applied. This leads to a mis-match between runtime code and node state - the runtime API attempts to load pre-migration state using new code paths, causing errors.

The indexer code already keeps track of this code/data drift: https://github.com/midnightntwrk/midnight-indexer/blob/55ec85cc06989e9c14c70c5a76edeb7e04b7ba24/chain-indexer/src/infra/subxt_node.rs#L202-L211

This PR fixes three ledger RPC calls for the runtime-upgrade block - we dispatch based on the ledger state key tag to either the ledger 8 or ledger 9 host apis. One of these RPC calls is used by the current indexer implementation, so unless the indexer code changes to avoid this call, it's broken without this fix.

Once we get `system_version: 3` into the runtime, this issue will no longer exist - see https://github.com/midnightntwrk/midnight-node/pull/1900


## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
