### PR TITLE
feat(node): ledger storage GC for pruned Anchored tips

### DIFF
--- a/changes/node/changed/ledger-gc-statekey.md
+++ b/changes/node/changed/ledger-gc-statekey.md
@@ -1,0 +1,23 @@
+#ledger #storage #node
+# Reclaim tagged Anchored wrappers after state pruning
+
+The node GC worker enumerates number-tagged ledger wrappers (persisted in
+`on_finalize` / genesis / warp import) and `release_tagged`s those whose
+height has left the configured state-pruning window (debounced
+`have_state_at == false` on the canonical hash at that number). There is
+no AuxStore reverse index: the wrapper tag *is* the block number,
+`release_tagged` is idempotent, and the decrement is staged into the same
+write cache as live block work — the next `on_finalize` flush commits it.
+Arena mark/sweep still runs only when the cache is empty (its
+reachability is DB-based).
+
+`ArchiveAll` and `ArchiveCanonical` keep history wrappers (no tip reclaim)
+but still run the arena GC loop so zero-ref Transient/intermediate garbage
+is culled. Number tags cannot distinguish a canonical tip from a stale
+fork at the same height, so archive-canonical does not reclaim forks.
+
+An existing archive DB restarted with `--state-pruning` omitted keeps its
+stored mode (`StateDb::open`); that case falls back to arena-only GC.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1991
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1983

--- a/changes/node/changed/tagged-anchored-ledger-roots.md
+++ b/changes/node/changed/tagged-anchored-ledger-roots.md
@@ -1,0 +1,15 @@
+#node #ledger
+# Anchored ledger tips are tagged with the block number at persist time
+
+`on_finalize` and genesis persist each Anchored ledger tip as a wrapper
+tagged with the block number (`System::Number`, known at finalize). The
+tag and the persist commit in the same `flush_storage`. Warp ledger-sync
+persists the recovered arena as a wrapper tagged with the warp-target
+number in the snapshot import flush. The GC worker later `release_tagged`s
+wrappers whose height has left the pruning window. Forks at the same
+height share a tag and are released together. Transient intra-block
+states still use a raw persist.
+
+Requires a resync from genesis; pre-wrapper anchored roots are not migrated.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1991

--- a/changes/node/changed/tagged-anchored-ledger-roots.md
+++ b/changes/node/changed/tagged-anchored-ledger-roots.md
@@ -2,13 +2,14 @@
 # Anchored ledger tips are tagged with the block number at persist time
 
 `on_finalize` and genesis persist each Anchored ledger tip as a wrapper
-tagged with the block number (`System::Number`, known at finalize). The
-tag and the persist commit in the same `flush_storage`. Warp ledger-sync
-persists the recovered arena as a wrapper tagged with the warp-target
-number in the snapshot import flush. The GC worker later `release_tagged`s
-wrappers whose height has left the pruning window. Forks at the same
-height share a tag and are released together. Transient intra-block
-states still use a raw persist.
+tagged with the block number (passed from `on_finalize(block)`; genesis
+is `0`). The tag and the persist commit in the same `flush_storage`. Warp
+ledger-sync persists the recovered arena as a wrapper tagged with the
+warp-target number in the snapshot import flush. Historical WASM that
+still calls host ABI v1/v2 peeks `System::Number` instead. The GC worker
+later `release_tagged`s wrappers whose height has left the pruning
+window. Forks at the same height share a tag and are released together.
+Transient intra-block states still use a raw persist.
 
 Requires a resync from genesis; pre-wrapper anchored roots are not migrated.
 

--- a/changes/runtime/changed/tagged-anchored-ledger-roots.md
+++ b/changes/runtime/changed/tagged-anchored-ledger-roots.md
@@ -1,0 +1,11 @@
+#runtime #ledger
+# Anchored ledger tips are tagged with the block number at persist time
+
+Post-block and genesis ledger states are persisted as a content-addressed
+wrapper tagged with `System::Number`. Warp ledger-sync persists the
+recovered arena already tagged with the warp target number. Intra-block
+Transient states are unchanged. Forks at the same height share a tag.
+
+Requires a resync from genesis; pre-wrapper anchored roots are not migrated.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1991

--- a/changes/runtime/changed/tagged-anchored-ledger-roots.md
+++ b/changes/runtime/changed/tagged-anchored-ledger-roots.md
@@ -2,9 +2,10 @@
 # Anchored ledger tips are tagged with the block number at persist time
 
 Post-block and genesis ledger states are persisted as a content-addressed
-wrapper tagged with `System::Number`. Warp ledger-sync persists the
-recovered arena already tagged with the warp target number. Intra-block
-Transient states are unchanged. Forks at the same height share a tag.
+wrapper tagged with the `on_finalize` block number. Warp ledger-sync
+persists the recovered arena already tagged with the warp target number.
+Intra-block Transient states are unchanged. Forks at the same height
+share a tag.
 
 Requires a resync from genesis; pre-wrapper anchored roots are not migrated.
 

--- a/ledger/src/common/types.rs
+++ b/ledger/src/common/types.rs
@@ -37,7 +37,10 @@ impl From<Hash128> for WrappedHash {
 /// - `Anchored` — a finalized state that must be retained for history (chain
 ///   tip after `post_block_update`, or genesis). The Bridge never unpersists
 ///   these on input; multiple sibling forks built on the same Anchored parent
-///   leave it untouched.
+///   leave it untouched. Anchored tips are persisted as a wrapper tagged with
+///   the block *number* (`on_finalize` / genesis / warp import). The node GC
+///   worker later `release_tagged`s wrappers whose height has left the
+///   Substrate pruning window. Forks at the same height share a tag.
 /// - `Transient` — an intra-block intermediate state produced by
 ///   `apply_transaction` / `apply_system_transaction`. The Bridge unpersists
 ///   these when they're consumed as input to a successor call.

--- a/ledger/src/gc.rs
+++ b/ledger/src/gc.rs
@@ -1,0 +1,180 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Reclaim number-tagged Anchored wrappers and run incremental arena GC.
+
+use std::time::Duration;
+
+use ledger_storage_ledger_8::{
+	DefaultDB,
+	db::{DB, ParityDb, paritydb::OwnedDb},
+	storage::{default_storage, try_get_default_storage},
+};
+use midnight_primitives_ledger::LedgerStorageExt;
+
+use crate::ledger_9;
+
+type DbSeparate = ParityDb;
+type DbUnified = ParityDb<sha2::Sha256, OwnedDb, { LedgerStorageExt::COLUMN_OFFSET }>;
+
+/// Tags of currently persisted wrapper roots (block numbers, little-endian).
+pub fn tagged_root_tags() -> Vec<Vec<u8>> {
+	fn tags_in<D: DB + 'static>() -> Option<Vec<Vec<u8>>> {
+		if try_get_default_storage::<D>().is_none() {
+			return None;
+		}
+		Some(
+			ledger_9::tagged_roots(&default_storage::<D>().arena)
+				.into_iter()
+				.map(|(_, tag)| tag)
+				.collect(),
+		)
+	}
+	tags_in::<DbSeparate>()
+		.or_else(tags_in::<DbUnified>)
+		.or_else(tags_in::<DefaultDB>)
+		.unwrap_or_default()
+}
+
+/// Decrement each matching tagged wrapper once. Does not flush — durability is
+/// the next block-boundary `flush_storage`. Replay of the same tags is a
+/// no-op. Returns 0 when ledger storage is not initialized.
+pub fn release_tagged_tips<M: AsRef<[u8]>>(tags: &[M]) -> usize {
+	if tags.is_empty() {
+		return 0;
+	}
+	if let Some(n) = release_in::<DbSeparate, M>(tags) {
+		return n;
+	}
+	if let Some(n) = release_in::<DbUnified, M>(tags) {
+		return n;
+	}
+	if let Some(n) = release_in::<DefaultDB, M>(tags) {
+		return n;
+	}
+	0
+}
+
+fn release_in<D: DB + 'static, M: AsRef<[u8]>>(tags: &[M]) -> Option<usize> {
+	if try_get_default_storage::<D>().is_none() {
+		return None;
+	}
+	Some(ledger_9::release_tagged(&default_storage::<D>().arena, tags))
+}
+
+/// Run incremental arena GC for up to `budget`. Returns culled node count.
+///
+/// Sweeps only when the ledger write cache is empty: mark/sweep reachability
+/// is DB-based, so staged-but-unflushed state is invisible to it. A dirty
+/// cache returns `0`.
+pub fn collect_garbage(budget: Duration) -> Result<usize, String> {
+	if let Some(n) = gc_in::<DbSeparate>(budget)? {
+		return Ok(n);
+	}
+	if let Some(n) = gc_in::<DbUnified>(budget)? {
+		return Ok(n);
+	}
+	if let Some(n) = gc_in::<DefaultDB>(budget)? {
+		return Ok(n);
+	}
+	Err("ledger storage is not initialized".into())
+}
+
+fn gc_in<D: DB + 'static>(budget: Duration) -> Result<Option<usize>, String> {
+	if try_get_default_storage::<D>().is_none() {
+		return Ok(None);
+	}
+	let culled = default_storage::<D>().with_backend(|backend| {
+		if backend.get_write_cache_len() > 0 {
+			return 0;
+		}
+		backend.gc(budget)
+	});
+	Ok(Some(culled))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ledger_storage_ledger_8::storage::default_storage;
+	use midnight_serialize::tagged_serialize;
+
+	fn persist_tagged_ledger(network_id: &str, tag: &[u8]) -> (Vec<u8>, Vec<u8>) {
+		use crate::ledger_9::api::Ledger;
+		use mn_ledger_9::structure::LedgerState;
+
+		let state: LedgerState<DefaultDB> = LedgerState::new(network_id);
+		let inner = default_storage::<DefaultDB>().arena.alloc(Ledger::new(state));
+		ledger_9::persist_tagged(&default_storage::<DefaultDB>().arena, tag.to_vec(), &inner);
+		default_storage::<DefaultDB>().with_backend(|b| b.flush_all_changes_to_db());
+		let mut tip = vec![];
+		tagged_serialize(&inner.as_typed_key(), &mut tip).expect("tip serializes");
+		(tag.to_vec(), tip)
+	}
+
+	fn pin_count(tip: &[u8]) -> u32 {
+		use crate::ledger_9::api::Ledger;
+		use ledger_storage_ledger_8::arena::{ArenaKey, TypedArenaKey};
+
+		let typed: TypedArenaKey<Ledger<DefaultDB>, _> =
+			midnight_serialize::tagged_deserialize(&mut &tip[..]).expect("tip decodes");
+		let key: ArenaKey<_> = typed.into();
+		ledger_9::tagged_pin_count(&default_storage::<DefaultDB>().arena, key.hash()).unwrap_or(0)
+	}
+
+	#[test]
+	fn release_decrements_once_per_tag() {
+		let (tag, tip) = persist_tagged_ledger("gc-once", &101u32.to_le_bytes());
+		assert_eq!(pin_count(&tip), 1);
+		assert_eq!(release_tagged_tips(std::slice::from_ref(&tag)), 1);
+		assert_eq!(pin_count(&tip), 0);
+		assert_eq!(release_tagged_tips(std::slice::from_ref(&tag)), 0);
+	}
+
+	#[test]
+	fn sibling_heights_release_independently() {
+		use crate::ledger_9::api::Ledger;
+		use mn_ledger_9::structure::LedgerState;
+
+		let state: LedgerState<DefaultDB> = LedgerState::new("gc-sib");
+		let inner = default_storage::<DefaultDB>().arena.alloc(Ledger::new(state));
+		let a = 201u32.to_le_bytes().to_vec();
+		let b = 202u32.to_le_bytes().to_vec();
+		ledger_9::persist_tagged(&default_storage::<DefaultDB>().arena, a.clone(), &inner);
+		ledger_9::persist_tagged(&default_storage::<DefaultDB>().arena, b.clone(), &inner);
+		default_storage::<DefaultDB>().with_backend(|be| be.flush_all_changes_to_db());
+
+		let mut tip = vec![];
+		tagged_serialize(&inner.as_typed_key(), &mut tip).unwrap();
+		assert_eq!(pin_count(&tip), 2);
+		assert_eq!(release_tagged_tips(std::slice::from_ref(&a)), 1);
+		assert_eq!(pin_count(&tip), 1);
+		assert_eq!(release_tagged_tips(std::slice::from_ref(&b)), 1);
+		assert_eq!(pin_count(&tip), 0);
+	}
+
+	#[test]
+	fn unknown_tag_is_noop() {
+		let _ = default_storage::<DefaultDB>();
+		assert_eq!(release_tagged_tips(&[vec![1, 2, 3]]), 0);
+	}
+
+	#[test]
+	fn tagged_root_tags_lists_wrappers() {
+		let (tag, _) = persist_tagged_ledger("gc-list", &9u32.to_le_bytes());
+		assert!(tagged_root_tags().iter().any(|t| t == &tag));
+		assert_eq!(release_tagged_tips(std::slice::from_ref(&tag)), 1);
+	}
+}

--- a/ledger/src/gc.rs
+++ b/ledger/src/gc.rs
@@ -32,9 +32,7 @@ type DbUnified = ParityDb<sha2::Sha256, OwnedDb, { LedgerStorageExt::COLUMN_OFFS
 /// Tags of currently persisted wrapper roots (block numbers, little-endian).
 pub fn tagged_root_tags() -> Vec<Vec<u8>> {
 	fn tags_in<D: DB + 'static>() -> Option<Vec<Vec<u8>>> {
-		if try_get_default_storage::<D>().is_none() {
-			return None;
-		}
+		try_get_default_storage::<D>()?;
 		Some(
 			ledger_9::tagged_roots(&default_storage::<D>().arena)
 				.into_iter()
@@ -68,9 +66,7 @@ pub fn release_tagged_tips<M: AsRef<[u8]>>(tags: &[M]) -> usize {
 }
 
 fn release_in<D: DB + 'static, M: AsRef<[u8]>>(tags: &[M]) -> Option<usize> {
-	if try_get_default_storage::<D>().is_none() {
-		return None;
-	}
+	try_get_default_storage::<D>()?;
 	Some(ledger_9::release_tagged(&default_storage::<D>().arena, tags))
 }
 

--- a/ledger/src/host_api/ledger_8.rs
+++ b/ledger/src/host_api/ledger_8.rs
@@ -46,6 +46,12 @@ fn is_unified(mut ext: &mut dyn Externalities) -> bool {
 	)
 }
 
+/// Frozen ledger-8 ABI has no block-number argument; peek `System::Number`.
+#[cfg(feature = "std")]
+fn overlay_block_number(ext: &mut dyn Externalities) -> u32 {
+	crate::ledger_8::block_number_from_overlay(ext)
+}
+
 /// The body of version 1 of `apply_transaction`, which skews the `tblock` of a block's first
 /// ledger transaction (see the trait below).
 ///
@@ -153,10 +159,19 @@ pub trait Ledger8Bridge {
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
 		let state_key = LedgerStateKey::Anchored(state_key.to_vec());
+		let block_number = overlay_block_number(*self);
 		let result = if is_unified(*self) {
-			Bridge::<Signature, DbUnified>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbUnified>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		} else {
-			Bridge::<Signature, DbSeparate>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbSeparate>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		};
 		result.map(LedgerStateKey::into_bytes)
 	}
@@ -167,17 +182,18 @@ pub trait Ledger8Bridge {
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
 		let state_key = LedgerStateKey::Anchored(state_key.to_vec());
+		let block_number = overlay_block_number(*self);
 		let result = if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
 			)
 		} else {
 			Bridge::<Signature, DbSeparate>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
 			)
 		};
 		result.map(LedgerStateKey::into_bytes)

--- a/ledger/src/host_api/ledger_9.rs
+++ b/ledger/src/host_api/ledger_9.rs
@@ -47,6 +47,12 @@ fn is_unified(mut ext: &mut dyn Externalities) -> bool {
 	)
 }
 
+/// Historical WASM (v1/v2) does not pass the block number; peek `System::Number`.
+#[cfg(feature = "std")]
+fn overlay_block_number(ext: &mut dyn Externalities) -> u32 {
+	crate::ledger_9::block_number_from_overlay(ext)
+}
+
 #[cfg(feature = "std")]
 use crate::ledger_8::Bridge as Bridge8;
 #[cfg(feature = "std")]
@@ -129,31 +135,75 @@ pub trait Ledger9Bridge {
 	///
 	/// Ledger 7 and 8 need no counterpart: the current runtime only ever calls the
 	/// ledger-9 bridge, so those two keep the legacy ABI and nothing else.
+	///
+	/// Tagging peeks `System::Number` from the overlay — this WASM cannot pass
+	/// the number. Version 3 takes it from `on_finalize(block)`.
 	fn post_block_update(
 		&mut self,
 		state_key: PassFatPointerAndRead<&[u8]>,
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
 		let state_key = LedgerStateKey::Anchored(state_key.to_vec());
+		let block_number = overlay_block_number(*self);
 		let result = if is_unified(*self) {
-			Bridge::<Signature, DbUnified>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbUnified>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		} else {
-			Bridge::<Signature, DbSeparate>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbSeparate>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		};
 		result.map(LedgerStateKey::into_bytes)
 	}
 
-	// Current Enabled Version
+	/// `LedgerStateKey` ABI without an explicit block number. Overlay peek as in v1.
 	#[version(2)]
 	fn post_block_update(
 		&mut self,
 		state_key: PassFatPointerAndDecode<LedgerStateKey>,
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<LedgerStateKey, LedgerApiError>> {
+		let block_number = overlay_block_number(*self);
 		if is_unified(*self) {
-			Bridge::<Signature, DbUnified>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbUnified>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		} else {
-			Bridge::<Signature, DbSeparate>::post_block_update(*self, &state_key, block_context)
+			Bridge::<Signature, DbSeparate>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
+		}
+	}
+
+	// Current Enabled Version
+	#[version(3)]
+	fn post_block_update(
+		&mut self,
+		state_key: PassFatPointerAndDecode<LedgerStateKey>,
+		block_context: PassFatPointerAndDecode<BlockContext>,
+		block_number: u32,
+	) -> AllocateAndReturnByCodec<Result<LedgerStateKey, LedgerApiError>> {
+		if is_unified(*self) {
+			Bridge::<Signature, DbUnified>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
+		} else {
+			Bridge::<Signature, DbSeparate>::post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
 		}
 	}
 
@@ -164,40 +214,65 @@ pub trait Ledger9Bridge {
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<Vec<u8>, LedgerApiError>> {
 		let state_key = LedgerStateKey::Anchored(state_key.to_vec());
+		let block_number = overlay_block_number(*self);
 		let result = if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
 			)
 		} else {
 			Bridge::<Signature, DbSeparate>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
 			)
 		};
 		result.map(LedgerStateKey::into_bytes)
 	}
 
-	// Current Enabled Version
+	/// `LedgerStateKey` ABI without an explicit block number. Overlay peek as in v1.
 	#[version(2)]
 	fn apply_post_block_update(
 		&mut self,
 		state_key: PassFatPointerAndDecode<LedgerStateKey>,
 		block_context: PassFatPointerAndDecode<BlockContext>,
 	) -> AllocateAndReturnByCodec<Result<LedgerStateKey, LedgerApiError>> {
+		let block_number = overlay_block_number(*self);
 		if is_unified(*self) {
 			Bridge::<Signature, DbUnified>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
 			)
 		} else {
 			Bridge::<Signature, DbSeparate>::apply_post_block_update(
-				*self,
 				&state_key,
 				block_context,
+				block_number,
+			)
+		}
+	}
+
+	// Current Enabled Version
+	#[version(3)]
+	fn apply_post_block_update(
+		&mut self,
+		state_key: PassFatPointerAndDecode<LedgerStateKey>,
+		block_context: PassFatPointerAndDecode<BlockContext>,
+		block_number: u32,
+	) -> AllocateAndReturnByCodec<Result<LedgerStateKey, LedgerApiError>> {
+		if is_unified(*self) {
+			Bridge::<Signature, DbUnified>::apply_post_block_update(
+				&state_key,
+				block_context,
+				block_number,
+			)
+		} else {
+			Bridge::<Signature, DbSeparate>::apply_post_block_update(
+				&state_key,
+				block_context,
+				block_number,
 			)
 		}
 	}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -25,6 +25,9 @@ extern crate alloc;
 pub mod json;
 
 #[cfg(feature = "std")]
+pub mod gc;
+
+#[cfg(feature = "std")]
 mod utils;
 
 pub mod host_api;
@@ -228,16 +231,18 @@ impl std::error::Error for SnapshotImportError {}
 
 #[cfg(feature = "std")]
 /// Verify a `Ledger`-rooted warp snapshot `blob` against the on-chain `expected_state_key` and, on
-/// success, persist it into the already-open arena backend so `get_lazy(StateKey)` resolves (warp
-/// ledger-sync verification + import). `unified` selects the DB instantiation, and dispatch on the
-/// `StateKey`'s `ledger-state[vNN]` tag picks the ledger module, as in
-/// [`serialize_ledger_snapshot`].
+/// success, persist it as a wrapper tagged with `block_number` (the warp target height) so
+/// `get_lazy(StateKey)` resolves and GC can later `release_tagged` that pin. `unified` selects
+/// the DB instantiation, and dispatch on the `StateKey`'s `ledger-state[vNN]` tag picks the
+/// ledger module, as in [`serialize_ledger_snapshot`].
 ///
-/// The caller must hold the authoring/import gate (the arena is single-writer).
+/// The tag is committed in this function's flush. The caller must hold the authoring/import
+/// gate (the arena is single-writer).
 pub fn import_verified_ledger_snapshot(
 	unified: bool,
 	blob: &[u8],
 	expected_state_key: &[u8],
+	block_number: u32,
 ) -> Result<(), SnapshotImportError> {
 	// Dispatch on the `StateKey`'s ledger-state version (the underlying method returns the shared
 	// `SnapshotImportError` for every version, so no error mapping is needed).
@@ -246,14 +251,14 @@ pub fn import_verified_ledger_snapshot(
 			bridge_arena_call!(
 				ledger_9,
 				unified,
-				import_verified_ledger_snapshot(blob, expected_state_key)
+				import_verified_ledger_snapshot(blob, expected_state_key, block_number)
 			)
 		},
 		Some(13) => {
 			bridge_arena_call!(
 				ledger_8,
 				unified,
-				import_verified_ledger_snapshot(blob, expected_state_key)
+				import_verified_ledger_snapshot(blob, expected_state_key, block_number)
 			)
 		},
 		other => Err(SnapshotImportError::StateKeyDecode(format!(

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -175,8 +175,9 @@ lazy_static! {
 }
 
 #[cfg(feature = "std")]
-/// Decode `System::Number` from SCALE storage. Production uses `u32`; the
-/// pallet mock runtime uses `u64`. Small values decode correctly either way.
+/// Decode `System::Number` from SCALE storage. Used only by legacy host ABI
+/// (v1/v2), whose WASM does not pass the block number. Production uses `u32`;
+/// the pallet mock runtime uses `u64`.
 fn decode_system_block_number(raw: &[u8]) -> Option<u32> {
 	match raw.len() {
 		4 => Some(u32::from_le_bytes(raw.try_into().ok()?)),
@@ -185,6 +186,19 @@ fn decode_system_block_number(raw: &[u8]) -> Option<u32> {
 			.ok()
 			.or_else(|| u64::decode(&mut &raw[..]).ok().and_then(|n| u32::try_from(n).ok())),
 	}
+}
+
+/// `System::Number` from the overlay. Fallback for historical WASM that still
+/// calls `apply_post_block_update` v1/v2 without an explicit block number.
+#[cfg(feature = "std")]
+pub(crate) fn block_number_from_overlay(externalities: &mut dyn Externalities) -> u32 {
+	let mut key = [0u8; 32];
+	key[..16].copy_from_slice(&Twox128::hash(b"System"));
+	key[16..].copy_from_slice(&Twox128::hash(b"Number"));
+	let Some(raw) = externalities.storage(&key) else {
+		return 0;
+	};
+	decode_system_block_number(&raw).unwrap_or(0)
 }
 
 #[cfg(feature = "std")]
@@ -266,24 +280,13 @@ where
 		}
 	}
 
-	/// Persist `ledger` as a wrapper tagged with `System::Number`.
-	fn persist_anchored_tip(externalities: &mut dyn Externalities, ledger: &Sp<Ledger<D>, D>) {
-		let n = Self::system_block_number(externalities);
+	/// Persist `ledger` as a wrapper tagged with `block_number`.
+	fn persist_anchored_tip(ledger: &Sp<Ledger<D>, D>, block_number: u32) {
 		persist_tagged(
 			&default_storage::<D>().arena,
-			persist_tag_from_block_number(n),
+			persist_tag_from_block_number(block_number),
 			ledger,
 		);
-	}
-
-	fn system_block_number(externalities: &mut dyn Externalities) -> u32 {
-		let mut key = [0u8; 32];
-		key[..16].copy_from_slice(&Twox128::hash(b"System"));
-		key[16..].copy_from_slice(&Twox128::hash(b"Number"));
-		let Some(raw) = externalities.storage(&key) else {
-			return 0;
-		};
-		decode_system_block_number(&raw).unwrap_or(0)
 	}
 
 	/// Apply the post-block transformation and produce the post-block ledger
@@ -292,11 +295,11 @@ where
 	/// # Persist refcount contract
 	///
 	/// On success, returns `LedgerStateKey::Anchored` pinned by a wrapper
-	/// tagged with the current `System::Number`. Anchored states are never
-	/// unpersisted on input by subsequent Bridge calls — preserved for
-	/// RPC/history within the Substrate pruning window. The node GC worker
-	/// later [`release_tagged`]s wrappers whose height has left that window.
-	/// Forks at the same height share a tag.
+	/// tagged with `block_number` (the Substrate height from `on_finalize`).
+	/// Anchored states are never unpersisted on input by subsequent Bridge
+	/// calls — preserved for RPC/history within the Substrate pruning window.
+	/// The node GC worker later [`release_tagged`]s wrappers whose height has
+	/// left that window. Forks at the same height share a tag.
 	///
 	/// If the input was `LedgerStateKey::Transient` (the last `apply_transaction`
 	/// output of this block), it is unpersisted once, dropping to rc=0.
@@ -305,9 +308,9 @@ where
 	///
 	/// On error, refcounts are unchanged.
 	pub fn post_block_update(
-		externalities: &mut dyn Externalities,
 		state_key: &LedgerStateKey,
 		block_context: BlockContext,
+		block_number: u32,
 	) -> Result<LedgerStateKey, LedgerApiError> {
 		let start_tx_processing_time = Instant::now();
 		log::trace!(
@@ -348,7 +351,7 @@ where
 			"⏱️  Persisting ledger (elapsed_ms={})",
 			start_tx_processing_time.elapsed().as_millis()
 		);
-		Self::persist_anchored_tip(externalities, &ledger);
+		Self::persist_anchored_tip(&ledger, block_number);
 		if state_key.is_transient() {
 			Self::unpersist_state(&api, state_key.bytes())?;
 		}
@@ -373,15 +376,15 @@ where
 	/// `Transient` input is unpersisted once, and `Anchored` inputs are left
 	/// alone. On error, refcounts are unchanged.
 	pub fn apply_post_block_update(
-		externalities: &mut dyn Externalities,
 		state_key: &LedgerStateKey,
 		block_context: BlockContext,
+		block_number: u32,
 	) -> Result<LedgerStateKey, LedgerApiError> {
 		let api = api::new();
 		let ledger = Self::get_ledger(&api, state_key.bytes())?;
 		let ledger = Ledger::apply_post_block_update(ledger, block_context);
 		let state_root = api.tagged_serialize(&ledger.as_typed_key())?;
-		Self::persist_anchored_tip(externalities, &ledger);
+		Self::persist_anchored_tip(&ledger, block_number);
 		if state_key.is_transient() {
 			Self::unpersist_state(&api, state_key.bytes())?;
 		}

--- a/ledger/src/versions/common/mod.rs
+++ b/ledger/src/versions/common/mod.rs
@@ -30,6 +30,8 @@ use transient_crypto_local::commitment::PureGeneratorPedersen;
 
 use alloc::vec::Vec;
 use frame_support::{StorageHasher, Twox128};
+#[cfg(feature = "std")]
+use parity_scale_codec::Decode;
 use sp_externalities::{Externalities, ExternalitiesExt};
 
 pub mod types;
@@ -37,6 +39,14 @@ use types::LedgerApiError;
 
 #[cfg(feature = "std")]
 pub mod storage;
+
+#[cfg(feature = "std")]
+pub mod tagged_root;
+#[cfg(feature = "std")]
+pub use tagged_root::{
+	block_number_from_persist_tag, persist_tag_from_block_number, persist_tagged, release_tagged,
+	tagged_pin_count, tagged_roots,
+};
 
 #[cfg(feature = "std")]
 pub mod api;
@@ -165,6 +175,19 @@ lazy_static! {
 }
 
 #[cfg(feature = "std")]
+/// Decode `System::Number` from SCALE storage. Production uses `u32`; the
+/// pallet mock runtime uses `u64`. Small values decode correctly either way.
+fn decode_system_block_number(raw: &[u8]) -> Option<u32> {
+	match raw.len() {
+		4 => Some(u32::from_le_bytes(raw.try_into().ok()?)),
+		8 => u32::try_from(u64::from_le_bytes(raw.try_into().ok()?)).ok(),
+		_ => u32::decode(&mut &raw[..])
+			.ok()
+			.or_else(|| u64::decode(&mut &raw[..]).ok().and_then(|n| u32::try_from(n).ok())),
+	}
+}
+
+#[cfg(feature = "std")]
 pub struct Bridge<S: SignatureKind<D>, D: DB> {
 	_phantom: core::marker::PhantomData<(S, D)>,
 }
@@ -243,16 +266,37 @@ where
 		}
 	}
 
+	/// Persist `ledger` as a wrapper tagged with `System::Number`.
+	fn persist_anchored_tip(externalities: &mut dyn Externalities, ledger: &Sp<Ledger<D>, D>) {
+		let n = Self::system_block_number(externalities);
+		persist_tagged(
+			&default_storage::<D>().arena,
+			persist_tag_from_block_number(n),
+			ledger,
+		);
+	}
+
+	fn system_block_number(externalities: &mut dyn Externalities) -> u32 {
+		let mut key = [0u8; 32];
+		key[..16].copy_from_slice(&Twox128::hash(b"System"));
+		key[16..].copy_from_slice(&Twox128::hash(b"Number"));
+		let Some(raw) = externalities.storage(&key) else {
+			return 0;
+		};
+		decode_system_block_number(&raw).unwrap_or(0)
+	}
+
 	/// Apply the post-block transformation and produce the post-block ledger
 	/// state.
 	///
 	/// # Persist refcount contract
 	///
-	/// On success, returns `LedgerStateKey::Anchored` at rc=1. Anchored states
-	/// are never unpersisted on input by subsequent Bridge calls, so the
-	/// post-block tip remains rooted forever — preserved for RPC and history,
-	/// and safe across sibling forks (a second fork built on the same parent
-	/// does not unpersist it).
+	/// On success, returns `LedgerStateKey::Anchored` pinned by a wrapper
+	/// tagged with the current `System::Number`. Anchored states are never
+	/// unpersisted on input by subsequent Bridge calls — preserved for
+	/// RPC/history within the Substrate pruning window. The node GC worker
+	/// later [`release_tagged`]s wrappers whose height has left that window.
+	/// Forks at the same height share a tag.
 	///
 	/// If the input was `LedgerStateKey::Transient` (the last `apply_transaction`
 	/// output of this block), it is unpersisted once, dropping to rc=0.
@@ -261,7 +305,7 @@ where
 	///
 	/// On error, refcounts are unchanged.
 	pub fn post_block_update(
-		mut _externalities: &mut dyn Externalities,
+		externalities: &mut dyn Externalities,
 		state_key: &LedgerStateKey,
 		block_context: BlockContext,
 	) -> Result<LedgerStateKey, LedgerApiError> {
@@ -284,7 +328,7 @@ where
 			"⏱️  Post block update start (elapsed_ms={})",
 			start_tx_processing_time.elapsed().as_millis()
 		);
-		let mut ledger = Ledger::post_block_update(ledger, block_context).inspect_err(|e| {
+		let ledger = Ledger::post_block_update(ledger, block_context).inspect_err(|e| {
 			log::error!(
 				target: LOG_TARGET,
 				"Post Block Update error: {e:?}"
@@ -304,7 +348,7 @@ where
 			"⏱️  Persisting ledger (elapsed_ms={})",
 			start_tx_processing_time.elapsed().as_millis()
 		);
-		ledger.persist();
+		Self::persist_anchored_tip(externalities, &ledger);
 		if state_key.is_transient() {
 			Self::unpersist_state(&api, state_key.bytes())?;
 		}
@@ -325,20 +369,19 @@ where
 	/// # Persist refcount contract
 	///
 	/// Same contract as [`Self::post_block_update`]: returns
-	/// `LedgerStateKey::Anchored` at rc=1, so the post-block tip stays rooted
-	/// for RPC and history and is safe across sibling forks; a `Transient`
-	/// input is unpersisted once, and `Anchored` inputs are left alone. On
-	/// error, refcounts are unchanged.
+	/// `LedgerStateKey::Anchored` pinned by a number-tagged wrapper. A
+	/// `Transient` input is unpersisted once, and `Anchored` inputs are left
+	/// alone. On error, refcounts are unchanged.
 	pub fn apply_post_block_update(
-		mut _externalities: &mut dyn Externalities,
+		externalities: &mut dyn Externalities,
 		state_key: &LedgerStateKey,
 		block_context: BlockContext,
 	) -> Result<LedgerStateKey, LedgerApiError> {
 		let api = api::new();
 		let ledger = Self::get_ledger(&api, state_key.bytes())?;
-		let mut ledger = Ledger::apply_post_block_update(ledger, block_context);
+		let ledger = Ledger::apply_post_block_update(ledger, block_context);
 		let state_root = api.tagged_serialize(&ledger.as_typed_key())?;
-		ledger.persist();
+		Self::persist_anchored_tip(externalities, &ledger);
 		if state_key.is_transient() {
 			Self::unpersist_state(&api, state_key.bytes())?;
 		}
@@ -885,12 +928,15 @@ where
 	/// caller), never state corruption.
 	///
 	/// Persists + flushes into the live `default_storage` so `get_lazy(StateKey)` resolves —
-	/// in-process, no restart, via the same `alloc`/`persist`/`flush` path live block execution
-	/// uses. The caller (warp client driver) MUST hold the authoring/import gate so no block
-	/// executes against the arena concurrently — the arena is single-writer.
+	/// in-process, no restart. The warp target *number* is known here, so the root is a tagged
+	/// wrapper (`persist_tagged`) committed in this same flush. A leftover raw pin on the same
+	/// inner (re-import of a pre-tag genesis) is dropped in that flush. The caller MUST hold the
+	/// authoring/import gate so no block executes against the arena concurrently — the arena is
+	/// single-writer.
 	pub fn import_verified_ledger_snapshot(
 		blob: &[u8],
 		expected_state_key: &[u8],
+		block_number: u32,
 	) -> Result<(), crate::SnapshotImportError> {
 		use crate::SnapshotImportError;
 
@@ -903,7 +949,7 @@ where
 		// arena; re-allocating the loaded value yields the persistable `Sp`.
 		let ledger: Ledger<D> =
 			helpers_local::deserialize(blob).map_err(SnapshotImportError::Deserialize)?;
-		let mut sp = default_storage::<D>().arena.alloc(ledger);
+		let sp = default_storage::<D>().arena.alloc(ledger);
 
 		// Cryptographic bind to the trie anchor: the reconstructed root must equal the on-chain
 		// `StateKey`. This is the whole security argument — reject anything else.
@@ -912,8 +958,16 @@ where
 			return Err(SnapshotImportError::RootMismatch);
 		}
 
-		sp.persist();
-		default_storage::<D>().with_backend(|backend| backend.flush_all_changes_to_db());
+		let tag = persist_tag_from_block_number(block_number);
+		if !tagged_root::is_tagged(&default_storage::<D>().arena, &tag, &sp.hash()) {
+			persist_tagged(&default_storage::<D>().arena, tag, &sp);
+		}
+		default_storage::<D>().with_backend(|backend| {
+			if backend.get_roots().contains_key(&sp.hash()) {
+				backend.unpersist(&sp.hash());
+			}
+			backend.flush_all_changes_to_db();
+		});
 		log::info!(target: LOG_TARGET, "Imported verified ledger snapshot ({} bytes)", blob.len());
 		Ok(())
 	}
@@ -1013,6 +1067,12 @@ where
 		let key: ArenaKey<D::Hasher> = typed_key.into();
 		default_storage::<D>().with_backend(|backend| backend.unpersist(key.hash()));
 		Ok(())
+	}
+
+	/// Decrement persist count once on every tagged wrapper whose tag is in
+	/// `tags`. Native-only helper for later reclaim; not durable until flush.
+	pub fn release_tagged_roots<M: AsRef<[u8]>>(tags: &[M]) -> usize {
+		tagged_root::release_tagged(&default_storage::<D>().arena, tags)
 	}
 
 	fn get_transaction_details(

--- a/ledger/src/versions/common/storage.rs
+++ b/ledger/src/versions/common/storage.rs
@@ -121,17 +121,22 @@ where
 {
 	use super::api::Ledger;
 	use super::ledger_storage_local::storage::default_storage;
+	use super::{persist_tag_from_block_number, persist_tagged};
 
 	let state: super::mn_ledger_local::structure::LedgerState<D> =
 		super::midnight_serialize_local::tagged_deserialize(&mut &initial_state[..])
 			.expect("failed to deserialize ledger genesis state");
 	let state = Ledger::new(state);
 
-	let mut state = default_storage::<D>().arena.alloc(state);
-	// Genesis is treated as `LedgerStateKey::Anchored` — persist once at rc=1
-	// and rely on the Bridge never unpersisting Anchored inputs to retain it
-	// for history.
-	state.persist();
+	let state = default_storage::<D>().arena.alloc(state);
+	// Genesis is treated as `LedgerStateKey::Anchored` — persist as a wrapper
+	// tagged with block 0. The Bridge never unpersists Anchored inputs, so it
+	// stays queryable until GC releases that height.
+	persist_tagged(
+		&default_storage::<D>().arena,
+		persist_tag_from_block_number(0),
+		&state,
+	);
 	default_storage::<D>().with_backend(|backend| backend.flush_all_changes_to_db());
 	let mut bytes = vec![];
 	super::midnight_serialize_local::tagged_serialize(&state.as_typed_key(), &mut bytes).unwrap();
@@ -159,6 +164,28 @@ pub fn get_state_root_count(state_key: &[u8]) -> Option<u32> {
 	let key: ArenaKey<_> = typed_key.into();
 	default_storage::<ParityDb>()
 		.with_backend(|backend| backend.get_roots().get(key.hash()).copied())
+}
+
+/// Returns the persist refcount of tagged wrappers pinning the ledger state
+/// addressed by `state_key`, or `None` if no such wrapper is currently a GC
+/// root.
+///
+/// Anchored tips (genesis, `on_finalize`, warp import) are number-tagged
+/// wrappers; [`get_state_root_count`] is then `None` and this helper reports
+/// the wrapper pin count. Transient intra-block states remain raw persists.
+#[cfg(all(feature = "std", feature = "test-utils"))]
+pub fn get_tagged_pin_count(state_key: &[u8]) -> Option<u32> {
+	use super::api::Ledger;
+	use super::ledger_storage_local::{
+		arena::{ArenaKey, TypedArenaKey},
+		db::ParityDb,
+		storage::default_storage,
+	};
+
+	let typed_key: TypedArenaKey<Ledger<ParityDb>, _> =
+		super::midnight_serialize_local::tagged_deserialize(&mut &state_key[..]).ok()?;
+	let key: ArenaKey<_> = typed_key.into();
+	super::tagged_root::tagged_pin_count(&default_storage::<ParityDb>().arena, key.hash())
 }
 
 #[cfg(feature = "std")]

--- a/ledger/src/versions/common/storage.rs
+++ b/ledger/src/versions/common/storage.rs
@@ -132,11 +132,7 @@ where
 	// Genesis is treated as `LedgerStateKey::Anchored` — persist as a wrapper
 	// tagged with block 0. The Bridge never unpersists Anchored inputs, so it
 	// stays queryable until GC releases that height.
-	persist_tagged(
-		&default_storage::<D>().arena,
-		persist_tag_from_block_number(0),
-		&state,
-	);
+	persist_tagged(&default_storage::<D>().arena, persist_tag_from_block_number(0), &state);
 	default_storage::<D>().with_backend(|backend| backend.flush_all_changes_to_db());
 	let mut bytes = vec![];
 	super::midnight_serialize_local::tagged_serialize(&state.as_typed_key(), &mut bytes).unwrap();

--- a/ledger/src/versions/common/tagged_root.rs
+++ b/ledger/src/versions/common/tagged_root.rs
@@ -1,0 +1,368 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GC-root tagging as ordinary content-addressed data.
+//!
+//! A [`TaggedRoot`] pins a value together with an opaque tag (here: a block
+//! *number*) by wrapping it in a regular DAG node and persisting the *wrapper*
+//! as the GC root. The number is known in `on_finalize`, so the persist and
+//! the tag commit in the same `flush_storage`.
+//!
+//! [`release_tagged`] later releases every wrapper whose tag is a pruned
+//! height. Forks at the same height share a tag and fall together.
+//!
+//! # Matching
+//!
+//! [`release_tagged`] and [`tagged_roots`] recognize wrapper nodes by a
+//! payload magic prefix plus their single-child shape, without deserializing
+//! arbitrary root types. A non-wrapper root whose payload happens to start
+//! with the magic *and* has exactly one child *and* parses to a submitted tag
+//! would be misidentified; the magic makes this practically impossible for
+//! honest data, and roots are only ever created by trusted in-process code.
+
+use super::ledger_storage_local::{
+	Storable,
+	arena::{Arena, ArenaHash, ArenaKey, Sp},
+	backend::{OnDiskObject, StorageBackend},
+	db::DB,
+	storable::{Loader, WellBehavedHasher},
+};
+use super::midnight_serialize_local::{Deserializable, Serializable, Tagged};
+use std::io::{Error, ErrorKind, Read, Write};
+
+/// Payload prefix identifying wrapper nodes.
+const MAGIC: [u8; 15] = *b"tagged-root[v1]";
+
+/// Sanity cap on tag length when parsing candidate wrapper payloads.
+const MAX_TAG_LEN: usize = 1 << 16;
+
+/// Persist tag for an anchored ledger tip: the block number, little-endian.
+pub fn persist_tag_from_block_number(number: u32) -> std::vec::Vec<u8> {
+	number.to_le_bytes().to_vec()
+}
+
+/// Parse a tag produced by [`persist_tag_from_block_number`].
+pub fn block_number_from_persist_tag(tag: &[u8]) -> Option<u32> {
+	let raw: [u8; 4] = tag.try_into().ok()?;
+	Some(u32::from_le_bytes(raw))
+}
+
+/// A GC-root wrapper pinning `inner` together with an opaque `tag`.
+///
+/// See the [module docs](self).
+pub struct TaggedRoot<T: Storable<D>, D: DB> {
+	/// The opaque tag, e.g. a block number from [`persist_tag_from_block_number`].
+	pub tag: std::vec::Vec<u8>,
+	/// The pinned value.
+	pub inner: Sp<T, D>,
+}
+
+impl<T: Storable<D>, D: DB> Clone for TaggedRoot<T, D> {
+	fn clone(&self) -> Self {
+		TaggedRoot { tag: self.tag.clone(), inner: self.inner.clone() }
+	}
+}
+
+impl<T: Storable<D>, D: DB> std::fmt::Debug for TaggedRoot<T, D> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TaggedRoot")
+			.field("tag", &hex::encode(&self.tag))
+			.finish_non_exhaustive()
+	}
+}
+
+impl<T: Storable<D>, D: DB> Storable<D> for TaggedRoot<T, D> {
+	fn children(&self) -> std::vec::Vec<ArenaKey<D::Hasher>> {
+		vec![self.inner.as_child()]
+	}
+
+	fn to_binary_repr<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+		writer.write_all(&MAGIC)?;
+		write_tag(&self.tag, writer)
+	}
+
+	fn from_binary_repr<R: Read>(
+		reader: &mut R,
+		child_nodes: &mut impl Iterator<Item = ArenaKey<D::Hasher>>,
+		loader: &impl Loader<D>,
+	) -> Result<Self, Error> {
+		let mut magic = [0u8; MAGIC.len()];
+		reader.read_exact(&mut magic)?;
+		if magic != MAGIC {
+			return Err(Error::new(ErrorKind::InvalidData, "not a tagged-root node"));
+		}
+		let tag = read_tag(reader)?;
+		let inner = loader.get_next(child_nodes)?;
+		loader.do_check(TaggedRoot { tag, inner })
+	}
+}
+
+impl<T: Storable<D>, D: DB> Tagged for TaggedRoot<T, D> {
+	fn tag() -> std::borrow::Cow<'static, str> {
+		std::borrow::Cow::Borrowed("tagged-root[v1]")
+	}
+	fn tag_unique_factor() -> String {
+		"tagged-root[v1]".into()
+	}
+}
+
+fn write_tag<W: Write>(tag: &[u8], writer: &mut W) -> Result<(), Error> {
+	let len =
+		u32::try_from(tag.len()).map_err(|_| Error::new(ErrorKind::InvalidData, "tag too long"))?;
+	writer.write_all(&len.to_le_bytes())?;
+	writer.write_all(tag)
+}
+
+fn read_tag<R: Read>(reader: &mut R) -> Result<std::vec::Vec<u8>, Error> {
+	let mut len = [0u8; 4];
+	reader.read_exact(&mut len)?;
+	let len = u32::from_le_bytes(len) as usize;
+	if len > MAX_TAG_LEN {
+		return Err(Error::new(ErrorKind::InvalidData, "tag too long"));
+	}
+	let mut tag = vec![0u8; len];
+	reader.read_exact(&mut tag)?;
+	Ok(tag)
+}
+
+/// Extract the wrapper payload via the public `OnDiskObject` serialization
+/// (`data` is crate-private in storage-core).
+fn payload_bytes<H: WellBehavedHasher>(obj: &OnDiskObject<H>) -> Option<std::vec::Vec<u8>> {
+	let mut buf = std::vec::Vec::new();
+	obj.serialize(&mut buf).ok()?;
+	Vec::<u8>::deserialize(&mut &buf[..], 0).ok()
+}
+
+/// Parse `(tag, inner hash)` out of a raw node, if the node is a wrapper.
+pub(crate) fn parse_wrapper<H: WellBehavedHasher>(
+	obj: &OnDiskObject<H>,
+) -> Option<(std::vec::Vec<u8>, ArenaHash<H>)> {
+	if obj.children.len() != 1 {
+		return None;
+	}
+	let rest = payload_bytes(obj)?.strip_prefix(&MAGIC[..])?.to_vec();
+	let tag = read_tag(&mut rest.as_slice()).ok()?;
+	Some((tag, obj.children[0].hash().clone()))
+}
+
+/// Persist `inner` pinned under `tag`, returning the wrapper.
+///
+/// The wrapper is the GC root; `inner` is pinned transitively for as long as
+/// the wrapper is persisted. Calling this twice with the same `(tag, inner)`
+/// yields the same content-addressed wrapper, incrementing its persist count.
+pub fn persist_tagged<T: Storable<D>, D: DB>(
+	arena: &Arena<D>,
+	tag: std::vec::Vec<u8>,
+	inner: &Sp<T, D>,
+) -> Sp<TaggedRoot<T, D>, D> {
+	let mut sp = arena.alloc(TaggedRoot { tag, inner: inner.clone() });
+	sp.persist();
+	sp
+}
+
+/// True if a wrapper with `tag` already pins `inner_hash`.
+pub fn is_tagged<D: DB>(arena: &Arena<D>, tag: &[u8], inner_hash: &ArenaHash<D::Hasher>) -> bool {
+	arena.with_backend(|backend| {
+		for hash in backend.get_roots().into_keys() {
+			let Some((existing, child)) = backend.get(&hash).and_then(parse_wrapper) else {
+				continue;
+			};
+			if existing.as_slice() == tag && &child == inner_hash {
+				return true;
+			}
+		}
+		false
+	})
+}
+
+/// Unpersist every tagged root whose tag equals one of `tags`, decrementing
+/// each matching wrapper once. Returns the number of wrappers released.
+///
+/// The scan and the decrements run under a single backend borrow. Roots whose
+/// persist count already reached zero are not listed as roots, so
+/// re-submitting the same tags after a release is a safe no-op.
+///
+/// The count change is not durable until the caller flushes (same as
+/// `unpersist`).
+pub fn release_tagged<D: DB, M: AsRef<[u8]>>(arena: &Arena<D>, tags: &[M]) -> usize {
+	if tags.is_empty() {
+		return 0;
+	}
+	arena.with_backend(|backend| release_on_backend(backend, tags))
+}
+
+fn release_on_backend<D: DB, M: AsRef<[u8]>>(backend: &mut StorageBackend<D>, tags: &[M]) -> usize {
+	let wanted: std::collections::HashSet<&[u8]> = tags.iter().map(|t| t.as_ref()).collect();
+	let mut matched = std::vec::Vec::new();
+	for hash in backend.get_roots().into_keys() {
+		let Some((tag, _)) = backend.get(&hash).and_then(parse_wrapper) else {
+			continue;
+		};
+		if wanted.contains(tag.as_slice()) {
+			matched.push(hash);
+		}
+	}
+	for hash in &matched {
+		backend.unpersist(hash);
+	}
+	matched.len()
+}
+
+/// Enumerate all tagged roots, as `(wrapper hash, tag)` pairs.
+pub fn tagged_roots<D: DB>(
+	arena: &Arena<D>,
+) -> std::vec::Vec<(ArenaHash<D::Hasher>, std::vec::Vec<u8>)> {
+	arena.with_backend(|backend| {
+		let mut result = std::vec::Vec::new();
+		for hash in backend.get_roots().into_keys() {
+			if let Some((tag, _)) = backend.get(&hash).and_then(parse_wrapper) {
+				result.push((hash, tag));
+			}
+		}
+		result
+	})
+}
+
+/// Sum of persist counts of wrappers whose inner child is `inner_hash`.
+///
+/// `None` if no such wrapper is currently a GC root.
+pub fn tagged_pin_count<D: DB>(arena: &Arena<D>, inner_hash: &ArenaHash<D::Hasher>) -> Option<u32> {
+	arena.with_backend(|backend| {
+		let mut total = 0u32;
+		for (hash, count) in backend.get_roots() {
+			let Some((_, child)) = backend.get(&hash).and_then(parse_wrapper) else {
+				continue;
+			};
+			if &child == inner_hash {
+				total = total.saturating_add(count);
+			}
+		}
+		(total > 0).then_some(total)
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::super::ledger_storage_local::{DefaultHasher, Storage, db::InMemoryDB};
+	use super::*;
+
+	type D = InMemoryDB<DefaultHasher>;
+
+	/// A leaf large enough to be a real (non-inlined) node.
+	#[derive(Clone)]
+	struct FatLeaf(u64);
+
+	impl<DBImpl: DB> Storable<DBImpl> for FatLeaf {
+		fn children(&self) -> std::vec::Vec<ArenaKey<DBImpl::Hasher>> {
+			std::vec::Vec::new()
+		}
+
+		fn to_binary_repr<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+			writer.write_all(&[0u8; 1024])?;
+			writer.write_all(&self.0.to_le_bytes())
+		}
+
+		fn from_binary_repr<R: Read>(
+			reader: &mut R,
+			_child_nodes: &mut impl Iterator<Item = ArenaKey<DBImpl::Hasher>>,
+			loader: &impl Loader<DBImpl>,
+		) -> Result<Self, Error> {
+			let mut pad = [0u8; 1024];
+			reader.read_exact(&mut pad)?;
+			let mut value = [0u8; 8];
+			reader.read_exact(&mut value)?;
+			loader.do_check(FatLeaf(u64::from_le_bytes(value)))
+		}
+	}
+
+	fn new_arena() -> Arena<D> {
+		Storage::new(64, D::default()).arena
+	}
+
+	fn leaf(arena: &Arena<D>, v: u64) -> Sp<FatLeaf, D> {
+		arena.alloc(FatLeaf(v))
+	}
+
+	fn inner_root_count(arena: &Arena<D>, inner: &Sp<FatLeaf, D>) -> Option<u32> {
+		arena.with_backend(|b| b.get_roots().get(&inner.hash()).copied())
+	}
+
+	#[test]
+	fn persist_tag_from_block_number_roundtrips() {
+		let tag = persist_tag_from_block_number(42);
+		assert_eq!(block_number_from_persist_tag(&tag), Some(42));
+		assert_eq!(block_number_from_persist_tag(&[1, 2, 3]), None);
+		assert_eq!(persist_tag_from_block_number(0), 0u32.to_le_bytes().to_vec());
+	}
+
+	#[test]
+	fn persist_tagged_pins_wrapper_not_inner() {
+		let arena = new_arena();
+		let inner = leaf(&arena, 7);
+		let tag = persist_tag_from_block_number(1);
+		let wrapper = persist_tagged(&arena, tag.clone(), &inner);
+
+		assert_eq!(inner_root_count(&arena, &inner), None, "inner is not a raw GC root");
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), Some(1));
+		assert_eq!(tagged_roots(&arena), vec![(wrapper.hash(), tag)]);
+	}
+
+	#[test]
+	fn release_tagged_decrements_once_and_is_idempotent() {
+		let arena = new_arena();
+		let inner = leaf(&arena, 1);
+		let tag = persist_tag_from_block_number(1);
+		let _w1 = persist_tagged(&arena, tag.clone(), &inner);
+		let _w2 = persist_tagged(&arena, tag.clone(), &inner);
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), Some(2));
+
+		assert_eq!(release_tagged(&arena, &[&tag]), 1);
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), Some(1));
+		assert_eq!(release_tagged(&arena, &[&tag]), 1);
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), None);
+		assert_eq!(release_tagged(&arena, &[&tag]), 0);
+	}
+
+	#[test]
+	fn shared_inner_survives_partial_release() {
+		let arena = new_arena();
+		let (t1, t2) = (persist_tag_from_block_number(1), persist_tag_from_block_number(2));
+		let inner = leaf(&arena, 42);
+		let _w1 = persist_tagged(&arena, t1.clone(), &inner);
+		let _w2 = persist_tagged(&arena, t2.clone(), &inner);
+		assert_eq!(tagged_roots(&arena).len(), 2);
+
+		assert_eq!(release_tagged(&arena, &[&t1]), 1);
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), Some(1));
+		assert_eq!(tagged_roots(&arena).len(), 1);
+
+		assert_eq!(release_tagged(&arena, &[&t2]), 1);
+		assert_eq!(tagged_pin_count(&arena, &inner.hash()), None);
+		assert_eq!(tagged_roots(&arena).len(), 0);
+	}
+
+	#[test]
+	fn same_height_tags_release_together() {
+		let arena = new_arena();
+		let tag = persist_tag_from_block_number(7);
+		let a = leaf(&arena, 1);
+		let b = leaf(&arena, 2);
+		let _w1 = persist_tagged(&arena, tag.clone(), &a);
+		let _w2 = persist_tagged(&arena, tag.clone(), &b);
+		assert_eq!(tagged_pin_count(&arena, &a.hash()), Some(1));
+		assert_eq!(tagged_pin_count(&arena, &b.hash()), Some(1));
+		assert_eq!(release_tagged(&arena, &[&tag]), 2);
+		assert_eq!(tagged_pin_count(&arena, &a.hash()), None);
+		assert_eq!(tagged_pin_count(&arena, &b.hash()), None);
+	}
+}

--- a/node/src/ledger_gc.rs
+++ b/node/src/ledger_gc.rs
@@ -17,7 +17,7 @@
 //! the Substrate pruning window, then run incremental arena `gc`.
 //!
 //! Wrappers are persisted in the same `on_finalize` flush as the tip itself
-//! (`persist_tagged(System::Number)`). This worker only decides *when* they
+//! (`persist_tagged(block_number)`). This worker only decides *when* they
 //! may go. Reclaim is staged (no flush). Arena mark/sweep still skips a dirty
 //! cache. Under `ArchiveAll` and `ArchiveCanonical`, tip reclaim is skipped
 //! (history wrappers stay; stale forks at a shared height leak until — or,

--- a/node/src/ledger_gc.rs
+++ b/node/src/ledger_gc.rs
@@ -1,0 +1,266 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ledger GC worker: `release_tagged` wrappers whose block *number* has left
+//! the Substrate pruning window, then run incremental arena `gc`.
+//!
+//! Wrappers are persisted in the same `on_finalize` flush as the tip itself
+//! (`persist_tagged(System::Number)`). This worker only decides *when* they
+//! may go. Reclaim is staged (no flush). Arena mark/sweep still skips a dirty
+//! cache. Under `ArchiveAll` and `ArchiveCanonical`, tip reclaim is skipped
+//! (history wrappers stay; stale forks at a shared height leak until — or,
+//! under archive, forever) but the arena GC loop still runs.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use futures::{FutureExt, StreamExt};
+use log::{debug, error, info, warn};
+use midnight_node_runtime::opaque::Block;
+use sc_client_api::{Backend, BlockchainEvents};
+use sc_client_db::PruningMode;
+use sc_service::SpawnTaskHandle;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{SaturatedConversion, traits::NumberFor};
+
+use crate::service::{FullBackend, FullClient};
+
+const LOG_TARGET: &str = "midnight::ledger_gc";
+/// Soft time bound for one arena mark/sweep slice after finality. Storage-core
+/// GC is incremental across calls, so backlog continues on later notifications
+/// instead of looping under the arena mutex in a single tick.
+const GC_SLICE: Duration = Duration::from_millis(25);
+
+/// Unpersist lag = the effective `--state-pruning` window.
+///
+/// `None` means tip reclaim is off (`ArchiveAll` / `ArchiveCanonical`) —
+/// Anchored history wrappers must stay — but the arena GC loop still runs to
+/// cull zero-ref transient/intermediate nodes unpersisted during block
+/// execution. Number tags cannot distinguish a canonical tip from a stale
+/// fork at the same height, so `ArchiveCanonical` does not reclaim forks.
+///
+/// A `None` *config* does not mean archive: the CLI's `[default: 256]` is
+/// help text only, so a node started without the flag reaches here with
+/// `None` while sc-client-db prunes at `PruningMode::default()` (constrained,
+/// 256). Map it through that same default. If the DB was created with a
+/// larger window and the flag later dropped, `have_state_at` (checked past
+/// the lag) still keeps wrappers live until actual pruning, so the mismatch
+/// is leak-only. (`None` resolving to a stored *archive* mode on an existing
+/// DB is diverted in `try_spawn` via the DB-effective `requires_full_sync()`
+/// before this mapping is consulted.)
+fn discovery_depth(state_pruning: &Option<PruningMode>) -> Option<u32> {
+	match state_pruning.clone().unwrap_or_default() {
+		PruningMode::Constrained(c) => Some(c.max_blocks.unwrap_or(0)),
+		PruningMode::ArchiveCanonical | PruningMode::ArchiveAll => None,
+	}
+}
+
+fn number_from_tag(tag: &[u8]) -> Option<u32> {
+	midnight_node_ledger::latest::block_number_from_persist_tag(tag)
+}
+
+/// Keep the wrapper while inside pruning lag or while canonical state at that
+/// height is still present. Missing canonical hash → reclaimable leftover.
+/// Transient `hash` errors → keep.
+fn height_still_live(
+	client: &FullClient,
+	backend: &FullBackend,
+	n: u32,
+	lag: NumberFor<Block>,
+) -> bool {
+	let number: NumberFor<Block> = n.saturated_into();
+	let finalized = client.info().finalized_number;
+	if finalized.saturating_sub(number) < lag {
+		return true;
+	}
+	match client.hash(number) {
+		Ok(Some(hash)) => backend.have_state_at(hash, number),
+		Ok(None) => false,
+		Err(e) => {
+			debug!(target: LOG_TARGET, "⏸️  hash({n}) failed ({e}); keeping wrapper");
+			true
+		},
+	}
+}
+
+fn reclaim_slice(
+	client: &FullClient,
+	backend: &FullBackend,
+	lag: NumberFor<Block>,
+	prev_pruned: HashSet<u32>,
+) -> HashSet<u32> {
+	let mut candidates = HashSet::new();
+	let mut to_release = Vec::new();
+
+	for tag in midnight_node_ledger::gc::tagged_root_tags() {
+		let Some(n) = number_from_tag(&tag) else {
+			continue;
+		};
+		if height_still_live(client, backend, n, lag) {
+			continue;
+		}
+		candidates.insert(n);
+		if prev_pruned.contains(&n) {
+			to_release.push(tag);
+		}
+	}
+
+	if !to_release.is_empty() {
+		let released = midnight_node_ledger::gc::release_tagged_tips(&to_release);
+		if released > 0 {
+			info!(
+				target: LOG_TARGET,
+				"🧹 Released {released} tagged wrapper(s) from {} pruned height(s)",
+				to_release.len()
+			);
+		}
+	}
+
+	run_arena_gc_slice();
+
+	candidates
+}
+
+/// One incremental arena GC slice (zero-ref Transient/intermediate cull).
+/// Paced on finality — no inner mutex-yield loop.
+fn run_arena_gc_slice() {
+	let started = std::time::Instant::now();
+	match midnight_node_ledger::gc::collect_garbage(GC_SLICE) {
+		Ok(0) => {},
+		Ok(n) => {
+			info!(
+				target: LOG_TARGET,
+				"🗑️  Arena GC slice: culled={n} elapsed_ms={}",
+				started.elapsed().as_millis()
+			);
+		},
+		Err(e) => {
+			debug!(target: LOG_TARGET, "⏸️  Arena GC deferred: {e}");
+		},
+	}
+}
+
+async fn run(client: Arc<FullClient>, backend: Arc<FullBackend>, depth: u32) {
+	info!(target: LOG_TARGET, "♻️  Ledger GC started (depth={depth})");
+
+	let mut finality = client.finality_notification_stream();
+	let lag: NumberFor<Block> = depth.saturated_into();
+	let mut pruned_candidates: HashSet<u32> = HashSet::new();
+
+	pruned_candidates = run_reclaim_slice(&client, &backend, lag, pruned_candidates).await;
+
+	loop {
+		let Some(_note) = finality.next().await else {
+			warn!(target: LOG_TARGET, "⚠️  Finality stream closed; stopping ledger GC");
+			return;
+		};
+		while let Some(Some(_)) = finality.next().now_or_never() {}
+
+		pruned_candidates = run_reclaim_slice(&client, &backend, lag, pruned_candidates).await;
+	}
+}
+
+async fn run_reclaim_slice(
+	client: &Arc<FullClient>,
+	backend: &Arc<FullBackend>,
+	lag: NumberFor<Block>,
+	prev: HashSet<u32>,
+) -> HashSet<u32> {
+	let client_gc = client.clone();
+	let backend_gc = backend.clone();
+	match tokio::task::spawn_blocking(move || reclaim_slice(&client_gc, &backend_gc, lag, prev))
+		.await
+	{
+		Ok(candidates) => candidates,
+		Err(e) => {
+			error!(target: LOG_TARGET, "💥 GC slice task failed: {e}");
+			HashSet::new()
+		},
+	}
+}
+
+/// Arena-GC-only loop: never releases Anchored history wrappers, but still
+/// culls zero-ref Transient/intermediate garbage that block execution already
+/// unpersisted. Paced on finality.
+async fn run_arena_only(client: Arc<FullClient>) {
+	info!(
+		target: LOG_TARGET,
+		"♻️  Ledger arena GC started (tip reclaim disabled; history wrappers kept)"
+	);
+
+	let mut finality = client.finality_notification_stream();
+	let _ = tokio::task::spawn_blocking(run_arena_gc_slice).await;
+
+	loop {
+		let Some(_note) = finality.next().await else {
+			warn!(target: LOG_TARGET, "⚠️  Finality stream closed; stopping ledger arena GC");
+			return;
+		};
+		while let Some(Some(_)) = finality.next().now_or_never() {}
+
+		if let Err(e) = tokio::task::spawn_blocking(run_arena_gc_slice).await {
+			error!(target: LOG_TARGET, "💥 Arena GC slice task failed: {e}");
+		}
+	}
+}
+
+/// Spawn the ledger GC worker for the configured pruning mode.
+pub fn try_spawn(
+	spawn: &SpawnTaskHandle,
+	client: Arc<FullClient>,
+	backend: Arc<FullBackend>,
+	state_pruning: &Option<PruningMode>,
+) {
+	// `StateDb::open` reuses the DB-stored pruning mode when the CLI flag is
+	// omitted (`(false, Some(stored), None) => stored`), so a `None` config
+	// only means "constrained 256" on a fresh DB. If the flag is omitted and
+	// the backend reports archive pruning, the stored mode is `ArchiveAll` or
+	// `ArchiveCanonical` — indistinguishable through the public API. Fall
+	// back to arena-only GC.
+	if state_pruning.is_none() && backend.requires_full_sync() {
+		info!(
+			target: LOG_TARGET,
+			"ℹ️  Archive DB with --state-pruning omitted; ledger tip reclaim disabled \
+			 (arena GC only)"
+		);
+		spawn.spawn("ledger-gc", Some("ledger"), run_arena_only(client));
+		return;
+	}
+
+	let Some(depth) = discovery_depth(state_pruning) else {
+		info!(
+			target: LOG_TARGET,
+			"ℹ️  Ledger tip reclaim disabled (archive pruning); arena GC still runs for \
+			 transient/intermediate garbage"
+		);
+		spawn.spawn("ledger-gc", Some("ledger"), run_arena_only(client));
+		return;
+	};
+
+	spawn.spawn("ledger-gc", Some("ledger"), run(client, backend, depth));
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn discovery_depth_matches_effective_pruning() {
+		assert_eq!(discovery_depth(&None), Some(256));
+		assert_eq!(discovery_depth(&Some(PruningMode::default())), Some(256));
+		assert_eq!(discovery_depth(&Some(PruningMode::blocks_pruning(1024))), Some(1024));
+		assert_eq!(discovery_depth(&Some(PruningMode::ArchiveAll)), None);
+		assert_eq!(discovery_depth(&Some(PruningMode::ArchiveCanonical)), None);
+	}
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -28,6 +28,7 @@ pub mod extensions;
 mod filtering_pool;
 pub mod genesis;
 pub mod inherent_data;
+mod ledger_gc;
 pub mod main_chain_follower;
 pub mod memory_monitor;
 pub mod metrics_push;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -241,7 +241,7 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 /// The minimum period of blocks on which justifications will be
 /// imported and generated.
-const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
+pub(crate) const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
 
 type TransactionPool = FilteringTransactionPool<Block, FullClient>;
 
@@ -648,6 +648,8 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		Vec::default(),
 	));
 
+	let state_pruning = config.state_pruning.clone();
+
 	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
 			config: &config,
@@ -662,6 +664,13 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 			block_relay: None,
 			metrics,
 		})?;
+
+	crate::ledger_gc::try_spawn(
+		&task_manager.spawn_handle(),
+		client.clone(),
+		backend.clone(),
+		&state_pruning,
+	);
 
 	// Capture peer_id before network is moved
 	let peer_id = network.local_peer_id().to_base58();

--- a/node/src/warp_ledger_sync/client.rs
+++ b/node/src/warp_ledger_sync/client.rs
@@ -20,7 +20,7 @@
 //! fetch the Snappy-compressed `Ledger`-rooted arena blob in byte ranges from peers, decompress it
 //! to the canonical blob, then hand that blob to
 //! [`midnight_node_ledger::import_verified_ledger_snapshot`], which verifies its root against the
-//! `StateKey` and persists it on success.
+//! `StateKey` and persists it as a wrapper tagged with `target_number` on success.
 //!
 //! Verification + persistence live in the ledger crate (next to the arena); this module is pure
 //! network orchestration. No peer is trusted: a bad blob fails the root check and is discarded.
@@ -32,7 +32,7 @@ use sc_client_api::{Backend, StorageProvider};
 use sc_network::{
 	IfDisconnected, NetworkRequest, PeerId, ProtocolName, request_responses::RequestFailure,
 };
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, UniqueSaturatedInto};
 
 use super::{
 	LOG_TARGET,
@@ -78,10 +78,16 @@ where
 
 	/// Recover, verify, and import the ledger arena at `target` (the captured warp target N) by
 	/// trying `peers` in order. Returns `Ok` as soon as one peer yields a complete blob that
-	/// verifies against the on-chain `StateKey` and imports; otherwise [`ClientError::AllPeersFailed`].
+	/// verifies against the on-chain `StateKey` and is persisted as a wrapper tagged with
+	/// `target_number`; otherwise [`ClientError::AllPeersFailed`].
 	///
 	/// The caller must hold the authoring/import gate while this runs (single-writer arena).
-	pub async fn recover(&self, target: B::Hash, peers: &[PeerId]) -> Result<(), ClientError> {
+	pub async fn recover(
+		&self,
+		target: B::Hash,
+		target_number: sp_runtime::traits::NumberFor<B>,
+		peers: &[PeerId],
+	) -> Result<(), ClientError> {
 		let state_key = read_state_key::<B, Client, BE>(&self.client, target)?
 			.ok_or(ClientError::NoStateKey)?;
 
@@ -109,6 +115,7 @@ where
 			let unified = self.unified;
 			let blob_len = blob.len();
 			let state_key = state_key.clone();
+			let persist_tag_number: u32 = target_number.unique_saturated_into();
 			log::info!(
 				target: LOG_TARGET,
 				"Verifying + importing ledger arena snapshot from {peer} ({blob_len} bytes); \
@@ -116,7 +123,12 @@ where
 			);
 			let started = std::time::Instant::now();
 			let mut import = tokio::task::spawn_blocking(move || {
-				midnight_node_ledger::import_verified_ledger_snapshot(unified, &blob, &state_key)
+				midnight_node_ledger::import_verified_ledger_snapshot(
+					unified,
+					&blob,
+					&state_key,
+					persist_tag_number,
+				)
 			});
 			let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
 			heartbeat.tick().await; // consume the immediate first tick

--- a/node/src/warp_ledger_sync/integration_tests.rs
+++ b/node/src/warp_ledger_sync/integration_tests.rs
@@ -70,18 +70,34 @@ fn ledger_snapshot_roundtrip_serialize_chunk_verify_import() {
 	let reassembled = compress_page_reassemble_decompress(&blob, 4096);
 	assert_eq!(reassembled, blob, "reassembled blob must be byte-identical to the server's");
 
-	// Client/import: verify root == StateKey and persist. Idempotent against the
-	// already-initialized arena (content-addressed; genesis nodes dedup).
-	midnight_node_ledger::import_verified_ledger_snapshot(false, &reassembled, &state_key)
-		.expect("verified import of a faithful snapshot should succeed");
+	// Client/import: verify root == StateKey and persist as a wrapper tagged with the warp
+	// target number (committed in the same flush). Idempotent against the already-initialized
+	// arena (content-addressed; a leftover raw genesis pin is dropped).
+	let warp_number = 42u32;
+	let warp_tag = warp_number.to_le_bytes();
+	midnight_node_ledger::import_verified_ledger_snapshot(
+		false,
+		&reassembled,
+		&state_key,
+		warp_number,
+	)
+	.expect("verified import of a faithful snapshot should succeed");
+	assert!(
+		midnight_node_ledger::gc::tagged_root_tags().iter().any(|t| t.as_slice() == warp_tag),
+		"warp-point persist must be a tagged wrapper so GC can reclaim it"
+	);
 
 	// Security property: tamper a byte well past the tag prefix (in the node-data region). The
 	// native multi-pass deserializer / root check must reject it — never a successful import.
 	let mut tampered = blob.clone();
 	let idx = tampered.len() / 2;
 	tampered[idx] ^= 0xFF;
-	let result =
-		midnight_node_ledger::import_verified_ledger_snapshot(false, &tampered, &state_key);
+	let result = midnight_node_ledger::import_verified_ledger_snapshot(
+		false,
+		&tampered,
+		&state_key,
+		warp_number,
+	);
 	assert!(
 		result.is_err(),
 		"a tampered snapshot must fail verification and not be imported, got {result:?}"

--- a/node/src/warp_ledger_sync/integration_tests.rs
+++ b/node/src/warp_ledger_sync/integration_tests.rs
@@ -83,7 +83,9 @@ fn ledger_snapshot_roundtrip_serialize_chunk_verify_import() {
 	)
 	.expect("verified import of a faithful snapshot should succeed");
 	assert!(
-		midnight_node_ledger::gc::tagged_root_tags().iter().any(|t| t.as_slice() == warp_tag),
+		midnight_node_ledger::gc::tagged_root_tags()
+			.iter()
+			.any(|t| t.as_slice() == warp_tag),
 		"warp-point persist must be a tagged wrapper so GC can reclaim it"
 	);
 

--- a/node/src/warp_ledger_sync/mod.rs
+++ b/node/src/warp_ledger_sync/mod.rs
@@ -30,7 +30,7 @@
 //!   `midnight_node_ledger::import_verified_ledger_snapshot`, which reuses the arena's **native**
 //!   multi-pass deserializer (`Arena::deserialize_sp`) for untrusted input rather than a bespoke
 //!   re-hash, then asserts the recomputed root equals `StateKey` before persisting in-process
-//!   (`alloc`/`persist`/`flush`, no restart).
+//!   (`alloc`/`persist_tagged(target number)`/`flush`, no restart).
 //! - [`monitor`] — detects warp completion, captures the target block, drives [`client`], releases
 //!   the gate. [`oracle`] keeps AURA from authoring until recovery is verified.
 

--- a/node/src/warp_ledger_sync/monitor.rs
+++ b/node/src/warp_ledger_sync/monitor.rs
@@ -189,7 +189,7 @@ async fn recover_and_release<B, Client, BE, Network>(
 	let driver = LedgerSyncClient::new(client, network.clone(), protocol_name, unified);
 	loop {
 		let peers = recovery_candidate_peers(&*network, &sync_service).await;
-		match driver.recover(target_hash, &peers).await {
+		match driver.recover(target_hash, target_number, &peers).await {
 			Ok(()) => break,
 			Err(e) => {
 				log::warn!(target: LOG_TARGET, "Ledger arena recovery attempt failed: {e}; retrying");

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -350,7 +350,8 @@ pub mod pallet {
 		}
 
 		fn on_finalize(_block: BlockNumberFor<T>) {
-			// Post Block Ledger Update
+			// Post Block Ledger Update. The tip is persisted as a wrapper tagged
+			// with `System::Number` (known here; the block hash is not).
 			let state_key = Self::state_key();
 			let block_context = Self::get_block_context();
 

--- a/pallets/midnight/src/lib.rs
+++ b/pallets/midnight/src/lib.rs
@@ -349,14 +349,16 @@ pub mod pallet {
 			ConfigurableOnInitializeWeight::<T>::get()
 		}
 
-		fn on_finalize(_block: BlockNumberFor<T>) {
+		fn on_finalize(block: BlockNumberFor<T>) {
 			// Post Block Ledger Update. The tip is persisted as a wrapper tagged
-			// with `System::Number` (known here; the block hash is not).
+			// with this block number (the hash is not known here).
 			let state_key = Self::state_key();
 			let block_context = Self::get_block_context();
+			let block_number = block.unique_saturated_into();
 
-			let state_root = LedgerApi::apply_post_block_update(state_key, block_context.clone())
-				.expect("FATAL: Apply post block update failed");
+			let state_root =
+				LedgerApi::apply_post_block_update(state_key, block_context.clone(), block_number)
+					.expect("FATAL: Apply post block update failed");
 
 			StateKey::<T>::put(state_root);
 

--- a/pallets/midnight/tests/persist_refcount.rs
+++ b/pallets/midnight/tests/persist_refcount.rs
@@ -42,13 +42,17 @@ fn init_ledger_state(block_context: BlockContext) {
 }
 
 fn process_block(block_number: u64, block_context: BlockContext) {
+	mock::System::set_block_number(block_number);
 	mock::Midnight::on_finalize(block_number);
-	mock::System::set_block_number(block_number + 1);
 	mock::Timestamp::set_timestamp(block_context.tblock * 1000);
 }
 
 fn root_count(state_key: &LedgerStateKey) -> Option<u32> {
 	midnight_node_ledger::latest::storage::get_state_root_count(state_key.bytes())
+}
+
+fn tagged_pin_count(state_key: &LedgerStateKey) -> Option<u32> {
+	midnight_node_ledger::latest::storage::get_tagged_pin_count(state_key.bytes())
 }
 
 fn current_state_key() -> LedgerStateKey {
@@ -57,9 +61,10 @@ fn current_state_key() -> LedgerStateKey {
 
 /// Walks an entire block lifecycle and asserts the LedgerStateKey persist
 /// contract at every transition:
-///   - `Anchored` states (genesis, post-block tips) are persisted at rc=1 and
-///     are NEVER unpersisted by subsequent Bridge calls — so they survive
-///     sibling forks and remain queryable for history,
+///   - `Anchored` states (genesis, post-block tips) are persisted as a
+///     number-tagged wrapper (inner is not a raw GC root) and are NEVER
+///     unpersisted by subsequent Bridge calls — so they survive sibling forks
+///     and remain queryable for history until GC releases that height.
 ///   - `Transient` states (intra-block intermediates) are persisted at rc=1
 ///     and unpersisted to rc=0 by their successor.
 ///
@@ -87,10 +92,11 @@ fn persist_refcount_invariants() {
 
 		let genesis_key = current_state_key();
 		assert!(matches!(genesis_key, LedgerStateKey::Anchored(_)), "genesis stored as Anchored");
+		assert_eq!(root_count(&genesis_key), None, "genesis inner is not a raw GC root");
 		assert_eq!(
-			root_count(&genesis_key),
+			tagged_pin_count(&genesis_key),
 			Some(1),
-			"genesis is persisted at rc=1 by alloc_with_initial_state"
+			"genesis is a number-tagged wrapper (block 0)"
 		);
 
 		// Read-only guard 1: validate_unsigned + pre_dispatch against the genesis
@@ -100,14 +106,18 @@ fn persist_refcount_invariants() {
 			&deploy_call
 		));
 		assert_eq!(current_state_key(), genesis_key);
-		assert_eq!(root_count(&genesis_key), Some(1), "validate_unsigned must not change tip rc");
+		assert_eq!(
+			tagged_pin_count(&genesis_key),
+			Some(1),
+			"validate_unsigned must not change tip pin"
+		);
 		assert_ok!(<mock::Midnight as ValidateUnsigned>::pre_dispatch(&deploy_call));
 		assert_eq!(current_state_key(), genesis_key);
-		assert_eq!(root_count(&genesis_key), Some(1), "pre_dispatch must not change tip rc");
+		assert_eq!(tagged_pin_count(&genesis_key), Some(1), "pre_dispatch must not change tip pin");
 
 		// Block 1: apply DEPLOY. Genesis is Anchored — Bridge must NOT unpersist
 		// it. (This is the property that makes sibling forks safe: a second fork
-		// applying its own first-tx on the same Anchored parent leaves rc=1.)
+		// applying its own first-tx on the same Anchored parent leaves the pin.)
 		assert_ok!(mock::Midnight::send_mn_transaction(RuntimeOrigin::none(), deploy_tx));
 		let post_deploy_key = current_state_key();
 		assert!(
@@ -117,13 +127,13 @@ fn persist_refcount_invariants() {
 		assert_ne!(post_deploy_key, genesis_key);
 		assert_eq!(root_count(&post_deploy_key), Some(1), "new Transient state at rc=1");
 		assert_eq!(
-			root_count(&genesis_key),
+			tagged_pin_count(&genesis_key),
 			Some(1),
 			"Anchored genesis must NOT be unpersisted by apply_transaction"
 		);
 
 		// Finalize block 1. post_block_update unpersists the Transient predecessor
-		// (post_deploy → rc=0) and returns Anchored at rc=1.
+		// (post_deploy → rc=0) and returns Anchored pinned by a number-tagged wrapper.
 		process_block(2, store_ctx.clone().into());
 		let post_block_1_key = current_state_key();
 		assert!(
@@ -138,34 +148,39 @@ fn persist_refcount_invariants() {
 		);
 		assert_eq!(
 			root_count(&post_block_1_key),
+			None,
+			"Anchored post-block inner is not a raw GC root"
+		);
+		assert_eq!(
+			tagged_pin_count(&post_block_1_key),
 			Some(1),
-			"Anchored post-block state at rc=1, retained for history"
+			"Anchored post-block state pinned by a number-tagged wrapper"
 		);
 
 		// Read-only guard 2: validate against the Anchored post-block tip. DEPLOY
-		// fails here (contract already deployed) but rc must be untouched on
+		// fails here (contract already deployed) but the pin must be untouched on
 		// either path.
 		let _ = <mock::Midnight as ValidateUnsigned>::validate_unsigned(
 			TransactionSource::External,
 			&deploy_call,
 		);
 		assert_eq!(
-			root_count(&post_block_1_key),
+			tagged_pin_count(&post_block_1_key),
 			Some(1),
-			"validate_unsigned against post-block tip must not change rc"
+			"validate_unsigned against post-block tip must not change pin"
 		);
 		let _ = <mock::Midnight as ValidateUnsigned>::pre_dispatch(&deploy_call);
 		assert_eq!(
-			root_count(&post_block_1_key),
+			tagged_pin_count(&post_block_1_key),
 			Some(1),
-			"pre_dispatch against post-block tip must not change rc"
+			"pre_dispatch against post-block tip must not change pin"
 		);
 
 		// Block 2: apply STORE. post_block_1 is Anchored — must NOT be unpersisted.
 		assert_ok!(mock::Midnight::send_mn_transaction(RuntimeOrigin::none(), store_tx));
 		let post_store_key = current_state_key();
 		assert_eq!(
-			root_count(&post_block_1_key),
+			tagged_pin_count(&post_block_1_key),
 			Some(1),
 			"Anchored post-block-1 must NOT be unpersisted by next block's first apply"
 		);
@@ -179,21 +194,29 @@ fn persist_refcount_invariants() {
 			None,
 			"Transient last-apply output of block 2 unrooted by post_block_update"
 		);
-		assert_eq!(root_count(&post_block_2_key), Some(1), "Anchored post-block-2 at rc=1");
 		assert_eq!(
-			root_count(&post_block_1_key),
+			tagged_pin_count(&post_block_2_key),
 			Some(1),
-			"prior Anchored post-block-1 unaffected, still at rc=1"
+			"Anchored post-block-2 pinned by a number-tagged wrapper"
+		);
+		assert_eq!(
+			tagged_pin_count(&post_block_1_key),
+			Some(1),
+			"prior Anchored post-block-1 unaffected"
 		);
 
 		// Block 3: apply CHECK and confirm Anchored states remain untouched.
 		assert_ok!(mock::Midnight::send_mn_transaction(RuntimeOrigin::none(), check_tx));
 		assert_eq!(
-			root_count(&post_block_2_key),
+			tagged_pin_count(&post_block_2_key),
 			Some(1),
 			"Anchored post-block-2 unaffected by block 3's first apply"
 		);
-		assert_eq!(root_count(&post_block_1_key), Some(1), "Anchored post-block-1 still at rc=1");
-		assert_eq!(root_count(&genesis_key), Some(1), "Anchored genesis still at rc=1");
+		assert_eq!(
+			tagged_pin_count(&post_block_1_key),
+			Some(1),
+			"Anchored post-block-1 still pinned"
+		);
+		assert_eq!(tagged_pin_count(&genesis_key), Some(1), "Anchored genesis still pinned");
 	});
 }


### PR DESCRIPTION
# Overview

Substrate `--state-pruning` removes historical trie state, but Midnight's ledger arena is a separate store. `post_block_update` persists Anchored tip roots that were never unpersisted when the corresponding block state was pruned, so `ledger_storage` grew without bound ([#1983](https://github.com/midnightntwrk/midnight-node/issues/1983)).

This PR adds a node-side ledger GC worker that:

1. At **finality**, reads `pallet_midnight::StateKey` for newly finalized / stale-fork hashes and records reclaimable `(block_hash → tip)` bindings in AuxStore (`midnight/ledger_gc`).
2. After the configured pruning lag, and once `have_state_at` has been false for a debounced slice, **retires** the AuxStore binding and then **`unpersist`s** the tip once (non-idempotent decrement).
3. **Flushes** the ledger write cache after those unpersists so a shutdown before the next block flush cannot drop staged root-count decrements while the retry binding is already gone.
4. Runs incremental arena `gc` after reclaim (skipped during major sync).

No Bridge Ext / import-path attribution: tips are indexed from on-disk `StateKey` at finality only. Self-authored Aura imports do not re-execute the runtime, so each executed block contributes one persist (`rc = 1` per tip binding).

### Pruning modes

| Mode | Worker | Behavior |
|---|---|---|
| Constrained (incl. omitted flag → default 256) | On | Lag = prune window; bind canonical + stale forks |
| `archive-canonical` | On (zero-lag) | Bind **only** stale forks; reclaim when `have_state_at` is false; keep canonical archive tips |
| `archive` / `ArchiveAll` | Off | Full history retained |

`depth == 0` alone is not used to detect archive-canonical (`Constrained(max_blocks: None)` must still bind canonical tips).

### Safety / fail-safe

- **Remove-then-unpersist**: crash between steps → leak, never double-decrement.
- Flush after unpersist before reporting success (durability of root-count updates).
- Index only ledger-8/9 tips (`is_reclaimable_tip`); pre-ledger-8 roots are not indexed.
- Pre-v3 raw `StateKey` (`Vec<u8>` tip) still indexed when reclaimable.
- One unpersist per removed hash binding (no tip-byte dedup).
- Fork capture at finality is best-effort under archive-canonical (non-canonical state may already be gone in the finalize commit).

### Ops note

Full-sync-from-genesis with `--state-pruning` smaller than the GRANDPA justification period can miss tips pruned in the same commit as batched finality. The node warns when the window is `< 512`. Prefer `--state-pruning >= 512` or warp sync for those nodes.

## 🗹 TODO before merging

- [ ] Ready
- [ ] Squash `fixup!` commits
- [ ] Confirm PR body / labels (`bot:ai-assisted` if applicable)

## 📌 Submission Checklist

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: `changes/node/changed/ledger-gc-statekey.md`
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

- Unit tests in `ledger/src/gc.rs` (reclaimable tip detection, once-per-tip unpersist, multiplicity, undecodable batch = leak not error).
- Unit test in `node/src/ledger_gc.rs` for `discovery_depth` vs pruning modes (including `ArchiveCanonical → Some(0)`).
- [ ] Additional tests are provided (if possible)
- [ ] Manual / long-run: constrained pruning + observe AuxStore tip count and ledger DB size after finality+prune
- [ ] Manual: `--state-pruning archive-canonical` — worker on, only stale-fork reclaim; AuxStore does not grow one entry per canonical block

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [x] Node Client Update
- [ ] Other:
- [ ] N/A

Client-only GC worker + ledger unpersist/flush helpers. Existing nodes pick this up on upgrade; AuxStore index is rebuilt from finality going forward (historical tips already past the prune window may remain until/unless captured). No runtime migration required for the GC worker itself.

## Links

- Closes https://github.com/midnightntwrk/midnight-node/issues/1983
- Change file: `changes/node/changed/ledger-gc-statekey.md`