### PR TITLE
test(e2e): cfg-gate local-only tests so unfiltered --features qanet doesn't hang

### DIFF
--- a/changes/node/changed/e2e-cfg-gate-local-only-tests.md
+++ b/changes/node/changed/e2e-cfg-gate-local-only-tests.md
@@ -15,5 +15,5 @@ dev-wallet and deploy helpers in `lib.rs` become unused, so a scoped
 `allow(dead_code, unused_imports)` (active only when no local feature is set) keeps that build
 warning-clean without cfg-gating every helper.
 
-PR: <link>
+PR: https://github.com/midnightntwrk/midnight-node/pull/2010
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1842

--- a/changes/node/changed/e2e-cfg-gate-local-only-tests.md
+++ b/changes/node/changed/e2e-cfg-gate-local-only-tests.md
@@ -5,15 +5,17 @@
 The e2e crate defaults to `local-ci` and the qanet/devnet nightly job runs filtered to
 `cnight::observation::`, so this never affects CI. But an unfiltered
 `cargo test --no-default-features --features qanet` compiles and runs the local-env-only tests
-(`operational`, `contract_state`, `governance`, `c2m_bridge`, and the non-observation `cnight`
+(in `operational`, `contract_state`, `governance`, `c2m_bridge`, and the non-observation `cnight`
 test), which call `ensure_dev_wallet_funded()` / the local faucet stack and hang ~180s.
 
-cfg-gate those modules and the lone local `cnight` test behind
-`any(feature = "local", feature = "local-dev", feature = "local-ci")`, leaving only
-`cnight::observation::` ungated (the set meant to run under both local and qanet). Under qanet the
-dev-wallet and deploy helpers in `lib.rs` become unused, so a scoped
-`allow(dead_code, unused_imports)` (active only when no local feature is set) keeps that build
-warning-clean without cfg-gating every helper.
+cfg-gate the fully local-env-only modules (`contract_state`, `governance`, `c2m_bridge`) and the
+individual local-only tests in `cnight` and `operational` behind
+`any(feature = "local", feature = "local-dev", feature = "local-ci")`. `cnight` and `operational`
+stay compiled under qanet/devnet because they own qanet-relevant tests: `cnight::observation::`
+and `operational`'s `dust_balance_smoke` / `dust_balance_smoke_many` (the Postgres fetch-cache
+smoke tests documented in the README). Under qanet the dev-wallet and deploy helpers in `lib.rs`
+become unused, so a scoped `allow(dead_code, unused_imports)` (active only when no local feature
+is set) keeps that build warning-clean without cfg-gating every helper.
 
 PR: https://github.com/midnightntwrk/midnight-node/pull/2010
 Issue: https://github.com/midnightntwrk/midnight-node/issues/1842

--- a/changes/node/changed/e2e-cfg-gate-local-only-tests.md
+++ b/changes/node/changed/e2e-cfg-gate-local-only-tests.md
@@ -1,0 +1,19 @@
+#tests
+
+# Gate local-only e2e tests behind the local features
+
+The e2e crate defaults to `local-ci` and the qanet/devnet nightly job runs filtered to
+`cnight::observation::`, so this never affects CI. But an unfiltered
+`cargo test --no-default-features --features qanet` compiles and runs the local-env-only tests
+(`operational`, `contract_state`, `governance`, `c2m_bridge`, and the non-observation `cnight`
+test), which call `ensure_dev_wallet_funded()` / the local faucet stack and hang ~180s.
+
+cfg-gate those modules and the lone local `cnight` test behind
+`any(feature = "local", feature = "local-dev", feature = "local-ci")`, leaving only
+`cnight::observation::` ungated (the set meant to run under both local and qanet). Under qanet the
+dev-wallet and deploy helpers in `lib.rs` become unused, so a scoped
+`allow(dead_code, unused_imports)` (active only when no local feature is set) keeps that build
+warning-clean without cfg-gating every helper.
+
+PR: <link>
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1842

--- a/tests/e2e/tests/cnight.rs
+++ b/tests/e2e/tests/cnight.rs
@@ -9,6 +9,10 @@ use crate::global_faucet_manager;
 
 // -------- TESTS --------
 
+// Local-env-only: drives the local Cardano faucet + registration flow, so it is
+// gated to the local features. `cnight::observation` (the qanet/devnet set)
+// lives in the submodule above and stays ungated.
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 #[e2e_test]
 async fn alice_cannot_deregister_bob() {
     let settings = Settings::default();

--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -1,3 +1,16 @@
+// The qanet/devnet nightly job runs this suite filtered to
+// `cnight::observation::` (see nightly-run-cnight-e2e-*.yml), which is the only
+// set meant to run there. The local-env test modules below are cfg-gated to the
+// local features so an unfiltered `cargo test --no-default-features --features
+// qanet` doesn't run (and hang on) local-only tests. That gating leaves the
+// dev-wallet / deploy helpers in this file unused when no local feature is set,
+// so silence dead_code/unused_imports for exactly those builds rather than
+// cfg-gating every helper individually.
+#![cfg_attr(
+    not(any(feature = "local", feature = "local-dev", feature = "local-ci")),
+    allow(dead_code, unused_imports)
+)]
+
 use midnight_node_e2e::api::cardano::CardanoClient;
 use midnight_node_e2e::config::Settings;
 use midnight_node_e2e::faucet::FaucetManager;
@@ -719,8 +732,19 @@ pub(crate) fn fetch_concurrency() -> usize {
 }
 
 // -------- TEST MODULES --------
+//
+// Only `cnight::observation::` is meant to run under qanet/devnet (the nightly
+// job filters to it). Every other module here is local-env-only: they call
+// `ensure_dev_wallet_funded()` / the local faucet stack and would hang ~180s
+// under an unfiltered `--features qanet` run. Gate them to the local features
+// so the per-feature test sets stay coherent. `cnight` stays ungated because it
+// owns `cnight::observation`; its own local-only test is gated inside the module.
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod c2m_bridge;
 mod cnight;
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod contract_state;
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod governance;
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod operational;

--- a/tests/e2e/tests/lib.rs
+++ b/tests/e2e/tests/lib.rs
@@ -733,12 +733,14 @@ pub(crate) fn fetch_concurrency() -> usize {
 
 // -------- TEST MODULES --------
 //
-// Only `cnight::observation::` is meant to run under qanet/devnet (the nightly
-// job filters to it). Every other module here is local-env-only: they call
-// `ensure_dev_wallet_funded()` / the local faucet stack and would hang ~180s
-// under an unfiltered `--features qanet` run. Gate them to the local features
-// so the per-feature test sets stay coherent. `cnight` stays ungated because it
-// owns `cnight::observation`; its own local-only test is gated inside the module.
+// Meant to run under qanet/devnet: `cnight::observation::`, plus the
+// qanet/devnet-gated smoke tests that `operational` owns (`dust_balance_smoke`,
+// `dust_balance_smoke_many`, which check the Postgres fetch-cache path). The
+// fully local-env-only modules below call `ensure_dev_wallet_funded()` / the
+// local faucet stack and would hang ~180s under an unfiltered `--features qanet`
+// run, so gate them to the local features. `cnight` and `operational` stay
+// ungated because they own qanet-relevant tests; each gates its own local-only
+// tests inside the module.
 #[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod c2m_bridge;
 mod cnight;
@@ -746,5 +748,4 @@ mod cnight;
 mod contract_state;
 #[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod governance;
-#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 mod operational;

--- a/tests/e2e/tests/operational.rs
+++ b/tests/e2e/tests/operational.rs
@@ -2,6 +2,9 @@ use midnight_node_e2e::api::cardano::CardanoClient;
 use midnight_node_e2e::config::Settings;
 use midnight_node_e2e::e2e_test;
 
+// Local-env-only (funds via `ensure_dev_wallet_funded`); gated so an unfiltered
+// `--features qanet` run doesn't try to run it and hang.
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 /// PR367-TC-0003-03 E2E: Valid Transaction Succeeds
 ///
 /// A well-formed contract deploy, built dynamically against the live chain and
@@ -28,6 +31,9 @@ async fn valid_deploy_transaction_succeeds_via_rpc() {
     tracing::info!("✓ valid DEPLOY_TX accepted and included");
 }
 
+// Local-env-only (funds via `ensure_dev_wallet_funded`); gated so an unfiltered
+// `--features qanet` run doesn't try to run it and hang.
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 /// Regression guard: the toolkit must not hang on exit when sending with
 /// multiple `--dest-url` options (ported from the old
 /// scripts/tests/toolkit-multi-dest-e2e.sh, which assumed the unfunded
@@ -120,6 +126,8 @@ async fn toolkit_multi_dest_send_does_not_hang() {
     unreachable!("multi-dest send loop returns or panics");
 }
 
+// Local-env-only (drives the local faucet); gated to the local features.
+#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]
 /// One-shot cleanup task: consolidates fragmented UTXOs at the funded faucet
 /// address. Useful when the faucet has accumulated many small change UTXOs
 /// from prior runs. Opt-in via `cargo test --ignored consolidate_faucet`.


### PR DESCRIPTION
# Overview

Closes #1842.

The e2e crate's default feature is `local-ci`, and the qanet/devnet nightly job runs filtered to `cnight::observation::`, so this is not a CI problem. But an unfiltered `cargo test --no-default-features --features qanet` compiles and runs the local-env-only tests (`operational`, `contract_state`, `governance`, `c2m_bridge`, and the non-observation `cnight` test), which call `ensure_dev_wallet_funded()` / the local faucet stack and hang ~180s each.

This gates the local-only test modules and the single local `cnight` test behind `#[cfg(any(feature = "local", feature = "local-dev", feature = "local-ci"))]`, leaving only `cnight::observation::` ungated (the set meant to run under both local and qanet). The per-feature test sets are now coherent: under `--features qanet` the binary contains only the qanet-relevant tests.

Two notes on scope:
- `c2m_bridge` is gated as well. The ticket enumerated the four hanging modules; `c2m_bridge` is likewise local-env-only (it drives the local faucet via `global_faucet_manager`), so it would also run under an unfiltered qanet build. Flagging in case you'd rather keep it out of this change.
- Gating those modules leaves the dev-wallet and deploy helpers in `lib.rs` unused under qanet. Rather than cfg-gate ~20 helpers individually, a single scoped `#![cfg_attr(not(any(feature = "local", ...)), allow(dead_code, unused_imports))]` (active only when no local feature is set) keeps the qanet build warning-clean. Happy to switch to per-helper gating if you prefer that.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Verified with `cargo test -p midnight-node-e2e --no-default-features --features <FEAT> --test e2e_tests -- --list` (lists tests without running them):

- **`--features qanet`** → 12 tests, all under `cnight::observation::`. The local-only modules are no longer compiled in, so an unfiltered qanet run can't hang on them. (Before this change they were listed and would each block ~180s in `ensure_dev_wallet_funded`.)
- **`--features local-ci`** (default) → 31 tests, full set unchanged: `c2m_bridge` (4), `cnight` (14 = 13 `observation` + `alice_cannot_deregister_bob`), `contract_state` (3), `governance` (7), `operational` (3).

Both feature builds are warning-clean from this change. The only warnings emitted are pre-existing and untouched here: a `cranelift-wasm` dev-profile spec note, and an unused `self` import in `cnight/observation.rs`.

- [ ] Additional tests are provided (if possible) — N/A, this gates existing tests.

## 🔱 Fork Strategy

- [x] N/A

## Links

Closes #1842
