### PR TITLE
fix(node): garbage-collect ledger_storage to honour state pruning

### DIFF
--- a/changes/node/changed/ledger-storage-pruning-gc.md
+++ b/changes/node/changed/ledger-storage-pruning-gc.md
@@ -1,0 +1,12 @@
+#ledger #storage #node
+# Garbage-collect ledger_storage to honour state pruning
+
+`ledger_storage` previously retained every persisted arena root forever, so a
+pruned validator's ledger DB grew without bound (~197G vs ~7G paritydb on
+preprod). A background worker now collects `Midnight::StateKey` values for the
+blocks still covered by Substrate `--state-pruning` (plus non-finalized forks)
+and runs the storage crate's incremental GC against that live root set.
+
+Archive nodes skip the worker and keep full ledger history.
+
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1983

--- a/ledger/src/gc.rs
+++ b/ledger/src/gc.rs
@@ -1,0 +1,267 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Garbage collection for the ledger storage arena.
+//!
+//! Every ledger host call that mutates state (`apply_transaction`,
+//! `apply_system_transaction`, `apply_post_block_update`, ...) persists the
+//! resulting state root in the storage arena, and nothing ever unpersists
+//! them. Left alone, the arena therefore accumulates every per-transaction
+//! and per-block state root since genesis — including roots from discarded
+//! block proposals — regardless of the node's pruning configuration
+//! (see <https://github.com/midnightntwrk/midnight-node/issues/1983>).
+//!
+//! This module exposes [`collect_garbage`], which runs the storage crate's
+//! incremental, time-budgeted mark-and-sweep collector
+//! ([`StorageBackend::gc_override_gc_roots`]) against an explicit set of
+//! *live* state keys supplied by the caller. Anything unreachable from those
+//! roots (or from in-flight, in-memory objects, which the backend tracks
+//! itself via `live_inserts`) is deleted, and any persisted root not in the
+//! set is effectively unpersisted. The node derives the live set from the
+//! `Midnight::StateKey` storage value of every block whose Substrate state
+//! is still retained, so the arena's retention exactly matches the node's
+//! state-pruning window.
+//!
+//! Using an override root set (rather than matched `unpersist` calls)
+//! sidesteps the persist reference-counting problem: the same root may be
+//! persisted several times (block authoring and import both execute the
+//! block; intermediate per-transaction roots are superseded within the same
+//! block) and would otherwise need an exactly matched number of unpersists.
+//!
+//! Only the ledger-8/9 storage backend (`ledger-storage-ledger-8`, shared by
+//! both ledger versions) supports garbage collection; the legacy ledger-7
+//! storage crate predates the collector. Callers must therefore only invoke
+//! this while the node is not re-executing ledger-7-era blocks (in practice:
+//! not during major sync).
+
+use std::time::Duration;
+
+use midnight_primitives_ledger::LedgerStorageExt;
+
+use ledger_storage_ledger_8::{
+	arena::{ArenaHash, ArenaKey, TypedArenaKey},
+	db::{DB, ParityDb, paritydb::OwnedDb},
+	storage::try_get_default_storage,
+};
+use midnight_serialize::tagged_deserialize;
+
+const LOG_TARGET: &str = "midnight::ledger_gc";
+
+// The two `ParityDb` instantiations under which the ledger-8/9 storage may be
+// registered, depending on the operator's `storage_separation` config (see
+// `host_api/ledger_8.rs`).
+type DbSeparate = ParityDb;
+type DbUnified = ParityDb<sha2::Sha256, OwnedDb, { LedgerStorageExt::COLUMN_OFFSET }>;
+
+/// Result of one garbage-collection slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcOutcome {
+	/// Number of arena nodes deleted from storage during this slice.
+	pub culled: usize,
+	/// Number of live root hashes derived from the supplied state keys.
+	pub live_roots: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcError {
+	/// A supplied state key failed to deserialize as a ledger-8 or ledger-9
+	/// state key. The GC slice is aborted: culling with an incomplete root
+	/// set could delete live data.
+	UnrecognizedStateKey,
+	/// No GC-capable ledger storage (ledger-8/9) is initialized yet.
+	StorageNotInitialized,
+}
+
+impl core::fmt::Display for GcError {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match self {
+			GcError::UnrecognizedStateKey => {
+				write!(f, "state key is not a recognized ledger-8/9 state key")
+			},
+			GcError::StorageNotInitialized => {
+				write!(f, "ledger-8/9 storage is not initialized")
+			},
+		}
+	}
+}
+
+/// Convert serialized `Midnight::StateKey` values into arena root hashes.
+///
+/// A state key is a tagged `TypedArenaKey<Ledger<D>>`; the tag differs
+/// between ledger versions, so both are tried (a retention window spanning
+/// the 8->9 hardfork contains keys of both tags). Small states may be
+/// serialized as a `Direct` key embedding the object inline — in that case
+/// the key itself holds the data and the roots to protect are its referenced
+/// children.
+fn state_key_roots<D: DB>(state_keys: &[Vec<u8>]) -> Result<Vec<ArenaHash<D::Hasher>>, GcError> {
+	let mut roots = Vec::with_capacity(state_keys.len());
+	for bytes in state_keys {
+		let key: ArenaKey<D::Hasher> = if let Ok(key) = tagged_deserialize::<
+			TypedArenaKey<crate::ledger_9::api::Ledger<D>, D::Hasher>,
+		>(&mut &bytes[..])
+		{
+			key.into()
+		} else if let Ok(key) = tagged_deserialize::<
+			TypedArenaKey<crate::ledger_8::api::Ledger<D>, D::Hasher>,
+		>(&mut &bytes[..])
+		{
+			key.into()
+		} else {
+			// Expected while the live window still contains pre-ledger-8
+			// blocks (initial sync): their state keys carry older tags. The
+			// caller skips the slice and retries later.
+			log::debug!(
+				target: LOG_TARGET,
+				"Aborting GC slice: unrecognized state key ({} bytes)",
+				bytes.len()
+			);
+			return Err(GcError::UnrecognizedStateKey);
+		};
+		roots.extend(key.refs().into_iter().cloned());
+	}
+	Ok(roots)
+}
+
+fn gc_storage<D: DB + std::any::Any>(
+	budget: Duration,
+	state_keys: &[Vec<u8>],
+) -> Result<Option<GcOutcome>, GcError> {
+	let Some(storage) = try_get_default_storage::<D>() else {
+		return Ok(None);
+	};
+	let roots = state_key_roots::<D>(state_keys)?;
+	let live_roots = roots.len();
+	let culled = storage
+		.arena
+		.with_backend(|backend| backend.gc_override_gc_roots(budget, move |_| roots));
+	Ok(Some(GcOutcome { culled, live_roots }))
+}
+
+/// Run one time-budgeted garbage-collection slice on the default ledger-8/9
+/// storage, treating `live_state_keys` (serialized `Midnight::StateKey`
+/// values of all blocks the node can still serve) as the complete set of
+/// persisted roots to keep.
+///
+/// **Warning**: any persisted root *not* reachable from `live_state_keys` is
+/// irreversibly unpersisted and its exclusively-owned data deleted. The
+/// caller is responsible for supplying every root it still needs.
+///
+/// The collector is incremental: a slice that exhausts `budget` parks its
+/// progress and resumes on the next call, so a return of `culled == 0` does
+/// not mean no progress was made. The backend lock is held for roughly
+/// `budget`, which blocks concurrent ledger host calls — keep budgets small
+/// (hundreds of milliseconds).
+pub fn collect_garbage(
+	budget: Duration,
+	live_state_keys: &[Vec<u8>],
+) -> Result<GcOutcome, GcError> {
+	// Exactly one of the two instantiations is registered in practice
+	// (separate vs unified storage); run on whichever exists.
+	if let Some(outcome) = gc_storage::<DbSeparate>(budget, live_state_keys)? {
+		return Ok(outcome);
+	}
+	if let Some(outcome) = gc_storage::<DbUnified>(budget, live_state_keys)? {
+		return Ok(outcome);
+	}
+	Err(GcError::StorageNotInitialized)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ledger_storage_ledger_8::{DefaultDB, storage::default_storage};
+	use midnight_serialize::tagged_serialize;
+
+	// These tests use the process-global `InMemoryDB` default storage (the
+	// same one the api tests use, auto-initialized on first use). That is
+	// safe with concurrently running tests: their live objects are held via
+	// `Sp`s, which the collector protects through the backend's in-memory
+	// root tracking, and no other test in this crate persists roots into the
+	// InMemoryDB storage.
+
+	fn alloc_persisted_ledger_9(
+		network_id: &str,
+	) -> (
+		ledger_storage_ledger_8::arena::Sp<crate::ledger_9::api::Ledger<DefaultDB>, DefaultDB>,
+		Vec<u8>,
+	) {
+		use crate::ledger_9::api::Ledger;
+		use mn_ledger_9::structure::LedgerState;
+
+		let state: LedgerState<DefaultDB> = LedgerState::new(network_id);
+		let mut sp = default_storage::<DefaultDB>().arena.alloc(Ledger::new(state));
+		sp.persist();
+		let mut key = vec![];
+		tagged_serialize(&sp.as_typed_key(), &mut key).expect("state key serializes");
+		(sp, key)
+	}
+
+	#[test]
+	fn state_key_roots_resolves_ledger_9_keys() {
+		let (sp, key) = alloc_persisted_ledger_9("gc-test-parse");
+		let roots = state_key_roots::<DefaultDB>(&[key]).expect("key parses");
+		// After `persist()` the Sp's child repr is a Ref, so the parsed
+		// root set is exactly the persisted root hash.
+		assert_eq!(roots, vec![sp.hash()]);
+	}
+
+	#[test]
+	fn state_key_roots_rejects_garbage() {
+		assert_eq!(
+			state_key_roots::<DefaultDB>(&[b"not a state key".to_vec()]),
+			Err(GcError::UnrecognizedStateKey)
+		);
+	}
+
+	#[test]
+	fn gc_culls_roots_missing_from_live_set_and_keeps_live_ones() {
+		use crate::ledger_9::api::Ledger;
+		use ledger_storage_ledger_8::arena::TypedArenaKey;
+
+		let (sp_live, key_live) = alloc_persisted_ledger_9("gc-test-live");
+		let (sp_dead, key_dead) = alloc_persisted_ledger_9("gc-test-dead");
+		let typed_live: TypedArenaKey<Ledger<DefaultDB>, _> = sp_live.as_typed_key();
+		let typed_dead: TypedArenaKey<Ledger<DefaultDB>, _> = sp_dead.as_typed_key();
+		default_storage::<DefaultDB>().with_backend(|b| b.flush_all_changes_to_db());
+		// Drop in-memory refs so only persistence keeps the states alive.
+		drop(sp_live);
+		drop(sp_dead);
+
+		// GC with only the live key in the root set; a generous budget lets
+		// a full mark + sweep cycle finish in one slice.
+		let outcome =
+			gc_storage::<DefaultDB>(std::time::Duration::from_secs(3600), &[key_live.clone()])
+				.expect("keys parse")
+				.expect("in-memory storage is initialized");
+		assert_eq!(outcome.live_roots, 1);
+		assert!(outcome.culled >= 1, "the dead state's root node should be culled");
+
+		// The live state survives and is fully loadable. `Arena::get` loads
+		// eagerly (unlike `get_lazy`, which succeeds without touching the
+		// DB and only fails on later access).
+		let live = default_storage::<DefaultDB>()
+			.arena
+			.get(&typed_live)
+			.expect("live state still loadable");
+		assert_eq!(live.state.network_id.as_str(), "gc-test-live");
+
+		// The dead state's root is gone.
+		assert!(
+			default_storage::<DefaultDB>().arena.get(&typed_dead).is_err(),
+			"dead state should have been culled"
+		);
+		// `key_dead` no longer parses to anything loadable, but the GC input
+		// path still accepts it (parsing is independent of liveness).
+		assert!(state_key_roots::<DefaultDB>(&[key_dead]).is_ok());
+	}
+}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -27,6 +27,9 @@ pub mod json;
 #[cfg(feature = "std")]
 mod utils;
 
+#[cfg(feature = "std")]
+pub mod gc;
+
 pub mod host_api;
 
 #[path = "versions"]

--- a/node/src/ledger_gc.rs
+++ b/node/src/ledger_gc.rs
@@ -1,0 +1,272 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Background worker that keeps `ledger_storage` aligned with Substrate state pruning.
+//!
+//! Every ledger host call that mutates state persists a new arena root. Without a
+//! matching cleanup, those roots (and their exclusively-owned nodes) accumulate for
+//! every block forever — see
+//! <https://github.com/midnightntwrk/midnight-node/issues/1983>.
+//!
+//! This worker periodically:
+//! 1. Collects the `Midnight::StateKey` values for every block whose Substrate
+//!    state is still retained (canonical pruning window + non-finalized forks).
+//! 2. Runs one time-budgeted slice of
+//!    [`midnight_node_ledger::gc::collect_garbage`], which treats that set as the
+//!    complete live root set and deletes everything else.
+//!
+//! Archive nodes (`--state-pruning archive` / `archive-canonical`) skip the worker:
+//! reconstructing the full historical root set would require reading every block
+//! since genesis, and archive operators intentionally keep that history.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use midnight_node_runtime::opaque::Block;
+use parity_scale_codec::Decode;
+use sc_client_api::{Backend as _, StorageProvider};
+use sc_client_db::PruningMode;
+use sc_service::SpawnTaskHandle;
+use sp_blockchain::{Backend as BlockchainBackend, HeaderBackend};
+use sp_core::storage::StorageKey;
+use sp_crypto_hashing::twox_128;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One};
+
+use crate::service::{FullBackend, FullClient};
+
+const LOG_TARGET: &str = "midnight::ledger_gc";
+
+/// How often to run a GC slice. Kept modest so disk reclamation progresses on
+/// large historical databases without monopolising the backend lock.
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Soft time budget per GC slice. The collector is incremental and resumes on
+/// the next tick; the backend lock is held for roughly this long.
+const DEFAULT_BUDGET: Duration = Duration::from_millis(250);
+
+/// Storage key for `Midnight::StateKey` (`twox128("Midnight") ++ twox128("StateKey")`).
+fn midnight_state_key() -> StorageKey {
+	StorageKey([twox_128(b"Midnight"), twox_128(b"StateKey")].concat())
+}
+
+/// Derive the ledger-GC retention window from Substrate's state-pruning config.
+///
+/// Returns `None` for archive modes (worker should not run).
+fn retention_window(state_pruning: &Option<PruningMode>) -> Option<u32> {
+	match state_pruning {
+		Some(PruningMode::ArchiveAll) | Some(PruningMode::ArchiveCanonical) => None,
+		Some(PruningMode::Constrained(constraints)) => Some(constraints.max_blocks.unwrap_or(256)),
+		// Substrate default when the flag is omitted.
+		None => Some(256),
+	}
+}
+
+/// Collect serialized `Midnight::StateKey` values for every block whose state we
+/// still expect Substrate to retain.
+fn collect_live_state_keys(
+	client: &FullClient,
+	backend: &FullBackend,
+	window: u32,
+) -> Vec<Vec<u8>> {
+	let info = client.info();
+	let best = info.best_number;
+	let finalized = info.finalized_number;
+	let storage_key = midnight_state_key();
+
+	let mut hashes: HashSet<<Block as BlockT>::Hash> = HashSet::new();
+
+	// Canonical chain covering the pruning window (and the non-finalized tip).
+	let window_start = finalized.saturating_sub(window);
+	let mut number: NumberFor<Block> = window_start;
+	while number <= best {
+		if let Ok(Some(hash)) = client.hash(number) {
+			hashes.insert(hash);
+		}
+		if number == best {
+			break;
+		}
+		number += <NumberFor<Block> as One>::one();
+	}
+
+	// Non-finalized forks: walk every leaf back to (and including) the finalized
+	// block so a reorg within the unfinalized window cannot see its roots culled.
+	if let Ok(leaves) = backend.blockchain().leaves() {
+		for mut hash in leaves {
+			loop {
+				if !hashes.insert(hash) {
+					break;
+				}
+				let Ok(Some(header)) = client.header(hash) else {
+					break;
+				};
+				if *header.number() <= finalized {
+					break;
+				}
+				hash = *header.parent_hash();
+				if hash == Default::default() {
+					break;
+				}
+			}
+		}
+	}
+
+	let mut keys = Vec::with_capacity(hashes.len());
+	let mut missing = 0u32;
+	for hash in hashes {
+		match client.storage(hash, &storage_key) {
+			Ok(Some(data)) => match Vec::<u8>::decode(&mut &data.0[..]) {
+				Ok(state_key) if !state_key.is_empty() => keys.push(state_key),
+				Ok(_) => {
+					log::debug!(
+						target: LOG_TARGET,
+						"Empty StateKey at {:?}; skipping",
+						hash
+					);
+				},
+				Err(e) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"Failed to SCALE-decode StateKey at {:?}: {e:?}",
+						hash
+					);
+					missing += 1;
+				},
+			},
+			Ok(None) => {
+				// State already pruned for this hash — expected at the trailing
+				// edge of the window / for ancient leaves.
+				missing += 1;
+			},
+			Err(e) => {
+				log::debug!(
+					target: LOG_TARGET,
+					"State unavailable at {:?}: {e:?}",
+					hash
+				);
+				missing += 1;
+			},
+		}
+	}
+
+	log::debug!(
+		target: LOG_TARGET,
+		"Collected {} live StateKeys (window={window}, best={}, finalized={}, unavailable={missing})",
+		keys.len(),
+		best,
+		finalized,
+	);
+	keys
+}
+
+async fn run(client: Arc<FullClient>, backend: Arc<FullBackend>, window: u32) {
+	log::info!(
+		target: LOG_TARGET,
+		"Ledger GC worker started (window={window} blocks, interval={DEFAULT_INTERVAL:?}, budget={DEFAULT_BUDGET:?})"
+	);
+
+	loop {
+		tokio::time::sleep(DEFAULT_INTERVAL).await;
+
+		let client = client.clone();
+		let backend = backend.clone();
+		let result = tokio::task::spawn_blocking(move || {
+			let keys = collect_live_state_keys(&client, &backend, window);
+			if keys.is_empty() {
+				// An empty root set would unpersist everything. Skip until the
+				// chain has produced at least one readable StateKey.
+				log::debug!(target: LOG_TARGET, "No live StateKeys yet; skipping GC slice");
+				return Ok(None);
+			}
+			midnight_node_ledger::gc::collect_garbage(DEFAULT_BUDGET, &keys).map(Some)
+		})
+		.await;
+
+		match result {
+			Ok(Ok(Some(outcome))) => {
+				if outcome.culled > 0 {
+					log::info!(
+						target: LOG_TARGET,
+						"GC slice culled {} arena nodes (live_roots={})",
+						outcome.culled,
+						outcome.live_roots,
+					);
+				} else {
+					log::trace!(
+						target: LOG_TARGET,
+						"GC slice made no deletions (live_roots={})",
+						outcome.live_roots,
+					);
+				}
+			},
+			Ok(Ok(None)) => {},
+			Ok(Err(midnight_node_ledger::gc::GcError::UnrecognizedStateKey)) => {
+				// Expected while syncing through the pre-ledger-8 era: those
+				// state keys carry older tags, and the legacy ledger-7 storage
+				// crate has no GC support. Retried on the next tick; the
+				// window clears once sync passes the ledger-8 hardfork.
+				log::debug!(
+					target: LOG_TARGET,
+					"GC slice deferred: live window contains pre-ledger-8 state keys"
+				);
+			},
+			Ok(Err(e)) => {
+				log::warn!(target: LOG_TARGET, "GC slice aborted: {e}");
+			},
+			Err(e) => {
+				log::error!(target: LOG_TARGET, "GC worker task failed: {e}");
+			},
+		}
+	}
+}
+
+/// Spawn the ledger-storage GC worker, or no-op on archive nodes.
+pub fn try_spawn(
+	state_pruning: &Option<PruningMode>,
+	client: Arc<FullClient>,
+	backend: Arc<FullBackend>,
+	spawn_handle: &SpawnTaskHandle,
+) {
+	let Some(window) = retention_window(state_pruning) else {
+		log::info!(
+			target: LOG_TARGET,
+			"Ledger GC worker disabled (state pruning is archive); ledger_storage retains full history"
+		);
+		return;
+	};
+
+	spawn_handle.spawn("ledger-storage-gc", None, run(client, backend, window));
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn retention_window_skips_archive() {
+		assert_eq!(retention_window(&Some(PruningMode::ArchiveAll)), None);
+		assert_eq!(retention_window(&Some(PruningMode::ArchiveCanonical)), None);
+	}
+
+	#[test]
+	fn retention_window_reads_constrained() {
+		assert_eq!(retention_window(&Some(PruningMode::blocks_pruning(128))), Some(128));
+		assert_eq!(retention_window(&None), Some(256));
+	}
+
+	#[test]
+	fn state_key_storage_key_is_stable() {
+		// Must match toolkit / metadata: twox128("Midnight") ++ twox128("StateKey").
+		assert_eq!(midnight_state_key().0, [twox_128(b"Midnight"), twox_128(b"StateKey")].concat());
+	}
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -27,6 +27,7 @@ pub mod extensions;
 mod filtering_pool;
 pub mod genesis;
 pub mod inherent_data;
+pub mod ledger_gc;
 pub mod main_chain_follower;
 pub mod memory_monitor;
 pub mod metrics_push;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -525,6 +525,8 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 	max_finality_subscriptions: u32,
 ) -> Result<(TaskManager, Arc<FullBackend>), ServiceError> {
 	let database_source = config.database.clone();
+	// Captured before `spawn_tasks` consumes `config`.
+	let state_pruning = config.state_pruning.clone();
 	let new_partial_components =
 		new_partial(&config, epoch_config.clone(), midnight_cfg, storage_config, tx_filter_config)?;
 
@@ -919,6 +921,14 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		&task_manager.spawn_essential_handle(),
 	)
 	.map_err(|e| ServiceError::Application(e.into()))?;
+
+	// Align ledger_storage retention with Substrate state pruning (issue #1983).
+	crate::ledger_gc::try_spawn(
+		&state_pruning,
+		client.clone(),
+		backend.clone(),
+		&task_manager.spawn_handle(),
+	);
 
 	// Spawn Prometheus metrics push task if configured
 	if let Some(mut push_config) = metrics_push_config {


### PR DESCRIPTION
ledger_storage retained every persisted arena root forever: each ledger host call that mutates state persists the resulting root, and nothing ever unpersisted them. Pruned validators therefore accumulated ~197G of ledger state (vs 6.8G paritydb) on preprod.

Add a background worker that, on non-archive nodes, periodically:

1. collects Midnight::StateKey values for every block whose Substrate state is still retained (canonical pruning window plus non-finalized forks), and
2. runs one time-budgeted slice of the storage crate's incremental mark-and-sweep collector (gc_override_gc_roots) with that set as the complete live root set.

Using an override root set sidesteps persist refcounting (the same root is persisted by both authoring and import, and intermediate per-transaction roots are superseded within a block). Live in-memory objects are protected by the backend's own root tracking, and any concurrent persist forces a root rescan before further sweeping.

Slices abort conservatively if the live window contains pre-ledger-8 state keys (initial sync through the ledger-7 era), and archive nodes skip the worker entirely.

Closes #1983

Assisted-by: Claude:claude-fable-5

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [ ] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
