### PR TITLE
feat: report BABE key presence in the keystore

### DIFF
--- a/changes/node/added/babe-key-readiness-metric.md
+++ b/changes/node/added/babe-key-readiness-metric.md
@@ -1,0 +1,22 @@
+#node #metrics
+
+# Report whether a validator holds a BABE key registered on Cardano
+
+Validators now publish `midnight_babe_key_registered`: `1` when the keystore
+holds a BABE key that is also registered as the `babe` key of a permissioned
+candidate on Cardano, `0` when it holds none. A probe intersects the keystore's
+BABE keys with the `babe` keys of the permissioned candidates read from the main
+chain, and a reporter runs it periodically.
+
+Ahead of the switch to BABE consensus this makes a missing or wrong BABE key
+visible is grafana.
+
+The probe deliberately uses the plain node keystore, not
+`AuraToBabeMigrationKeystore`, which answers BABE queries with AURA keys and
+would report every node as ready.
+
+We need reliable data about how good operators did in adding keys to keystores
+to not lose chain density (hence link to https://github.com/midnightntwrk/midnight-node/issues/1753)
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/1996
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1753

--- a/node/src/babe_key_readiness/mod.rs
+++ b/node/src/babe_key_readiness/mod.rs
@@ -1,0 +1,35 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Observability for the upcoming AURA-to-BABE consensus migration: tells us
+//! whether a node operator has put a usable BABE key in their keystore.
+//!
+//! When the chain flips to BABE, a validator whose keystore holds no BABE key
+//! (or the wrong one) silently stops producing blocks. Rather than find out at
+//! the flip, we check ahead of time:
+//!
+//! - [`probe::BabeKeyProbe`] reads the BABE keys from the keystore, reads the
+//!   `babe` keys of the permissioned candidates registered on Cardano, and
+//!   returns the intersection.
+//! - [`reporter::run`] runs the probe on an interval and publishes
+//!   `midnight_babe_key_registered` (1 = a matching key is present, 0 = none).
+//!
+//! The probe must be given the plain node keystore, not
+//! [`crate::aura_to_babe_migration_keystore::AuraToBabeMigrationKeystore`],
+//! which answers BABE queries with AURA keys and would therefore report every
+//! node as ready.
+
+pub mod probe;
+pub mod reporter;
+
+const LOG_TARGET: &str = "babe-key-readiness";

--- a/node/src/babe_key_readiness/probe.rs
+++ b/node/src/babe_key_readiness/probe.rs
@@ -1,0 +1,286 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Probes if node's keystore hold a BABE key that is registered as the `babe` key of a permissioned candidate on Cardano?
+
+use async_trait::async_trait;
+use authority_selection_inherents::{
+	AuthoritySelectionDataSource, AuthoritySelectionInputs, CommitteeMember,
+};
+use midnight_node_runtime::{
+	CrossChainPublic,
+	opaque::{Block, SessionKeys},
+};
+use sidechain_domain::{
+	McEpochNumber, PermissionedCandidateData, ScEpochNumber,
+	mainchain_epoch::{MainchainEpochConfig, MainchainEpochDerivation, Timestamp},
+};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_core::{crypto::key_types::BABE, sr25519};
+use sp_keystore::{Keystore, KeystorePtr};
+use sp_session_validator_management::SessionValidatorManagementApi;
+use std::sync::Arc;
+use time_source::TimeSource;
+
+use super::LOG_TARGET;
+
+/// Error type of the probe and its data sources.
+pub type ProbeError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The permissioned candidates in effect on Cardano.
+#[async_trait]
+pub trait PermissionedCandidatesDataSource: Send + Sync {
+	/// Returns the permissioned candidates in effect for the current main chain
+	/// epoch. An empty vector means no list is set on the main chain.
+	async fn permissioned_candidates(&self) -> Result<Vec<PermissionedCandidateData>, ProbeError>;
+}
+
+/// The datasource for probe
+pub struct ProbeCandidatesDataSource<C> {
+	client: Arc<C>,
+	data_source: Arc<dyn AuthoritySelectionDataSource + Send + Sync>,
+	mc_epoch_config: MainchainEpochConfig,
+	time_source: Arc<dyn TimeSource + Send + Sync>,
+}
+
+impl<C> ProbeCandidatesDataSource<C> {
+	/// Constructor.
+	pub fn new(
+		client: Arc<C>,
+		data_source: Arc<dyn AuthoritySelectionDataSource + Send + Sync>,
+		mc_epoch_config: MainchainEpochConfig,
+		time_source: Arc<dyn TimeSource + Send + Sync>,
+	) -> Self {
+		Self { client, data_source, mc_epoch_config, time_source }
+	}
+
+	fn current_mc_epoch(&self) -> Result<McEpochNumber, ProbeError> {
+		let now = Timestamp::from_unix_millis(self.time_source.get_current_time_millis());
+		Ok(self.mc_epoch_config.timestamp_to_mainchain_epoch(now)?)
+	}
+}
+
+#[async_trait]
+impl<C> PermissionedCandidatesDataSource for ProbeCandidatesDataSource<C>
+where
+	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,
+	C::Api: SessionValidatorManagementApi<
+			Block,
+			CommitteeMember<CrossChainPublic, SessionKeys>,
+			AuthoritySelectionInputs,
+			ScEpochNumber,
+		>,
+{
+	async fn permissioned_candidates(&self) -> Result<Vec<PermissionedCandidateData>, ProbeError> {
+		let epoch = self.current_mc_epoch()?;
+		// Read the policy IDs from the best block. Scoped so the (non-`Send`)
+		// runtime API handle is dropped before the await below.
+		let scripts = {
+			let best_hash = self.client.info().best_hash;
+			self.client.runtime_api().get_main_chain_scripts(best_hash)?
+		};
+
+		let parameters = self
+			.data_source
+			.get_ariadne_parameters(
+				epoch,
+				scripts.d_parameter_policy_id,
+				scripts.permissioned_candidates_policy_id,
+			)
+			.await?;
+
+		match parameters.permissioned_candidates {
+			Some(candidates) => Ok(candidates),
+			None => Ok(Vec::new()),
+		}
+	}
+}
+
+/// Reports which of this node's BABE keys are registered on Cardano.
+pub struct BabeKeyProbe {
+	candidates: Arc<dyn PermissionedCandidatesDataSource>,
+	keystore: KeystorePtr,
+}
+
+impl BabeKeyProbe {
+	/// Constructor. `keystore` must be the plain node keystore, not any wrapper with Aura fallback
+	pub fn new(
+		candidates: Arc<dyn PermissionedCandidatesDataSource>,
+		keystore: KeystorePtr,
+	) -> Self {
+		Self { candidates, keystore }
+	}
+
+	/// The node's local BABE keys that are also registered as the `babe` key of a permissioned candidate on Cardano.
+	pub async fn matching_babe_keys(&self) -> Result<Vec<sr25519::Public>, ProbeError> {
+		let local_keys = self.keystore.sr25519_public_keys(BABE);
+		let candidates = self.candidates.permissioned_candidates().await?;
+		let babe_key_on_cardano = extract_babe_keys(&candidates);
+
+		log::debug!(
+			target: LOG_TARGET,
+			"{} local BABE key(s) in keystore, {} of {} permissioned candidate(s) registered a valid BABE key",
+			local_keys.len(),
+			babe_key_on_cardano.len(),
+			candidates.len(),
+		);
+
+		Ok(local_keys.into_iter().filter(|key| babe_key_on_cardano.contains(key)).collect())
+	}
+}
+
+fn extract_babe_keys(candidates: &[PermissionedCandidateData]) -> Vec<sr25519::Public> {
+	candidates
+		.iter()
+		.filter_map(|candidate| {
+			let bytes = candidate.keys.find(BABE)?;
+			match <[u8; 32]>::try_from(bytes.as_slice()) {
+				Ok(raw) => Some(sr25519::Public::from_raw(raw)),
+				Err(_) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"Permissioned candidate 0x{} has an invalid 'babe' key of {} bytes",
+						hex::encode(&candidate.sidechain_public_key.0),
+						bytes.len(),
+					);
+					None
+				},
+			}
+		})
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sidechain_domain::{CandidateKey, CandidateKeys, SidechainPublicKey};
+	use sp_core::crypto::key_types::{AURA, GRANDPA};
+	use sp_keystore::testing::MemoryKeystore;
+
+	/// Static [`PermissionedCandidatesDataSource`] mock.
+	struct MockCandidates(Result<Vec<PermissionedCandidateData>, String>);
+
+	#[async_trait]
+	impl PermissionedCandidatesDataSource for MockCandidates {
+		async fn permissioned_candidates(
+			&self,
+		) -> Result<Vec<PermissionedCandidateData>, ProbeError> {
+			self.0.clone().map_err(|e| e.into())
+		}
+	}
+
+	fn candidate(keys: Vec<CandidateKey>) -> PermissionedCandidateData {
+		PermissionedCandidateData {
+			sidechain_public_key: SidechainPublicKey(vec![1u8; 33]),
+			keys: CandidateKeys(keys),
+		}
+	}
+
+	fn babe_key(public: &sr25519::Public) -> CandidateKey {
+		CandidateKey::new(BABE, public.0.to_vec())
+	}
+
+	fn probe(
+		candidates: Result<Vec<PermissionedCandidateData>, String>,
+		keystore: MemoryKeystore,
+	) -> BabeKeyProbe {
+		BabeKeyProbe::new(Arc::new(MockCandidates(candidates)), Arc::new(keystore))
+	}
+
+	fn keystore_with(
+		key_type: sp_core::crypto::KeyTypeId,
+		seed: &str,
+	) -> (MemoryKeystore, sr25519::Public) {
+		let keystore = MemoryKeystore::new();
+		let public = keystore.sr25519_generate_new(key_type, Some(seed)).unwrap();
+		(keystore, public)
+	}
+
+	#[tokio::test]
+	async fn reports_local_babe_key_registered_on_cardano() {
+		let (keystore, local) = keystore_with(BABE, "//Alice");
+		let probe = probe(Ok(vec![candidate(vec![babe_key(&local)])]), keystore);
+
+		assert_eq!(probe.matching_babe_keys().await.unwrap(), vec![local]);
+	}
+
+	#[tokio::test]
+	async fn reports_nothing_when_keystore_has_no_babe_key() {
+		let (keystore, aura) = keystore_with(AURA, "//Alice");
+		// The candidate registered a BABE key equal to this node's AURA key: the
+		// keystore still has no BABE key, so the node is not ready.
+		let probe = probe(Ok(vec![candidate(vec![babe_key(&aura)])]), keystore);
+
+		assert!(probe.matching_babe_keys().await.unwrap().is_empty());
+	}
+
+	#[tokio::test]
+	async fn reports_nothing_when_candidate_registered_a_different_babe_key() {
+		let (keystore, _local) = keystore_with(BABE, "//Alice");
+		let other = sr25519::Public::from_raw([7u8; 32]);
+		let probe = probe(Ok(vec![candidate(vec![babe_key(&other)])]), keystore);
+
+		assert!(probe.matching_babe_keys().await.unwrap().is_empty());
+	}
+
+	#[tokio::test]
+	async fn reports_nothing_when_candidates_registered_no_babe_key() {
+		let (keystore, local) = keystore_with(BABE, "//Alice");
+		// A pre-migration registration: AURA and GRANDPA only.
+		let legacy = candidate(vec![
+			CandidateKey::new(AURA, local.0.to_vec()),
+			CandidateKey::new(GRANDPA, vec![2u8; 32]),
+		]);
+		let probe = probe(Ok(vec![legacy]), keystore);
+
+		assert!(probe.matching_babe_keys().await.unwrap().is_empty());
+	}
+
+	#[tokio::test]
+	async fn reports_nothing_when_no_candidate_list_is_set() {
+		let (keystore, _local) = keystore_with(BABE, "//Alice");
+		let probe = probe(Ok(vec![]), keystore);
+
+		assert!(probe.matching_babe_keys().await.unwrap().is_empty());
+	}
+
+	/// A malformed on-chain key must be skipped, not abort the whole probe: the
+	/// valid registration of another candidate still has to be found.
+	#[tokio::test]
+	async fn skips_candidates_with_malformed_babe_key() {
+		let (keystore, local) = keystore_with(BABE, "//Alice");
+		let malformed = candidate(vec![CandidateKey::new(BABE, vec![0xab; 16])]);
+		let probe = probe(Ok(vec![malformed, candidate(vec![babe_key(&local)])]), keystore);
+
+		assert_eq!(probe.matching_babe_keys().await.unwrap(), vec![local]);
+	}
+
+	#[tokio::test]
+	async fn finds_match_among_several_local_keys() {
+		let keystore = MemoryKeystore::new();
+		let _first = keystore.sr25519_generate_new(BABE, Some("//Alice")).unwrap();
+		let second = keystore.sr25519_generate_new(BABE, Some("//Bob")).unwrap();
+		let probe = probe(Ok(vec![candidate(vec![babe_key(&second)])]), keystore);
+
+		assert_eq!(probe.matching_babe_keys().await.unwrap(), vec![second]);
+	}
+
+	#[tokio::test]
+	async fn propagates_data_source_errors() {
+		let (keystore, _local) = keystore_with(BABE, "//Alice");
+		let probe = probe(Err("db-sync is down".into()), keystore);
+
+		assert!(probe.matching_babe_keys().await.is_err());
+	}
+}

--- a/node/src/babe_key_readiness/reporter.rs
+++ b/node/src/babe_key_readiness/reporter.rs
@@ -1,0 +1,91 @@
+// This file is part of midnight-node.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Periodically runs the [`BabeKeyProbe`] and publishes the result as a
+//! Prometheus gauge.
+
+use prometheus_endpoint::{Gauge, PrometheusError, Registry, U64, register};
+use std::time::Duration;
+
+use super::{LOG_TARGET, probe::BabeKeyProbe};
+
+/// How often the reporter probes in production.
+pub const DEFAULT_PROBE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Prometheus metric published by the reporter.
+#[derive(Clone)]
+pub struct BabeKeyMetrics {
+	ready: Gauge<U64>,
+}
+
+impl BabeKeyMetrics {
+	/// Registers the metric with the given Prometheus registry.
+	pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			ready: register(
+				Gauge::new(
+					"midnight_babe_key_registered",
+					"1 if the keystore holds a BABE key registered for a permissioned candidate on Cardano, 0 otherwise",
+				)?,
+				registry,
+			)?,
+		})
+	}
+
+	fn set(&self, matching: bool) {
+		self.ready.set(u64::from(matching));
+	}
+}
+
+/// Runs the probe every `interval` and publishes the result.
+pub async fn run(probe: BabeKeyProbe, metrics: BabeKeyMetrics, interval: Duration) {
+	loop {
+		match probe.matching_babe_keys().await {
+			Ok(keys) => {
+				let matching = !keys.is_empty();
+				metrics.set(matching);
+			},
+			Err(err) => log::warn!(
+				target: LOG_TARGET,
+				"Failed to check whether this node's BABE keys are registered on Cardano: {err}",
+			),
+		}
+
+		tokio::time::sleep(interval).await;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn metric_starts_at_zero_and_tracks_the_probe_result() {
+		let registry = Registry::new();
+		let metrics = BabeKeyMetrics::register(&registry).unwrap();
+		assert_eq!(metrics.ready.get(), 0);
+
+		metrics.set(true);
+		assert_eq!(metrics.ready.get(), 1);
+
+		metrics.set(false);
+		assert_eq!(metrics.ready.get(), 0);
+	}
+
+	#[test]
+	fn metric_can_only_be_registered_once_per_registry() {
+		let registry = Registry::new();
+		BabeKeyMetrics::register(&registry).unwrap();
+		assert!(BabeKeyMetrics::register(&registry).is_err());
+	}
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 
 pub mod armed_babe_proposer;
 mod aura_to_babe_migration_keystore;
+pub mod babe_key_readiness;
 pub mod backend;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -14,6 +14,11 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use crate::aura_to_babe_migration_keystore::AuraToBabeMigrationKeystore;
+use crate::babe_key_readiness::{
+	self,
+	probe::{BabeKeyProbe, ProbeCandidatesDataSource},
+	reporter::BabeKeyMetrics,
+};
 use crate::backend::{create_database_source, open_paritydb};
 use crate::cfg::midnight_cfg::StorageSeparation;
 use crate::main_chain_follower::create_cached_main_chain_follower_data_sources;
@@ -762,6 +767,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		let sc_slot_config = sidechain_slots::runtime_api_client::slot_config(&*client)
 			.map_err(sp_blockchain::Error::from)?;
 		let time_source = Arc::new(SystemTimeSource);
+		let babe_key_readiness_epoch_config = epoch_config.clone();
 		let inherent_config =
 			CreateInherentDataConfig::new(epoch_config, sc_slot_config.clone(), time_source)
 				.map_err(|e| {
@@ -811,6 +817,39 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 				AuraToBabeMigrationKeystore::new_arc(keystore_container.keystore()),
 			),
 		);
+
+		// Report whether this validator holds a BABE key registered on Cardano, so
+		// operators can fix their keystore before the switch to BABE consensus.
+		// Remove after mainnet switch to BABE.
+		match prometheus_registry.as_ref().map(BabeKeyMetrics::register) {
+			Some(Ok(metrics)) => {
+				let candidates = ProbeCandidatesDataSource::new(
+					client.clone(),
+					data_sources.authority_selection.clone(),
+					babe_key_readiness_epoch_config,
+					Arc::new(SystemTimeSource),
+				);
+				let probe = BabeKeyProbe::new(Arc::new(candidates), keystore_container.keystore());
+
+				task_manager.spawn_handle().spawn(
+					"babe-key-readiness",
+					None,
+					babe_key_readiness::reporter::run(
+						probe,
+						metrics,
+						babe_key_readiness::reporter::DEFAULT_PROBE_INTERVAL,
+					),
+				);
+			},
+			Some(Err(err)) => log::error!(
+				target: "prometheus",
+				"Failed to register BABE key readiness metric: {err}",
+			),
+			None => log::debug!(
+				target: "prometheus",
+				"No Prometheus registry available; not reporting BABE key readiness",
+			),
+		}
 	}
 
 	if enable_grandpa {


### PR DESCRIPTION
# Overview

Probe that reports `1` if there exists BABE key in the keystore that is a `babe` pub key of permissioned candidates. Otherwise it reports `0`

This data will be used to make decision when to flip to BABE.

The code added in this PR is meant to be removed after migration. It won't be used for registered (pemissionless candidates) because we don't have access to their prometheus data.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
