### PR TITLE
fix(ledger): serve ledger state reads at the ledger-hardfork set_code block

### DIFF
--- a/changes/node/changed/hardfork-skew-block-ledger-reads.md
+++ b/changes/node/changed/hardfork-skew-block-ledger-reads.md
@@ -32,5 +32,5 @@ Behaviour note: at the `set_code` block `midnight_ledgerStateRoot` now returns a
 root — correct, since that block's state *is* v8 — so consumers walking the fork see the tag
 flip at the migration block rather than a hole.
 
-PR: https://github.com/midnightntwrk/midnight-node/pull/1982
+PR: https://github.com/midnightntwrk/midnight-node/pull/1985
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1959

--- a/changes/node/changed/hardfork-skew-block-ledger-reads.md
+++ b/changes/node/changed/hardfork-skew-block-ledger-reads.md
@@ -1,0 +1,36 @@
+#node #ledger
+# Serve ledger state reads at the ledger-hardfork `set_code` block
+
+On a chain that hardforks ledger 8 -> 9 via a governance `set_code`, exactly one historical
+block was permanently unreadable: every ledger state read at that hash failed with
+`Deserialization(TypedArenaKey)`. The pre-fork runtime shipped `system_version: 1`, so
+`frame_system` overwrote `:code` *inside* the `set_code` block while pallet-midnight's v8 -> v9
+state translation only ran in the next block's `initialize_block`. That block's committed state
+therefore pairs ledger-9 `:code` with a ledger-8 `StateKey` forever, and any read at that hash
+executes ledger-9 code against a ledger-8 arena root.
+
+The read-only accessors of the ledger-9 host API now check the tagged-serialization header of
+the `state_key` they are handed. If it is a ledger-8 arena root, the read is served from the
+ledger-8 bridge instead — v8 and v9 share one storage crate and hence one arena, so this is a
+pure dispatch with no data movement. The `StateKey` tag is the signal rather than the pallet
+storage version, because the 2.0.0 runtime already ran ledger 9 while still reporting
+pallet-midnight storage version 1.
+
+Because the dispatch sits in the host function, it covers every caller of the affected reads —
+the `midnight_*` JSON-RPCs, `MidnightRuntimeApi` through `state_call`, and subxt-based tooling
+such as `chain-indexer` — rather than only the node's own RPC layer. Affected reads:
+`get_contract_state`, `get_zswap_chain_state`, `get_zswap_state_root`, `get_ledger_state_root`,
+`get_ledger_parameters`, `get_c_to_m_bridge_min_amount`, `get_unclaimed_amount`,
+`get_bridge_receiving_amount`.
+
+Not covered, deliberately: the transaction paths (`get_transaction_cost`,
+`validate_transaction`, `apply_transaction`). At the skew block those concern ledger-9-format
+transactions, which ledger-8 code cannot deserialize in any case, and they resolve on their own
+one block later once the migration has run.
+
+Behaviour note: at the `set_code` block `midnight_ledgerStateRoot` now returns a **v8-tagged**
+root — correct, since that block's state *is* v8 — so consumers walking the fork see the tag
+flip at the migration block rather than a hole.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1982
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1959

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -67,24 +67,12 @@ fn as_ledger_9_error(error: crate::ledger_8::types::LedgerApiError) -> LedgerApi
 /// is a ledger-8 arena root, by returning early from the enclosing host function.
 /// Falls through to the ledger-9 body otherwise.
 ///
-/// The `set_code` block of the ledger 8->9 hardfork commits a state that pairs the
-/// *new* `:code` with the *old* `StateKey`: `frame_system` overwrites `:code`
-/// inside that block (the pre-fork runtime ships `system_version: 1`, so the code
-/// is not staged in `:pending_code`), while pallet-midnight's v8->v9 state
-/// translation only runs in the next block's `on_runtime_upgrade`. Reading the
-/// ledger state *at* that block therefore executes ledger-9 code against a
-/// ledger-8 arena root and fails with `Deserialization(TypedArenaKey)` — GH #1959.
+/// For the ledger 8 -> 9 hard-fork, `system_version == 1` which means runtime code
+/// is applied during the upgrade block rather than queued to be applied in the next
+/// block. This code allows off-chain runtime calls to access historic block data
+/// using the correct ledger api despite the runtime code/chain data skew.
 ///
-/// That block is committed history: it stays that way for every future sync, and
-/// `system_version: 3` only prevents *further* skew blocks. So answer from the
-/// ledger-8 bridge, which is what the state at that block actually is. v8 and v9
-/// share one storage crate and hence one arena (see `super::migration_8_to_9`),
-/// so `DbSeparate`/`DbUnified` name the same types for both and no data movement
-/// is involved.
-///
-/// Doing this in the host function rather than in the node's RPC layer fixes every
-/// caller at once — `midnight_*` RPCs, `MidnightRuntimeApi` via `state_call`, and
-/// subxt-based tooling — since they all reach the ledger through here.
+/// This will not be needed for future forks; see: https://github.com/midnightntwrk/midnight-node/pull/1900
 ///
 /// `$call` names the `Bridge` method and takes its arguments verbatim; only the
 /// storage-mode dispatch and the error translation are supplied here.

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -72,7 +72,8 @@ fn as_ledger_9_error(error: crate::ledger_8::types::LedgerApiError) -> LedgerApi
 /// block. This code allows off-chain runtime calls to access historic block data
 /// using the correct ledger api despite the runtime code/chain data skew.
 ///
-/// This will not be needed for future forks; see: https://github.com/midnightntwrk/midnight-node/pull/1900
+/// This will not be needed for future forks; see:
+/// - https://github.com/midnightntwrk/midnight-node/pull/1900
 ///
 /// `$call` names the `Bridge` method and takes its arguments verbatim; only the
 /// storage-mode dispatch and the error translation are supplied here.

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -45,6 +45,63 @@ fn is_unified(mut ext: &mut dyn Externalities) -> bool {
 	)
 }
 
+#[cfg(feature = "std")]
+use crate::ledger_8::Bridge as Bridge8;
+#[cfg(feature = "std")]
+type Signature8 = crate::ledger_8::TransactionSignature;
+
+/// Translate a ledger-8 `LedgerApiError` into its ledger-9 counterpart.
+///
+/// The two are distinct types generated from the same source
+/// (`versions/common/types.rs`) by module parameterization, so their SCALE
+/// encodings are identical by construction. Round-tripping keeps this correct
+/// when a variant is added, where a hand-written match would need editing in
+/// lockstep. `ledger_8_error_encoding_matches_ledger_9` guards the assumption.
+#[cfg(feature = "std")]
+fn as_ledger_9_error(error: crate::ledger_8::types::LedgerApiError) -> LedgerApiError {
+	use parity_scale_codec::{Decode, Encode};
+	LedgerApiError::decode(&mut &error.encode()[..]).unwrap_or(LedgerApiError::HostApiError)
+}
+
+/// Serve a read-only ledger accessor from the ledger-8 bridge when `$state_key`
+/// is a ledger-8 arena root, by returning early from the enclosing host function.
+/// Falls through to the ledger-9 body otherwise.
+///
+/// The `set_code` block of the ledger 8->9 hardfork commits a state that pairs the
+/// *new* `:code` with the *old* `StateKey`: `frame_system` overwrites `:code`
+/// inside that block (the pre-fork runtime ships `system_version: 1`, so the code
+/// is not staged in `:pending_code`), while pallet-midnight's v8->v9 state
+/// translation only runs in the next block's `on_runtime_upgrade`. Reading the
+/// ledger state *at* that block therefore executes ledger-9 code against a
+/// ledger-8 arena root and fails with `Deserialization(TypedArenaKey)` — GH #1959.
+///
+/// That block is committed history: it stays that way for every future sync, and
+/// `system_version: 3` only prevents *further* skew blocks. So answer from the
+/// ledger-8 bridge, which is what the state at that block actually is. v8 and v9
+/// share one storage crate and hence one arena (see `super::migration_8_to_9`),
+/// so `DbSeparate`/`DbUnified` name the same types for both and no data movement
+/// is involved.
+///
+/// Doing this in the host function rather than in the node's RPC layer fixes every
+/// caller at once — `midnight_*` RPCs, `MidnightRuntimeApi` via `state_call`, and
+/// subxt-based tooling — since they all reach the ledger through here.
+///
+/// `$call` names the `Bridge` method and takes its arguments verbatim; only the
+/// storage-mode dispatch and the error translation are supplied here.
+#[cfg(feature = "std")]
+macro_rules! serve_pre_migration_v8_read {
+	($ext:expr, $state_key:expr, $call:ident($($arg:expr),* $(,)?)) => {
+		if crate::is_ledger_8_state_key($state_key) {
+			let result = if is_unified($ext) {
+				Bridge8::<Signature8, DbUnified>::$call($($arg),*)
+			} else {
+				Bridge8::<Signature8, DbSeparate>::$call($($arg),*)
+			};
+			return result.map_err(as_ledger_9_error);
+		}
+	};
+}
+
 #[runtime_interface]
 pub trait Ledger9Bridge {
 	fn set_default_storage(&mut self) {
@@ -235,6 +292,12 @@ pub trait Ledger9Bridge {
 		state_key: PassFatPointerAndRead<&[u8]>,
 		contract_address: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		serve_pre_migration_v8_read!(
+			*self,
+			state_key,
+			get_contract_state(state_key, contract_address)
+		);
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_contract_state(state_key, contract_address)
 		} else {
@@ -266,6 +329,12 @@ pub trait Ledger9Bridge {
 		state_key: PassFatPointerAndRead<&[u8]>,
 		contract_address: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		serve_pre_migration_v8_read!(
+			*self,
+			state_key,
+			get_zswap_chain_state(state_key, contract_address)
+		);
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_zswap_chain_state(state_key, contract_address)
 		} else {
@@ -282,6 +351,12 @@ pub trait Ledger9Bridge {
 		state_key: PassFatPointerAndRead<&[u8]>,
 		beneficiary: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<u128, LedgerApiError>> {
+		serve_pre_migration_v8_read!(
+			*self,
+			state_key,
+			get_unclaimed_amount(state_key, beneficiary)
+		);
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_unclaimed_amount(state_key, beneficiary)
 		} else {
@@ -298,6 +373,12 @@ pub trait Ledger9Bridge {
 		state_key: PassFatPointerAndRead<&[u8]>,
 		beneficiary: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<u128, LedgerApiError>> {
+		serve_pre_migration_v8_read!(
+			*self,
+			state_key,
+			get_bridge_receiving_amount(state_key, beneficiary)
+		);
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_bridge_receiving_amount(state_key, beneficiary)
 		} else {
@@ -313,6 +394,8 @@ pub trait Ledger9Bridge {
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		serve_pre_migration_v8_read!(*self, state_key, get_ledger_parameters(state_key));
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_ledger_parameters(state_key)
 		} else {
@@ -328,6 +411,8 @@ pub trait Ledger9Bridge {
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<u128, LedgerApiError>> {
+		serve_pre_migration_v8_read!(*self, state_key, get_c_to_m_bridge_min_amount(state_key));
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_c_to_m_bridge_min_amount(state_key)
 		} else {
@@ -337,6 +422,14 @@ pub trait Ledger9Bridge {
 
 	/*
 	 * Returns the expected fee to pay for a submitting a transaction
+	 *
+	 * No `serve_pre_migration_v8_read!` guard here, unlike the accessors above: a
+	 * cost estimate is always requested for a transaction about to be submitted,
+	 * and `get_ledger_version` reports ledger 9 as soon as the new code is live, so
+	 * `tx` is a v9-format transaction that ledger-8 code cannot deserialize anyway.
+	 * The same reasoning covers the transaction paths (`validate_transaction`,
+	 * `apply_transaction`, ...): at the skew block they concern v9 transactions, and
+	 * they resolve on their own one block later once the migration has run.
 	 */
 	fn get_transaction_cost(
 		&mut self,
@@ -370,6 +463,8 @@ pub trait Ledger9Bridge {
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		serve_pre_migration_v8_read!(*self, state_key, get_zswap_state_root(state_key));
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_zswap_state_root(state_key)
 		} else {
@@ -392,6 +487,8 @@ pub trait Ledger9Bridge {
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
+		serve_pre_migration_v8_read!(*self, state_key, get_ledger_state_root(state_key));
+
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::get_ledger_state_root(state_key)
 		} else {
@@ -558,5 +655,38 @@ pub trait Ledger9Bridge {
 				10_000,
 			);
 		});
+	}
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+	use super::as_ledger_9_error;
+	use crate::{ledger_8::types as v8, ledger_9::types as v9};
+
+	/// `as_ledger_9_error` relies on the two versions' `LedgerApiError` sharing a
+	/// SCALE encoding, which holds because both are generated from
+	/// `versions/common/types.rs`. Pin that down — including a nested payload and
+	/// the last variant, which is where a divergence would first show up — so a
+	/// future edit to one version's enum fails here rather than silently turning
+	/// every pre-migration read error into `HostApiError`.
+	#[test]
+	fn ledger_8_error_encoding_matches_ledger_9() {
+		let cases = [
+			(v8::LedgerApiError::NoLedgerState, v9::LedgerApiError::NoLedgerState),
+			(v8::LedgerApiError::ContractNotPresent, v9::LedgerApiError::ContractNotPresent),
+			(v8::LedgerApiError::BeneficiaryNotFound, v9::LedgerApiError::BeneficiaryNotFound),
+			(
+				v8::LedgerApiError::Deserialization(v8::DeserializationError::TypedArenaKey),
+				v9::LedgerApiError::Deserialization(v9::DeserializationError::TypedArenaKey),
+			),
+			(
+				v8::LedgerApiError::Serialization(v8::SerializationError::LedgerParameters),
+				v9::LedgerApiError::Serialization(v9::SerializationError::LedgerParameters),
+			),
+		];
+
+		for (from, expected) in cases {
+			assert_eq!(as_ledger_9_error(from.clone()), expected, "mistranslated {from:?}");
+		}
 	}
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -203,6 +203,22 @@ pub fn init_ledger_storage_unified<
 	}
 }
 
+/// Returns true if `state_key` is a ledger-8 arena root, i.e. a tagged-serialized
+/// `TypedArenaKey<ledger_8::api::Ledger<_>, _>`.
+#[cfg(feature = "std")]
+pub(crate) fn is_ledger_8_state_key(state_key: &[u8]) -> bool {
+	use ledger_storage_ledger_8::{DefaultDB, arena::TypedArenaKey, db::DB};
+	use midnight_serialize::Tagged;
+
+	type Ledger8Root = TypedArenaKey<ledger_8::api::Ledger<DefaultDB>, <DefaultDB as DB>::Hasher>;
+
+	let expected = <Ledger8Root as Tagged>::tag();
+	match midnight_serialize::peek_tag(&mut std::io::Cursor::new(state_key)) {
+		Ok(tag) => tag.as_str() == expected.as_ref(),
+		Err(_) => false,
+	}
+}
+
 mod common;
 
 pub mod types {
@@ -245,5 +261,33 @@ mod tests {
 		// Drop default storage
 		unsafe_drop_default_storage::<ParityDb>();
 		assert!(try_get_default_storage::<ParityDb>().is_none());
+	}
+
+	/// `is_ledger_8_state_key` is what the ledger-9 host API dispatches on to read the
+	/// `set_code` block of the 8->9 hardfork, whose `StateKey` is one version behind
+	/// its `:code` (GH #1959). It has to tell a ledger-8 arena root from a ledger-9
+	/// one from the header tag alone.
+	#[test]
+	fn ledger_8_state_key_tag_is_recognised() {
+		use ledger_storage_ledger_8::DefaultDB;
+		use midnight_serialize::{GLOBAL_TAG, Tagged};
+
+		// A `StateKey` is `tagged_serialize(&Sp<Ledger<D>, D>::as_typed_key())`, and
+		// `TypedArenaKey`'s tag wraps its referent's — which for `Ledger` is just
+		// `LedgerState`'s. Only the header matters here; `peek_tag` never reads the body.
+		fn header<T: Tagged>() -> Vec<u8> {
+			format!("{GLOBAL_TAG}storage-key({}):", T::tag()).into_bytes()
+		}
+		let v8 = header::<mn_ledger_8::structure::LedgerState<DefaultDB>>();
+		let v9 = header::<mn_ledger_9::structure::LedgerState<DefaultDB>>();
+		assert_ne!(v8, v9, "v8 and v9 ledger states must not share a tag");
+
+		assert!(super::is_ledger_8_state_key(&v8));
+		assert!(!super::is_ledger_8_state_key(&v9));
+
+		// An unset `StateKey`, or anything else untagged, is not a ledger-8 root: the
+		// host API must take its ordinary ledger-9 path rather than guess.
+		assert!(!super::is_ledger_8_state_key(&[]));
+		assert!(!super::is_ledger_8_state_key(b"not-tagged-at-all"));
 	}
 }

--- a/util/toolkit/tests/hardfork_e2e.rs
+++ b/util/toolkit/tests/hardfork_e2e.rs
@@ -19,6 +19,7 @@ use clap::Parser;
 use common::{test_image, wait_for_node::wait_for_finalized_block};
 use midnight_node_toolkit::cli::{Cli, run_command};
 use std::{process::Command, time::Duration};
+use subxt::rpcs::{RpcClient, rpc_params};
 use testcontainers::{
 	GenericImage, ImageExt,
 	core::{ContainerPort, WaitFor},
@@ -51,6 +52,111 @@ async fn run_cli(args: &[&str]) {
 		panic!("CLI command failed: {e}");
 	}
 	eprintln!("[hardfork_e2e] CLI command succeeded");
+}
+
+/// Hash of the block at `height`, hex-encoded.
+async fn block_hash_at(rpc: &RpcClient, height: u64) -> String {
+	let hash: serde_json::Value = rpc
+		.request("chain_getBlockHash", rpc_params![height])
+		.await
+		.unwrap_or_else(|e| panic!("chain_getBlockHash({height}) failed: {e}"));
+	hash.as_str()
+		.unwrap_or_else(|| panic!("no block at height {height}"))
+		.to_owned()
+}
+
+/// The runtime `specVersion` *stored at* `hash`.
+///
+/// Raw `state_getRuntimeVersion` rather than subxt's typed metadata on purpose:
+/// across a runtime upgrade the client's metadata follows the new runtime, so
+/// anything the old runtime encoded decodes unreliably. See
+/// `midnight_node_toolkit::commands::runtime_upgrade`.
+async fn spec_version_at(rpc: &RpcClient, hash: &str) -> u64 {
+	let version: serde_json::Value = rpc
+		.request("state_getRuntimeVersion", rpc_params![hash])
+		.await
+		.unwrap_or_else(|e| panic!("state_getRuntimeVersion({hash}) failed: {e}"));
+	version
+		.get("specVersion")
+		.and_then(|v| v.as_u64())
+		.unwrap_or_else(|| panic!("no specVersion in runtime version at {hash}"))
+}
+
+async fn finalized_height(rpc: &RpcClient) -> u64 {
+	let hash: serde_json::Value = rpc
+		.request("chain_getFinalizedHead", rpc_params![])
+		.await
+		.expect("chain_getFinalizedHead failed");
+	let header: serde_json::Value = rpc
+		.request("chain_getHeader", rpc_params![hash])
+		.await
+		.expect("chain_getHeader failed");
+	header
+		.get("number")
+		.and_then(|n| n.as_str())
+		.and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+		.expect("no number in finalized header")
+}
+
+/// Locate the block that applied the new runtime code — the one whose committed
+/// state pairs the *new* `:code` with the *old* ledger version's `StateKey`.
+///
+/// `frame_system` overwrites `:code` inside that block (the pre-fork runtime ships
+/// `system_version: 1`, so the code is not staged in `:pending_code`), while
+/// pallet-midnight's v8->v9 state translation only runs in the next block's
+/// `initialize_block`. Executing a read at that hash therefore runs ledger-9 WASM
+/// against a ledger-8 arena root, which is what GH #1959 reports.
+///
+/// `state_getRuntimeVersion` reports the code stored at a block, so the first
+/// height reporting the new spec is exactly that block. spec_version is monotonic
+/// along the chain, so binary-search for it.
+async fn find_code_applied_block(rpc: &RpcClient, head: u64, old_spec: u64) -> u64 {
+	let (mut lo, mut hi) = (1u64, head);
+	while lo < hi {
+		let mid = lo + (hi - lo) / 2;
+		let hash = block_hash_at(rpc, mid).await;
+		if spec_version_at(rpc, &hash).await > old_spec {
+			hi = mid;
+		} else {
+			lo = mid + 1;
+		}
+	}
+	lo
+}
+
+/// Every way of reading the ledger state must answer at `height`.
+///
+/// Both the `midnight_*` RPCs and a raw `state_call`: the fix lives in the ledger-9
+/// host function, so the runtime API has to work at the skew block too — that is
+/// the path subxt-based tooling (`chain-indexer`, GH #1969) takes, and it does not
+/// go anywhere near the node's own RPC layer.
+async fn assert_ledger_state_readable(rpc: &RpcClient, height: u64, label: &str) {
+	let hash = block_hash_at(rpc, height).await;
+
+	for method in ["midnight_zswapStateRoot", "midnight_ledgerStateRoot"] {
+		let root: Vec<u8> = rpc
+			.request(method, rpc_params![&hash])
+			.await
+			.unwrap_or_else(|e| panic!("{method} failed at {label} (#{height}, {hash}): {e}"));
+		assert!(!root.is_empty(), "{method} returned an empty root at {label} (#{height})");
+	}
+
+	// `Result<Vec<u8>, LedgerApiError>` SCALE-encoded: a leading 0x00 is `Ok`, and
+	// anything else is the pallet reporting a ledger error (0x01 plus the variant).
+	for api in
+		["MidnightRuntimeApi_get_ledger_state_root", "MidnightRuntimeApi_get_ledger_parameters"]
+	{
+		let encoded: String = rpc
+			.request("state_call", rpc_params![api, "0x", &hash])
+			.await
+			.unwrap_or_else(|e| panic!("{api} failed at {label} (#{height}, {hash}): {e}"));
+		assert!(
+			encoded.starts_with("0x00"),
+			"{api} returned an error at {label} (#{height}): {encoded}"
+		);
+	}
+
+	eprintln!("[hardfork_e2e] ledger state readable at {label} (#{height})");
 }
 
 #[test_log::test(tokio::test)]
@@ -140,7 +246,34 @@ async fn hardfork_single_tx() {
 	])
 	.await;
 
-	// 5. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
+	// 5. GH #1959: the whole fork boundary must stay readable. The block that
+	//    applied the new code carries a ledger-8 `StateKey` under ledger-9 `:code`,
+	//    so the ledger-9 host API has to detect that and serve the read from the
+	//    ledger-8 bridge; the block after it is already translated to v9 and must
+	//    keep taking the ordinary ledger-9 path.
+	let rpc = RpcClient::from_insecure_url(&url).await.expect("failed to open raw RPC client");
+	let pre_fork_spec = {
+		let hash = block_hash_at(&rpc, 1).await;
+		spec_version_at(&rpc, &hash).await
+	};
+	let head = finalized_height(&rpc).await;
+	let applied = find_code_applied_block(&rpc, head, pre_fork_spec).await;
+	eprintln!(
+		"[hardfork_e2e] new runtime code applied at #{applied} \
+		 (pre-fork spec {pre_fork_spec}, finalized head #{head})"
+	);
+	assert!(applied > 1, "expected the code-applying block to be past #1, got #{applied}");
+	assert!(applied < head, "expected the code-applying block to be below the finalized head");
+
+	// `runtime-upgrade` already waits for finality to pass `applied`, but the
+	// assertion below needs `applied + 1` to exist regardless.
+	wait_for_finalized_block(&url, applied + 1, Duration::from_secs(60)).await;
+
+	assert_ledger_state_readable(&rpc, applied - 1, "pre-fork").await;
+	assert_ledger_state_readable(&rpc, applied, "code-applied block").await;
+	assert_ledger_state_readable(&rpc, applied + 1, "post-migration").await;
+
+	// 6. Post-fork: run single-tx again to verify the node still works after the (future) upgrade
 	run_cli(&[
 		"generate-txs",
 		"--fetch-cache",


### PR DESCRIPTION
# Overview

Supersedes #1982, which fixed this in the node's JSON-RPC layer. That left the runtime API broken — see [Tomasz's review](https://github.com/midnightntwrk/midnight-node/pull/1982) — so the dispatch has moved into the ledger-9 host API instead, where every caller benefits and the diff is a third of the size.

## The bug (GH #1959)

On a chain that hardforks ledger 8 → 9 via a governance `set_code`, exactly one historical block is permanently unreadable: every ledger state read at that hash fails with `Deserialization(TypedArenaKey)`.

The pre-fork runtime ships `system_version: 1`, so `frame_system` overwrites `:code` **inside** the `set_code` block, while pallet-midnight's v8 → v9 state translation only runs in the next block's `initialize_block`. That block's committed state therefore pairs ledger-9 `:code` with a ledger-8 `StateKey` **forever**, and any read at that hash executes ledger-9 code against a ledger-8 arena root.

This is committed history. #1900 (`system_version: 3`) prevents *future* skew blocks by staging code in `:pending_code`, but the 8→9 skew block stays that way for every future sync, so the node has to carry the exception.

## The fix

The read-only accessors of the ledger-9 host API now check the tagged-serialization header of the `state_key` they are handed. If it is a ledger-8 arena root, the read is served from the ledger-8 bridge instead — which is what the state at that block actually is. v8 and v9 share one storage crate and hence one arena, so this is a pure dispatch with no data movement.

The `StateKey` tag is the signal rather than the pallet storage version, because the 2.0.0 runtime already ran ledger 9 while still reporting pallet-midnight storage version 1 (the same reason `migrate_state_v8_to_v9` has its tag-based idempotency guard).

Guarded accessors: `get_contract_state`, `get_zswap_chain_state`, `get_zswap_state_root`, `get_ledger_state_root`, `get_ledger_parameters`, `get_c_to_m_bridge_min_amount`, `get_unclaimed_amount`, `get_bridge_receiving_amount`.

### Why the host API and not the RPC layer

Because host functions are where **all** the read paths converge:

| Caller | #1982 (RPC layer) | This PR (host API) |
| --- | --- | --- |
| `midnight_*` JSON-RPCs | fixed | fixed |
| `MidnightRuntimeApi` via `state_call` | still broken | fixed |
| subxt tooling, e.g. chain-indexer | still broken | fixed |

The indexer does log when this code/storage skew occurs in a block, but does not appear to handle it.

### Not covered, deliberately

The transaction paths — `get_transaction_cost`, `validate_transaction`, `apply_transaction`. `get_ledger_version` 

Although the new runtime code is applied at the time of the extrinsic, the block author loads the runtime wasm at the start of the block - so the block authors and block importers are not affected by this skew issue. We need to patch this so that runtime calls into the block once it's applied to that chain work as expected.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

`hardfork_e2e` now walks the fork boundary. It binary-searches `state_getRuntimeVersion` for the block that applied the new code, then asserts the state is readable at `applied - 1` (pre-fork), `applied` (the skew block) and `applied + 1` (post-migration) — through both the `midnight_*` RPCs **and** a raw `state_call` of `MidnightRuntimeApi_get_ledger_state_root` / `_get_ledger_parameters`. The `state_call` assertions are the ones #1982 would have passed while leaving the bug in place. `node-1.0.1` (the fork-from image) is already `api_version(5)`, so the pre-fork block answers them too.

New unit test `ledger_8_error_encoding_matches_ledger_9` pins the assumption behind the v8 → v9 `LedgerApiError` translation: the two are distinct types generated from the same `versions/common/types.rs` by module parameterization, so their SCALE encodings agree by construction, and a round-trip beats a 13-arm match that would need editing in lockstep.

Local verification:

- `cargo check --workspace --all-targets` — clean
- runtime WASM blob rebuilt, confirming the `std`-gated dispatch does not leak into the no-std runtime build
- `cargo clippy -p midnight-node-ledger --all-targets` — clean
- `cargo test -p midnight-node-ledger --lib` — 96 passed

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

Node-side only: the dispatch lives in a host function, so it takes effect on node upgrade with no runtime change and no state change. A node without this fix and a node with it agree on every block's execution — only queries *at* the skew block differ.

## Links

Closes #1959
Supersedes #1982
Related: #1969, #1900