### PR TITLE
chore: stop duplicating binaries and res/ in a second image layer

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -197,9 +197,11 @@ node-image-minimal:
     USER root
 
     RUN mkdir -p /node
-    COPY +build-node-only/artifacts-$NATIVEARCH/midnight-node /
+    COPY --chown=appuser:appuser +build-node-only/artifacts-$NATIVEARCH/midnight-node /
 
-    RUN chown -R appuser:appuser /midnight-node /node ./bin ./res
+    # Only /node (created above as root) needs fixing: everything else is copied
+    # with --chown, so no `chown -R` rewrites it into a duplicate layer.
+    RUN chown appuser:appuser /node
     SAVE IMAGE localhost/node-minimal:latest
 
 # Grabs metadata.scale file from the latest node
@@ -1454,8 +1456,8 @@ node-image:
     RUN mkdir -p /artifacts-$NATIVEARCH
     RUN mkdir -p node
 
-    COPY +build/artifacts-$NATIVEARCH/midnight-node /
-    COPY +build/artifacts-$NATIVEARCH/aiken-deployer /
+    COPY --chown=appuser:appuser +build/artifacts-$NATIVEARCH/midnight-node /
+    COPY --chown=appuser:appuser +build/artifacts-$NATIVEARCH/aiken-deployer /
     COPY +build/artifacts-$NATIVEARCH/midnight-node-runtime/*.wasm /artifacts-$NATIVEARCH/
 
     # Extract version from Cargo.toml to preserve semver pre-release suffix (e.g., 0.19.0-rc.1)
@@ -1469,7 +1471,9 @@ node-image:
     ENV IMAGE_TAG_DEV="$(cat /version)-dev-$CONTENT_HASH_SHORT-$NATIVEARCH"
 
     RUN echo image tag=midnight-node:$IMAGE_TAG | tee /artifacts-$NATIVEARCH/node_image_tag
-    RUN chown -R appuser:appuser /midnight-node /aiken-deployer /node ./bin ./res
+    # Only /node needs fixing: the binaries are copied with --chown and the base
+    # image already owns ./bin and ./res, so no `chown -R` duplicates them.
+    RUN chown -R appuser:appuser /node
     SAVE IMAGE --push \
         $GHCR_REGISTRY/midnight-node:latest-$NATIVEARCH \
         $GHCR_REGISTRY/midnight-node:$IMAGE_TAG \
@@ -1546,20 +1550,20 @@ toolkit-image:
 
     # Add toolkit-js (only when INCLUDE_TOOLKIT_JS=true)
     IF [ "$INCLUDE_TOOLKIT_JS" = "true" ]
-        COPY +toolkit-js-prep/toolkit-js /toolkit-js
+        COPY --chown=appuser:appuser +toolkit-js-prep/toolkit-js /toolkit-js
         # compactc for run-compactc invocations from this image (e.g. genesis
         # compiling simple-merkle-tree.compact). Reuse the SAME compiler the CI
         # image selected per COMPACTC_VERSION (built or fetched) and that compiled
         # the contracts in +toolkit-js-prep — no rebuild, no risk of a divergent
         # compactc version between the CI and toolkit images.
-        COPY +toolkit-js-prep/compact-home /compact-home
+        COPY --chown=appuser:appuser +toolkit-js-prep/compact-home /compact-home
         ENV COMPACT_HOME=/compact-home
     ELSE
-        RUN mkdir -p /toolkit-js
+        RUN mkdir -p /toolkit-js && chown appuser:appuser /toolkit-js
     END
 
-    COPY +build/artifacts-$NATIVEARCH/midnight-node-toolkit /
-    RUN mkdir -p /.cache/midnight/zk-params /.cache/sync
+    COPY --chown=appuser:appuser +build/artifacts-$NATIVEARCH/midnight-node-toolkit /
+    RUN mkdir -p /.cache/midnight/zk-params /.cache/sync && chown -R appuser:appuser /.cache
 
     LET NODE_VERSION="$(cat node_version)"
     ENV GIT_CONTENT_HASH="$CONTENT_HASH"
@@ -1567,7 +1571,6 @@ toolkit-image:
     ENV GHCR_REGISTRY_PUBLIC=ghcr.io/midnightntwrk
     ENV IMAGE_TAG="${NODE_VERSION}-${CONTENT_HASH_SHORT}-${NATIVEARCH}"
     LABEL org.opencontainers.image.source=https://github.com/midnight-ntwrk/artifacts
-    RUN chown -R appuser:appuser /midnight-node-toolkit /toolkit-js ./bin /.cache /test-static
     SAVE IMAGE --push \
         $GHCR_REGISTRY/midnight-node-toolkit:latest-$NATIVEARCH \
         $GHCR_REGISTRY/midnight-node-toolkit:$IMAGE_TAG \

--- a/changes/node/changed/image-layer-dedup-copy-chown.md
+++ b/changes/node/changed/image-layer-dedup-copy-chown.md
@@ -16,4 +16,4 @@ Side effect: `chown -R … ./bin` never reached the file it was aimed at, since
 `/bin` is a usr-merge symlink and `chown -R` does not traverse it. `.envrc` is
 now owned by `appuser` like the rest.
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/2048

--- a/changes/node/changed/image-layer-dedup-copy-chown.md
+++ b/changes/node/changed/image-layer-dedup-copy-chown.md
@@ -1,0 +1,19 @@
+#node #toolkit #docker
+# Stop duplicating binaries and `res/` in a second image layer
+
+The node and toolkit images copied their files as root and then ran
+`chown -R appuser:appuser …` over the same paths. `chown` rewrites every file,
+so buildkit stored a second full copy of them in the `chown` layer. Measured on
+the node image with a stand-in 133M binary, that layer was 210MB: the binary
+plus the whole 74M `res/` tree, duplicated.
+
+The files are now copied with `COPY --chown=appuser:appuser` (the `appuser`
+account moved above the `COPY`s in both base Dockerfiles), and the remaining
+`chown` only covers directories created by `RUN mkdir`. Same for the toolkit
+image, where `/toolkit-js` was being duplicated as well.
+
+Side effect: `chown -R … ./bin` never reached the file it was aimed at, since
+`/bin` is a usr-merge symlink and `chown -R` does not traverse it. `.envrc` is
+now owned by `appuser` like the rest.
+
+PR:

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -23,11 +23,14 @@ RUN microdnf -y install \
     rm -f /tmp/bytehound.tgz && \
     microdnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
-COPY .envrc ./bin/.envrc
-COPY res/ ./res/
+# Create appuser before the COPYs so files land already owned by it: a later
+# `chown -R` rewrites every copied file into a duplicate image layer.
+RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -U -c "" appuser
+
+COPY --chown=appuser:appuser .envrc ./bin/.envrc
+COPY --chown=appuser:appuser res/ ./res/
 COPY node/bin/entrypoint.sh /entrypoint.sh
 
-RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -U -c "" appuser
 USER appuser
 
 EXPOSE 30333 9933 9944 9615

--- a/images/toolkit/Dockerfile
+++ b/images/toolkit/Dockerfile
@@ -13,8 +13,12 @@ RUN microdnf -y install \
   tree-1.8.0 && \
   microdnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
-COPY .envrc ./bin/.envrc
-COPY static/contracts/simple-merkle-tree /test-static/simple-merkle-tree
+# Create appuser before the COPYs so files land already owned by it: a later
+# `chown -R` rewrites every copied file into a duplicate image layer.
+RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -U -c "" appuser
+
+COPY --chown=appuser:appuser .envrc ./bin/.envrc
+COPY --chown=appuser:appuser static/contracts/simple-merkle-tree /test-static/simple-merkle-tree
 
 ENV TOOLKIT_JS_PATH="/toolkit-js"
 ENV MIDNIGHT_LEDGER_TEST_STATIC_DIR=/test-static
@@ -28,6 +32,5 @@ RUN cat /node/Cargo.toml | grep -m 1 version | sed 's/version *= *"\([^\"]*\)".*
   rm -rf /node
 COPY util/toolkit/bin/entrypoint.sh /entrypoint.sh
 
-RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -U -c "" appuser
 USER appuser
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
# Overview

Each binary currently appears **twice** in the shipped images, in two different layers.

The node and toolkit images `COPY` their files as root and then run
`chown -R appuser:appuser …` over the same paths. `chown` rewrites every file it
touches, so buildkit records them all as changed and stores a second full copy in
the `chown` layer.

Fix: copy with `COPY --chown=appuser:appuser` (the `appuser` account moves above the
`COPY`s in both base Dockerfiles so the name resolves), and leave `chown` covering
only the directories that `RUN mkdir` creates.

Two things worth noting beyond the binaries:

- It is not just the binaries. `chown -R … ./res` was duplicating the whole 74M
  `res/` tree in `+node-image` too, and `/toolkit-js` (node_modules) in `+toolkit-image`.
- `chown -R … ./bin` never reached the file it was aimed at: `/bin` is a usr-merge
  symlink and GNU `chown -R` does not traverse symlinks, so `/usr/bin/.envrc` stayed
  root-owned. It is `appuser`-owned now, via the base Dockerfile `COPY`.

`+srtool-build` / `+srtool-info` have the same `chown -R` pattern and are deliberately
left alone: they are build-only targets that are never pushed.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

A/B measured on the real `images/node/Dockerfile` base image with a 133M stand-in
binary in place of the built one, comparing the old and new tails:

```
before:  210MB  RUN chown -R appuser:appuser /midnight-node /node ./bin ./res
         133MB  COPY midnight-node-fake /midnight-node

after:      0B  RUN chown -R appuser:appuser /node
         133MB  COPY --chown=appuser:appuser midnight-node-fake /midnight-node
```

~210MB removed from the node image: the duplicated binary plus the duplicated
`res/` tree. Ownership in the resulting image is unchanged:

```
-rw-r--r--. 1 appuser appuser 133000000 /midnight-node
drwxr-xr-x. 1 appuser appuser           /node
drwxr-xr-x. 1 appuser appuser           /res
-rw-r--r--. 1 appuser appuser      5430 /usr/bin/.envrc   (was root-owned before)
```

The equivalent toolkit-image saving was not measured separately; it is the same
mechanism applied to `/midnight-node-toolkit` and `/toolkit-js`. CI building both
images is the check that the `--chown` copies and the trimmed `chown` still produce
working images.

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [x] Other: image build only. No node, runtime, or on-chain behaviour changes; the
      image contents are identical, only the layer they live in changes.

## Links

Follow-up to a review finding on #36 (out of scope there).