### PR TITLE
docs: add 2.1.0-beta.1 release notes

### DIFF
--- a/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md
+++ b/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md
@@ -1,0 +1,235 @@
+<!-- markdownlint-disable MD012 MD013 MD014 MD022 MD031 MD032 MD033 MD034 MD060 -->
+
+# Migration: hard-forking a 1.0.3 chain to 2.1.0-beta.1
+
+This guide covers upgrading a chain **already running the 1.0.3 runtime** to `2.1.0-beta.1`. That
+is the supported fork-from baseline; the 1.0.3 release itself is still pending. It is a ledger hard
+fork (ledger 8 → ledger 9) enacted by a governance `set_code`, not a rolling binary upgrade — the
+boundary block permanently changes how ledger state is encoded, and one on-chain migration runs
+across several blocks afterwards.
+
+`2.1.0-beta.1` is a **pre-release**. Run this on a test or pre-production network first; do not
+treat this guide as a mainnet runbook until the corresponding final release ships.
+
+CI currently exercises the fork boundary from `midnightntwrk/midnight-node:1.0.1`
+(`util/toolkit/tests/hardfork_e2e.rs`, default set in
+`util/toolkit/test-images.docker-compose.yml`, overridable with `FORK_FROM_NODE_IMAGE`). That path
+crosses the boundary under `system_version: 1` and so exercises the skew-block handling in §3.1,
+which does not arise from 1.0.3.
+
+## 1. Before the upgrade
+
+### 1.1 Every validator must be on the new binary first
+
+> **This is the one step that breaks the chain if skipped.**
+
+A runtime can only be instantiated by a node that exports every host function it imports, so a
+validator left on an older binary stops importing blocks at the `set_code` and is stuck there.
+Roll every validator onto 2.1.0 and confirm they are all importing and finalizing normally
+*before* the governance action is submitted. The binary upgrade on its own is a hot swap — the
+1.0.3 runtime keeps running until `set_code`.
+
+```shell
+docker pull midnightntwrk/midnight-node:2.1.0-beta.1
+docker pull midnightntwrk/midnight-node-toolkit:2.1.0-beta.1
+```
+
+### 1.2 Remove retired config keys
+
+Nothing to do here if you are coming from 1.0.3 — the key below never existed on the 1.0.x line.
+It applies only to an operator moving across from a 2.0.0 pre-release. The config loader ignores
+keys it does not recognise, so a stale key is a **silent no-op** rather than a startup error; clean
+it out so nobody later reads it as a live setting.
+
+| Key | Why it went | Replacement |
+| --- | --- | --- |
+| `cnight_observation_window_size` | The sliding-window observation cache was reverted ([#2030](https://github.com/midnightntwrk/midnight-node/pull/2030)). | None — the follower is back on the per-call db-sync path. |
+
+Also note `block_stability_margin` now defaults to **30** (was 10) across every preset
+([#1914](https://github.com/midnightntwrk/midnight-node/pull/1914)). The on-chain effective margin
+is the minimum across all producers, so this only takes effect when the whole validator set moves;
+if you pin it via `BLOCK_STABILITY_MARGIN`, coordinate the change with the rest of the set.
+
+### 1.3 Take a database snapshot
+
+The v8 → v9 state translation is one-way. Snapshot at least one validator's database at a
+pre-fork height; that snapshot is the only route back (§6).
+
+## 2. Enacting the upgrade
+
+The runtime is swapped by a governance `set_code`. Using the toolkit's `runtime-upgrade`
+command, which submits the proposal, collects collective approvals, and waits for finality past
+the applying block:
+
+```shell
+midnight-node-toolkit runtime-upgrade \
+  --wasm-file midnight_node_runtime.compact.compressed.wasm \
+  -c <collective-signer-1> -c <collective-signer-2> \
+  -t <technical-signer-1> -t <technical-signer-2> \
+  --rpc-url ws://<node>:9944 \
+  --signer-key <submitter-key>
+```
+
+Substitute your network's actual governance keys for the `-c` / `-t` / `--signer-key` values; the
+e2e test uses the dev accounts `//Dave`, `//Eve`, `//Alice`, `//Bob`.
+
+This pre-release publishes **no runtime WASM asset**
+([#2061](https://github.com/midnightntwrk/midnight-node/issues/2061)), so extract the blob from
+the node image:
+
+```shell
+cid=$(docker create midnightntwrk/midnight-node:2.1.0-beta.1)
+docker cp "$cid:/artifacts-amd64/midnight_node_runtime.compact.compressed.wasm" .
+docker rm -f "$cid"
+```
+
+Because there is no deterministic (srtool) build for this tag, the blob's hash is not independently
+reproducible. For a governance action that needs a verifiable artefact, wait for a release that
+publishes one.
+
+## 3. What happens at the boundary
+
+### 3.1 The `set_code` block is a skew block (only if upgrading from 1.0.2 or earlier)
+
+**Not applicable on the 1.0.3 baseline.** 1.0.3 ships `system_version: 3`, so `frame_system` stages
+the new code in `:pending_code` and applies it at the start of the *next* block; `:code` and the
+ledger `StateKey` it is read against stay in step across the boundary. Skip to §3.2 unless you are
+forking from 1.0.2 or earlier.
+
+On those earlier runtimes `system_version` is 1, so `frame_system` overwrites `:code` *inside* the
+`set_code` block, while pallet-midnight's v8 → v9 state translation only runs in the *next*
+block's `initialize_block`. That one block's committed state therefore pairs ledger-9 `:code` with
+a ledger-8 `StateKey`, permanently.
+
+[#1985](https://github.com/midnightntwrk/midnight-node/pull/1985) makes this readable: the
+read-only ledger-9 host accessors inspect the tagged-serialization header of the `state_key` they
+are handed and, when it is a ledger-8 arena root, serve the read from the ledger-8 bridge instead.
+Because the dispatch lives in the host function, it covers the `midnight_*` JSON-RPCs,
+`MidnightRuntimeApi` via `state_call`, and subxt-based tooling such as `chain-indexer` alike.
+
+Behaviour to expect: at the `set_code` block `midnight_ledgerStateRoot` returns a **v8-tagged**
+root — correct, because that block's state *is* v8. Consumers walking the fork see the tag flip at
+the migration block rather than a hole.
+
+Transaction paths (`get_transaction_cost`, `validate_transaction`, `apply_transaction`) are
+deliberately *not* covered; they resolve on their own one block later.
+
+### 3.2 Dust state is wiped
+
+The v8 → v9 translation drops the ledger's dust state and installs the empty one genesis starts
+from. Nothing you do avoids this; the replay below puts back the part that can be reconstructed.
+
+### 3.3 cNIGHT dust generation is replayed (multi-block)
+
+`pallet-cnight-observation` migrates storage version 1 → 2
+([#2012](https://github.com/midnightntwrk/midnight-node/pull/2012)):
+
+- `on_runtime_upgrade` saves the pre-fork ledger-8 arena root in `PreForkStateKey` — the only
+  place the wiped entries' night value and dust owner survive.
+- A multi-block migration pages through `UtxoOwners`, reads each nonce's pre-wipe value and owner
+  through the `dust_generation_values` host function, and re-applies them in batches of 25 as
+  `CNightGeneratesDustUpdate` system transactions.
+- **Cardano observations are ignored while it runs.** `NextCardanoPosition` does not advance, so
+  the observer re-delivers the same UTXOs once the gate lifts — no cNIGHT events are lost, they
+  are only delayed.
+
+Throughput is roughly **175 nonces/block**. Measured live generating sets on 2026-08-06:
+
+| Network | Entries | Approx. blocks of gated observation |
+| --- | --- | --- |
+| mainnet | 4870 | ~28 |
+| preview | 1524 | ~9 |
+| preprod | 85 | 1 |
+
+Restored entries are field-for-field identical to the wiped ones except the accrual clock: the
+original creation time lived on the destroyed dust UTXO, so the replay stamps
+`fork block time - dust.time_to_cap()` (~1 week). Every cNIGHT holder lands back **at their cap**
+rather than at zero refilling over a week.
+
+## 4. After the upgrade: what holders must do
+
+### 4.1 Native NIGHT holders must re-register their dust address
+
+Only **cNIGHT's slice** of the generating set is restored. Native NIGHT registers generation
+entries too, and nothing in this repo records which of those the wipe took. A wallet holding
+native NIGHT crosses the fork still holding its NIGHT but generating no DUST — and with no DUST it
+cannot pay a fee.
+
+Re-register to restart generation. The registration funds itself from the retroactive DUST the
+now-generationless NIGHT accrued, which is the path a real holder takes after the wipe:
+
+```shell
+midnight-node-toolkit generate-txs \
+  --fetch-cache inmemory \
+  register-dust-address \
+  --wallet-seed <seed> \
+  -s ws://<node>:9944 -d ws://<node>:9944
+```
+
+The re-registered NIGHT starts generating from *that* block's time, so allow a couple of blocks
+before attempting a fee-paying transaction.
+
+> `DustReapplyCompleted` must **not** be read as "all dust generation restored". It means cNIGHT's
+> slice is restored.
+
+### 4.2 Clients, SDKs, and indexers must re-fetch metadata
+
+`transaction_version` bumps 3 → 4, so extrinsics encoded against the 1.0.x runtime will not decode.
+Every client must re-fetch metadata from a block at or after the `set_code`, and any pre-signed or
+queued extrinsic must be rebuilt.
+
+Two traps here:
+
+- **subxt resolves metadata at the finalized head.** While finality is still behind the fork, a
+  subxt client that connects fresh picks up the *old* metadata and then fails against the new
+  runtime ([#1969](https://github.com/midnightntwrk/midnight-node/issues/1969)). Wait for finality
+  to pass the `set_code` block, or pin metadata explicitly.
+- **`CNightObservation` error indices are renumbered** (see
+  [runtime-diff.md](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md#cnightobservation-index-13)). Tooling that maps
+  `DispatchError::Module { index, error }` through a hardcoded table rather than through metadata
+  fetched at the block being decoded will mis-report errors.
+
+## 5. Watching it happen
+
+New events on `CNightObservation`: `DustReapplyStarted`, `DustReapplyBatchFailed { nonces }`,
+`DustReapplyCompleted { applied, skipped }`, `DustReapplySkipped { applied, skipped }`,
+`ObservationsSkippedForMigration` (once per block while the gate holds).
+
+**Only `DustReapplyStarted` and `ObservationsSkippedForMigration` show up in Polkadot.js Apps.**
+The rest are deposited from a multi-block-migration step, whose phase is `ApplyExtrinsic(n)` for
+an `n` no extrinsic in the block has, and the explorer drops events it cannot attach to an
+extrinsic. Read them via `System::Events`, subxt's `events()`, or the node log — each is logged
+under its own name.
+
+Verification checklist, in order:
+
+| Check | How | Expected |
+| --- | --- | --- |
+| New code applied | `state_getRuntimeVersion` at successive heights; the first height reporting the new spec is the `set_code` block | `specVersion` 2001000 |
+| Fork boundary readable | `midnight_zswapStateRoot` / `midnight_ledgerStateRoot` at `applied - 1`, `applied`, `applied + 1` | non-empty root at all three |
+| Runtime API readable at the boundary | `state_call` `MidnightRuntimeApi_get_ledger_state_root` and `..._get_ledger_parameters` at `applied` | SCALE result starts `0x00` (`Ok`) |
+| Replay wound up | `CNightObservation` storage version | `2` |
+| Pre-fork key cleared | `CNightObservation::PreForkStateKey` | unset |
+| Replay actually restored something | `DustReapplyCompleted` event fields | `applied > 0` |
+| Observation resumed | `ObservationsSkippedForMigration` stops appearing; `NextCardanoPosition` advances | — |
+
+A `DustReapplySkipped`, or a `DustReapplyCompleted` with `applied == 0` on a chain that had cNIGHT
+`UtxoOwners`, means the replay fell short — capture the events and the node log before doing
+anything else.
+
+## 6. Rollback
+
+There is no supported downgrade path. The v8 → v9 state translation rewrites ledger state in
+place, and `transaction_version` has moved, so a `set_code` back to the 1.0.x runtime does not
+undo the fork.
+
+Recovering means restoring the pre-fork database snapshot from §1.3 across the validator set and
+abandoning every block produced after the boundary. Treat that as an incident, coordinate it with
+the node team, and do not attempt it piecemeal on individual validators.
+
+## Related
+
+- [2.1.0-beta.1 release notes](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/release-notes-2.1.0-beta.1.md)
+- [Runtime diff 1.0.3 → 2.1.0-beta.1](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md)
+- [Ledger 9 and the C2M bridge](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/eng-ledger9-c2m-bridge.md)
+- [Storage separation config](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/config-storage-separation.md)

--- a/docs/release-notes/2.1.0-beta.1/release-notes-2.1.0-beta.1.md
+++ b/docs/release-notes/2.1.0-beta.1/release-notes-2.1.0-beta.1.md
@@ -1,0 +1,285 @@
+<!-- markdownlint-disable MD012 MD013 MD014 MD022 MD031 MD032 MD033 MD034 MD060 -->
+
+# Midnight Node 2.1.0-beta.1
+
+## Metadata
+
+- **Type of release**: major (relative to the previous final release, `node-1.0.1`; relative to the 2.0.0 pre-release line it is a minor)
+- **Date**: 2026-08-21
+- **Ships in bundle**: TBD — standalone major pre-release (not bundled)
+- **Git tag**: [node-2.1.0-beta.1](https://github.com/midnightntwrk/midnight-node/tree/node-2.1.0-beta.1)
+- **Environment**: All public networks at time of release. For the full compatibility matrix, see the [release notes overview](https://docs.midnight.network/relnotes/overview).
+- **Upgrade scope**: binary + runtime
+- **Reset required**: No
+- **Governance action required**: Yes
+- **Sister-line note**: The 1.0.x maintenance line runs in parallel. **1.0.3 is the supported fork-from baseline for 2.1.0**; that release is still pending. Changes shared with it — the runtime-gated tblock correction and the `system_version` bump to 3 — are part of that baseline and are not restated here.
+
+## High-level summary
+
+`2.1.0-beta.1` is the feature-complete beta of the 2.1.0 line: **its feature set is identical to 2.0.0** ([node-2.0.0-rc.4](https://github.com/midnightntwrk/midnight-node/releases/tag/node-2.0.0-rc.4), [2.0.0-alpha.1 release notes](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/release-notes-2.0.0-alpha.1.md)), which never shipped a final release. On top of that it adds two months of maintenance and security patches from `main`, and the ability to **hard-fork from a running 1.0.x chain** rather than only from a fresh genesis.
+
+This is a **binary + runtime** upgrade: `spec_version` moves 1_000_003 → 2_001_000 and `transaction_version` moves 3 → 4. Enacting it is a ledger 8 → 9 hard fork with an on-chain multi-block migration — follow the [1.0.3 → 2.1.0 hardfork migration guide](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md).
+
+The supported fork-from baseline is the **pending 1.0.3 release**. `system_version` is already 3 there, so the block applying this runtime is not a skew block and the boundary needs no special handling on that account.
+
+The change entries below are the delta against the 2.0.0 pre-release line and against 1.0.3, so anything shared with the 1.0.x maintenance line is not restated. For everything the 2.x line introduced relative to 1.0.x, see the 2.0.0 notes linked above and the [runtime diff](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md).
+
+## Audience
+
+- [x] Operators who run validators or RPC nodes on a chain that will hard-fork from 1.0.x
+- [x] Operators who maintain node config presets or `.env` overrides
+- [x] Developers who build, sign, or decode extrinsics against the node (SDK, indexer, toolkit users)
+- [x] Developers who hold or generate DUST from native NIGHT
+- [x] Administrators who hold governance keys and enact the runtime upgrade
+
+## Dependencies
+
+- **midnight-ledger 9.1.0.0-rc.4** — pinned as a single workspace tag; the node binary provides it via host calls. Ledger 7 is fully removed, so this node cannot decode or replay chain history predating the ledger 7 → 8 hardfork.
+- **The chain must already be running the 1.0.3 runtime** (pending release) — that is the fork-from baseline this release is built and tested against. Forking from 1.0.2 or earlier is not the documented path; see [Other Changes](#other-changes).
+
+**Downstream impact (cascading effects)**: the node's consumers must be rebuilt or re-pointed before they can follow a 2.1.0 chain.
+
+- `transaction_version` 3 → 4: every client, SDK, and indexer must re-fetch metadata at or after the `set_code` block, and any pre-signed or queued extrinsic must be rebuilt.
+- `CNightObservation` error indices are renumbered; tooling that maps `DispatchError::Module { index, error }` through a hardcoded table will mis-report errors.
+- subxt-based consumers (`chain-indexer`) resolve metadata at the *finalized* head, so a client connecting while finality is still behind the fork picks up the old metadata and then fails against the new runtime — see the migration guide.
+- The toolkit's block fetcher now recognises the 1.0.3 runtime (`001_000_003`); older toolkits reject those blocks with `UnsupportedBlockVersion`.
+
+For all other interop questions, see the bundle dependency matrix.
+
+## Deployment information
+
+- **Upgrade scope**: binary + runtime — a coordinated on-chain runtime upgrade, not a new image alone.
+- **Reset required**: No. One caveat: a toolkit block cache holding genuinely ledger-7 blocks is now rejected with a "delete the cache and re-fetch" error.
+- **Governance action required**: Yes — the runtime is swapped by a governance `set_code`, held by the collective/technical signers. Enabling the C2M bridge additionally requires a governance action to set its `MainChainScripts` and data checkpoint; without it the bridge's inherent data provider stays `Inert`.
+- **Downtime / coordination**: Coordinated. Roll every validator onto the new binary first (hot swap, old runtime keeps running), confirm the whole set is importing and finalizing, then enact `set_code`. Cardano observation is gated for the duration of the dust replay — roughly 28 blocks at mainnet scale, 9 at preview scale, 1 at preprod scale.
+
+## Artifacts
+
+- **Docker**: `midnightntwrk/midnight-node:2.1.0-beta.1` and `midnightntwrk/midnight-node-toolkit:2.1.0-beta.1`
+- **Binaries**: `midnight-node-2.1.0-beta.1-linux-{amd64,arm64}.tar.gz`, `midnight-node-toolkit-2.1.0-beta.1-linux-{amd64,arm64}.tar.gz`, with `SHA256SUMS-amd64` / `SHA256SUMS-arm64`
+- **Git tree hash**: `d87a3992d0d087418f78b456da31e0bb289c2e35`
+- **Runtime WASM**: **not published** — the deterministic (srtool) build is blocked by [#2061](https://github.com/midnightntwrk/midnight-node/issues/2061). Extract the blob from the node image at `/artifacts-{amd64,arm64}/midnight_node_runtime.compact.compressed.wasm`; see [Known issues](#known-issues).
+
+```shell
+docker pull midnightntwrk/midnight-node:2.1.0-beta.1
+docker pull midnightntwrk/midnight-node-toolkit:2.1.0-beta.1
+```
+
+## What changed
+
+- cNIGHT dust generation is rebuilt after the ledger 8 → 9 hardfork wipes it, as a multi-block migration that gates Cardano observation while it runs.
+- Ledger moves to a single 9.1.0.0-rc.4 workspace pin, and ledger 7 support is removed entirely.
+- The cNIGHT observation sliding-window cache is reverted while its security hardening is finished.
+- `block_stability_margin` defaults to 30 across every preset.
+- Toolkit: contract e2e coverage (tic-tac-toe, welcome), resumable long ledger replays, and a wallet-cache GC retention floor.
+
+| Change | Upgrade Type | PR |
+| --- | --- | --- |
+| Re-apply cNIGHT dust generation after the ledger 8 → 9 hardfork | Runtime upgrade | [#2012](https://github.com/midnightntwrk/midnight-node/pull/2012) |
+| Bump ledger to 9.1.0.0-rc.4 | Node upgrade + Toolkit | [#2022](https://github.com/midnightntwrk/midnight-node/pull/2022) |
+| Remove ledger 7 support | Node upgrade + Toolkit | [#1999](https://github.com/midnightntwrk/midnight-node/pull/1999) |
+| Revert the cNIGHT observation sliding-window cache | Node upgrade | [#2030](https://github.com/midnightntwrk/midnight-node/pull/2030) |
+| Default `block_stability_margin` to 30 across all config presets | Node upgrade | [#1914](https://github.com/midnightntwrk/midnight-node/pull/1914) |
+| Toolkit: opt-in wallet-cache checkpoints during long ledger replays, plus snapshot GC retention floor | Toolkit | [#1968](https://github.com/midnightntwrk/midnight-node/pull/1968) |
+| Add tic-tac-toe and welcome contract e2e tests | Toolkit | [#1940](https://github.com/midnightntwrk/midnight-node/pull/1940) |
+| Rename `StandardTrasactionInfo` to `StandardTransactionInfo` | Toolkit | [#2016](https://github.com/midnightntwrk/midnight-node/pull/2016) |
+| Runtime metadata diff (subwasm) — [runtime-diff.md](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md) | Runtime upgrade | [#2061](https://github.com/midnightntwrk/midnight-node/issues/2061) |
+
+## New features
+
+### Re-apply cNIGHT dust generation after the ledger 8 → 9 hardfork
+
+**Description**: The v8 → v9 state translation drops the ledger's dust state and installs the empty one genesis starts from, which would silently stop DUST generation for every cNIGHT holder. `pallet-cnight-observation` now rebuilds its own slice of the generating set as a multi-block migration (storage version 1 → 2). `on_runtime_upgrade` saves the pre-fork ledger-8 arena root — the only place the wiped entries' night value and dust owner survive — and the migration pages through `UtxoOwners`, reads each nonce's pre-wipe value and owner through a new `dust_generation_values` host function, and re-applies them in batches of 25 as `CNightGeneratesDustUpdate` system transactions. Cardano observations are ignored while it runs, so `NextCardanoPosition` does not advance and the observer re-delivers the same UTXOs afterwards.
+
+Each batch is priced before it is applied and applied only if it fits the remaining migration weight budget; a batch too large for a whole block's budget is given up on, emitting `DustReapplySkipped` and lifting the gate. Restoration runs at ~175 nonces/block; measured live sets on 2026-08-06 were 4870 (mainnet), 1524 (preview) and 85 (preprod) — about 28, 9 and 1 block of gated observation. Restored entries are field-for-field identical to the wiped ones except the accrual clock: the replay stamps `fork block time - dust.time_to_cap()` (~1 week), so every holder lands back at their cap rather than at zero.
+
+Developers interact with it through five new `CNightObservation` events (`DustReapplyStarted`, `DustReapplyBatchFailed`, `DustReapplyCompleted`, `DustReapplySkipped`, `ObservationsSkippedForMigration`) and four new storage items. Note that only `DustReapplyStarted` and `ObservationsSkippedForMigration` appear in Polkadot.js Apps — the rest are deposited from a migration step whose phase no extrinsic owns, so read them via `System::Events`, subxt, or the node log.
+
+**Only cNIGHT's slice is restored.** Native NIGHT registers generation entries too, and nothing in this repo records which of those the wipe took, so `DustReapplyCompleted` must not be read as "all dust generation restored". Native NIGHT holders must re-register their dust address — see the [migration guide](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md#41-native-night-holders-must-re-register-their-dust-address). *Runtime upgrade.*
+
+**PR**: [#2012](https://github.com/midnightntwrk/midnight-node/pull/2012)
+
+### Resumable long ledger replays in the toolkit
+
+**Description**: `generate-txs` — and every command sharing the `Source` args — accepts `--replay-checkpoint-interval <BLOCKS>` (env `MN_REPLAY_CHECKPOINT_INTERVAL`, default `0` = off). When set, the cached context builder saves a ledger snapshot plus per-wallet cache entries every N replayed blocks, so an interrupted full replay — tens of minutes on a long chain — resumes from the last checkpoint instead of starting over from genesis. Wallets cached beyond a checkpoint boundary are withheld from that replay chunk, and intermediate snapshots are collected by the existing reference-based GC as wallet heights advance past them. *Toolkit.*
+
+**PR**: [#1968](https://github.com/midnightntwrk/midnight-node/pull/1968)
+
+### Contract e2e coverage: tic-tac-toe and welcome
+
+**Description**: Two contracts ported from `midnight-contracts` and driven end to end through the compile → prove → submit → on-chain-verify pipeline. Tic-tac-toe plays a full two-player game: deploy with X and O identities derived from private witness keys, alternate `make_move` (each move proves knowledge of the current player's secret while fees are paid by `FUNDING_SEED`), then assert the outcome via the `verify_game_state` and `verify_winner` circuits — exercising Map- and Counter-backed on-chain state and private-witness turn authorization independent of the public fee-paying wallet. Welcome drives deploy → `add_participant` → `check_in`, and adds a config template plus a `generate_intent_deploy_with_args` helper for constructor arguments.
+
+This also fixes `prerequisites_ready` to match the compact variant directory by major.minor.patch rather than major.minor. Without that fix **all** contract e2e tests silently skipped; when `compact-contract-tests` is enabled, missing prerequisites now fail the test instead of reporting a successful skip. *Toolkit.*
+
+**PR**: [#1940](https://github.com/midnightntwrk/midnight-node/pull/1940)
+
+## New features requiring configuration updates
+
+### Retired node config keys
+
+Only relevant if you are coming from a **2.0.0 pre-release**. Neither key ever existed on the 1.0.x line, so operators on 1.0.3 have nothing to do here.
+
+**Required updates**:
+
+- Remove `cnight_observation_window_size` and `cnight_follower_genesis_from_storage` — the sliding-window observation cache they configured has been reverted ([#2030](https://github.com/midnightntwrk/midnight-node/pull/2030)).
+
+**Impact**: The config loader ignores unrecognised keys, so a stale entry is a silent no-op rather than a startup error. Clean them out so they are not later mistaken for live settings.
+
+### `block_stability_margin` default raised to 30
+
+**Required updates**:
+
+- No action if you rely on the preset default: `res/cfg/default.toml` (inherited by dev/devnet/govnet/guardnet/local/perfnet/preview/qanet/stagenet) and the `preprod` and `mainnet` presets now all specify 30, up from 10.
+- If you pin the value via `BLOCK_STABILITY_MARGIN`, decide deliberately and coordinate with the rest of the validator set.
+
+**Impact**: `block_stability_margin` adds to `cardano_security_parameter` when selecting the latest stable Cardano block a producer references (`tip − (k + margin)`). The on-chain effective margin is the minimum across all producers, so a uniform value is required for it to take effect network-wide; the mainnet value should only change via a deliberate, coordinated rollout ([#1914](https://github.com/midnightntwrk/midnight-node/pull/1914)).
+
+## Improvements
+
+### Ledger 9.1.0.0-rc.4
+
+**Description**: Moves the midnight-ledger patch set from the per-crate 9.1.0.0-rc.3 tags to the single 9.1.0.0-rc.4 workspace tag, so every L9 crate is pinned to one commit instead of a mix of per-crate tags straddling several commits. Upstream's fix is dust registration accounting: a registration's initial DUST is now valued at block time rather than the transaction's declared `ctime`, and dust-generation uniqueness is keyed on the initial nonce alone rather than the generating set. `GenerationInfoAlreadyPresent` is renamed to `InitialNonceAlreadyPresent` upstream; the node-side `InvalidError` / `SystemTransactionError` variant names and their error codes (198 / 207) are unchanged, since it is the same condition and they are a stable runtime surface. Runtime metadata is not regenerated — no pallet storage item, extrinsic signature or runtime API changed. See [Breaking changes](#breaking-changes) for the regenerated proof fixtures. *Node upgrade + Toolkit.*
+
+**PR**: [#2022](https://github.com/midnightntwrk/midnight-node/pull/2022)
+
+### Toolkit wallet-cache: GC retention floor and cache observability
+
+**Description**: The file-backend ledger-snapshot GC now always retains the newest two snapshots even when no cached wallet references their height. Previously a save whose per-wallet writes were skipped by `write_wallet_if_newer` left its just-written ledger snapshot unreferenced, and the next GC deleted exactly the snapshot the following warm start needed. `set_wallet_states` now reports skipped writes instead of counting them as saved, and the transaction builder logs a warning when uncached wallet seeds force the replay back to genesis — previously that fallback was silent, so a single stray seed caused a full-chain replay with no indication why. *Toolkit.*
+
+**PR**: [#1968](https://github.com/midnightntwrk/midnight-node/pull/1968)
+
+### `StandardTransactionInfo` spelling fixed
+
+**Description**: Fixes the typo in `StandardTrasactionInfo` in `ledger/helpers` and all of its uses in the toolkit transaction builders. No behaviour change; a deprecated alias under the old spelling keeps existing callers building — see [Deprecations](#deprecations). *Toolkit.*
+
+**PR**: [#2016](https://github.com/midnightntwrk/midnight-node/pull/2016)
+
+## Deprecations
+
+- **Deprecated item**: `StandardTrasactionInfo` (type alias in `ledger/helpers`)
+- **Starts**: 2.1.0-beta.1
+- **Full removal**: TBD — the next major release
+- **Replacement**: `StandardTransactionInfo`
+- **Migration steps**: Rename the type at each use site. The alias is a plain `#[deprecated]` re-export, so a compile with warnings enabled lists every occurrence; there is no behavioural or wire-format difference.
+
+## Breaking changes
+
+> **Warning**: this release is a runtime upgrade. `transaction_version` moves 3 → 4 and `spec_version` 1_000_003 → 2_001_000. Signed extrinsics encoded against a 1.0.x runtime will not decode. Review the [runtime metadata diff](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md) before enacting the upgrade.
+
+### `transaction_version` bump
+
+**What changed**: `transaction_version` 3 → 4 and `spec_version` 1_000_003 → 2_001_000 (`system_version` stays at 3, the value 1.0.3 already ships). One pallet is added (`C2MBridge`, index 33) and four change their error/event/storage surface; `CNightObservation` renumbers its error variants and renames storage `Mappings` → `Mapping`.
+
+**What breaks**:
+
+- Any extrinsic signed or encoded against the 1.0.x runtime — pre-signed, queued, or built from cached metadata — fails to decode after the `set_code`.
+- A fresh subxt client resolves metadata at the *finalized* head, so while finality is still behind the fork it picks up the old metadata and then fails against the new runtime ([#1969](https://github.com/midnightntwrk/midnight-node/issues/1969)).
+- Tooling that maps `DispatchError::Module { index, error }` through a hardcoded table rather than through metadata fetched at the block being decoded mis-reports `CNightObservation` errors: `MaxRegistrationsExceeded` is gone and every remaining variant shifted down one index.
+- `Bridge`'s `Transfer` event and three `FederatedAuthority` errors (`MotionTooEarlyToClose`, `MotionAlreadyExists`, `MotionExpired`) are removed. `MidnightSystem`'s catch-all `LedgerApiError` is replaced by thirteen granular variants.
+
+**Required actions**:
+
+- Re-fetch metadata from a block at or after the `set_code`, or pin metadata explicitly; wait for finality to pass the boundary before relying on a fresh subxt client.
+- Rebuild any pre-signed or queued extrinsic.
+- Resolve error names from metadata at the decoded block, not from a compiled-in table.
+
+**Code example**:
+
+```rust
+// Before: a client built once at startup, whose metadata is whatever the
+// finalized head reported then.
+let api = OnlineClient::<Cfg>::from_insecure_url(url).await?;
+
+// After: for reads that straddle the fork, resolve the runtime version from
+// the block itself rather than trusting the client's cached metadata.
+let rpc = RpcClient::from_insecure_url(url).await?;
+let version: serde_json::Value =
+    rpc.request("state_getRuntimeVersion", rpc_params![block_hash]).await?;
+// ... then build a client whose metadata matches `version["specVersion"]`.
+```
+
+### Ledger 7 support removed
+
+**What changed**: Mainnet has always run ledger 8 onwards, so ledger 7 — a pre-mainnet protocol generation — is dead code. The `ledger_7` host bridge, storage, validation, error and system-tx modules are removed from the `ledger` and `ledger/helpers` crates, and all ledger-7 builders/commands from the toolkit. `ForkAwareLedgerContext::dispatch` now takes two closures instead of three, and `LedgerVersion` no longer has a `Ledger7` variant.
+
+**What breaks**: This is a full purge, not a version-support drop. The node can no longer decode or replay chain history that predates the ledger 7 → 8 hardfork. Mainnet is unaffected (it launched post-hardfork), but devnet/testnet archives from before that hardfork are no longer replayable by the toolkit. A cached block that really is ledger 7 is now rejected with an explicit "delete the cache and re-fetch" error rather than silently replaying as ledger 8.
+
+**Required actions**:
+
+- Discard any toolkit block cache (redb or PostgreSQL) that may hold pre-hardfork blocks; existing caches whose contents are ledger 8 or 9 keep decoding, since `LedgerVersion` now carries explicit wire discriminants (`Ledger8 = 1`, `Ledger9 = 2`) with hand-written serde impls so dropping `Ledger7` does not renumber the postcard encoding.
+- Keep a 1.0.x toolkit around if you need to replay a pre-hardfork archive.
+
+**PR**: [#1999](https://github.com/midnightntwrk/midnight-node/pull/1999)
+
+### Dust spend proofs built against ledger 9.1.0.0-rc.3 no longer verify
+
+**What changed**: rc.4's dust spend circuit changed, so the `spend.zkir` / `spend.verifier` artefacts are new.
+
+**What breaks**: Every committed `.mn` fixture carrying a dust spend fails `well_formed` with `InvalidDustSpendProof` under rc.4. In-repo fixtures were rebuilt via `earthly -P +rebuild-genesis-state-undeployed`: undeployed genesis, the derived test transactions, and the toolkit's counter/mint contract fixtures. The undeployed contract address is unchanged, and the deployed networks' genesis and chainspecs are unchanged.
+
+**Required actions**: Regenerate any locally held dust-spend proof or `.mn` fixture built against rc.3. Nothing on a deployed chain is affected.
+
+**PR**: [#2022](https://github.com/midnightntwrk/midnight-node/pull/2022)
+
+### Native NIGHT holders lose DUST generation across the fork
+
+**What changed**: The v8 → v9 translation wipes the ledger's dust state, and the replay restores only cNIGHT's slice of the generating set.
+
+**What breaks**: A wallet holding native NIGHT crosses the fork still holding its NIGHT but generating no DUST — and with no DUST it cannot pay a fee.
+
+**Required actions**: Re-register the dust address. The registration funds itself from the retroactive DUST the now-generationless NIGHT accrued, and generation restarts from that block's time, so allow a couple of blocks before attempting a fee-paying transaction.
+
+**Code example**:
+
+```shell
+midnight-node-toolkit generate-txs \
+  --fetch-cache inmemory \
+  register-dust-address \
+  --wallet-seed <seed> \
+  -s ws://<node>:9944 -d ws://<node>:9944
+```
+
+## Known issues
+
+### No runtime WASM asset on this release
+
+**Description**: The deterministic (srtool) runtime build fails, so this release publishes no `*.wasm` asset. The srtool image is pinned to Rust 1.93.0 while the repo builds and tests on Rust 1.95.0, and no published srtool image for 1.95.0 exists — it may have to be built in-house. A deterministic WASM is a requirement for a final release, so this blocks 2.1.0 final.
+
+Workaround: extract the blob from the node image at `/artifacts-{amd64,arm64}/midnight_node_runtime.compact.compressed.wasm`. Its hash is not independently reproducible, so for a governance action that needs a verifiable artefact, wait for a release that publishes one.
+
+**Issue**: [#2061](https://github.com/midnightntwrk/midnight-node/issues/2061)
+
+**Workaround (if any)**: See above — extract from the docker image for testing; do not treat the extracted blob as a reproducible artefact.
+
+### Sync from genesis is slower again
+
+**Description**: Reverting the cNIGHT observation sliding-window cache while its security hardening is finished puts the follower back on the per-call db-sync path, so sync from genesis is slower again. In practice this reopens the sync-performance issue the cache was written to close. Two levers bundled into the same original PR are deliberately kept, since neither touches the cNIGHT query path: the autovacuum tuning on the db-sync hot tables, and the default `storage_cache_size` of 100000.
+
+**Issue**: [#1158](https://github.com/midnightntwrk/midnight-node/issues/1158)
+
+**Workaround (if any)**: None. Restore from a database snapshot rather than syncing from genesis where that option exists.
+
+## Links and references
+
+- **PRs**: [#2012](https://github.com/midnightntwrk/midnight-node/pull/2012), [#1985](https://github.com/midnightntwrk/midnight-node/pull/1985), [#2054](https://github.com/midnightntwrk/midnight-node/pull/2054), [#2022](https://github.com/midnightntwrk/midnight-node/pull/2022), [#1999](https://github.com/midnightntwrk/midnight-node/pull/1999), [#2030](https://github.com/midnightntwrk/midnight-node/pull/2030), [#1914](https://github.com/midnightntwrk/midnight-node/pull/1914), [#1968](https://github.com/midnightntwrk/midnight-node/pull/1968), [#1940](https://github.com/midnightntwrk/midnight-node/pull/1940), [#2016](https://github.com/midnightntwrk/midnight-node/pull/2016)
+- **Engineering docs**: [Runtime diff 1.0.3 → 2.1.0-beta.1](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/runtime-diff.md), [Ledger 9 and the C2M bridge](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/eng-ledger9-c2m-bridge.md), [Storage separation config](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/config-storage-separation.md), [2.0.0-alpha.1 release notes](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.0.0-alpha.1/release-notes-2.0.0-alpha.1.md)
+- **Migration guides**: [Hard-forking a 1.0.x chain to 2.1.0-beta.1](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md)
+- **SDK docs**: [Clients, SDKs, and indexers must re-fetch metadata](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md#42-clients-sdks-and-indexers-must-re-fetch-metadata)
+- **Known issues board**: [open bugs](https://github.com/midnightntwrk/midnight-node/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- **GitHub release**: [node-2.1.0-beta.1](https://github.com/midnightntwrk/midnight-node/releases/tag/node-2.1.0-beta.1)
+- **Prior 2.x line**: [node-2.0.0-rc.4](https://github.com/midnightntwrk/midnight-node/releases/tag/node-2.0.0-rc.4)
+
+## Fixed defect list
+
+| Defect number | Description |
+| --- | --- |
+| [#1970](https://github.com/midnightntwrk/midnight-node/issues/1970) | Interrupted long ledger replays restarted from genesis, and wallet-cache GC deleted the snapshot the next warm start needed |
+| [shieldedtech/shielded-security-engineering#548](https://github.com/shieldedtech/shielded-security-engineering/issues/548), [#549](https://github.com/shieldedtech/shielded-security-engineering/issues/549), [#550](https://github.com/shieldedtech/shielded-security-engineering/issues/550) | DUST generation would silently stop for every cNIGHT holder after the ledger 8 → 9 hardfork (internal tracker) |
+| [shieldedtech/shielded-sre#424](https://github.com/shieldedtech/shielded-sre/issues/424) | `block_stability_margin` default was too low for a conservative Cardano-reference lag (internal tracker) |
+
+Reopened in practice by [#2030](https://github.com/midnightntwrk/midnight-node/pull/2030): [#1158](https://github.com/midnightntwrk/midnight-node/issues/1158) — see [Known issues](#known-issues).
+
+## Other Changes
+
+- Use the upstream ledger v8 → v9 state translation crate ([#2054](https://github.com/midnightntwrk/midnight-node/pull/2054)) — internal hardfork plumbing. The in-repo copy of the translation table is replaced by a git dependency on the ledger team's own crate, so ledger-side fixes land without a manual re-port and the node stays aligned with the indexer. No behaviour change; the table was never a published surface. Closes [#2049](https://github.com/midnightntwrk/midnight-node/issues/2049).
+- Serve ledger state reads at the ledger-hardfork `set_code` block ([#1985](https://github.com/midnightntwrk/midnight-node/pull/1985)) — the ledger-9 read-only host accessors detect a ledger-8 arena root from the `state_key`'s tagged-serialization header and serve the read from the ledger-8 bridge. This only matters for a chain that crosses the fork under `system_version: 1`, i.e. one forking from 1.0.2 or earlier; on the 1.0.3 baseline the applying block is not a skew block and the dispatch never triggers. Fixes [#1959](https://github.com/midnightntwrk/midnight-node/issues/1959).

--- a/docs/release-notes/2.1.0-beta.1/runtime-diff.md
+++ b/docs/release-notes/2.1.0-beta.1/runtime-diff.md
@@ -1,0 +1,278 @@
+<!-- markdownlint-disable MD012 MD013 MD014 MD022 MD031 MD032 MD033 MD034 MD060 -->
+
+# Runtime Diff: 1.0.3 → 2.1.0-beta.1
+
+`1.0.3` is the supported fork-from baseline for 2.1.0. That release is still **pending**, so no
+1.0.3 runtime WASM exists to feed `subwasm` directly, and this pre-release publishes no WASM asset
+of its own either — see [#2061](https://github.com/midnightntwrk/midnight-node/issues/2061).
+
+**How the prior side was obtained.** Relative to `node-1.0.1`, the `release/node-1.0.3` branch
+changes exactly two things inside `runtime/`: `spec_version` (`001_000_000` → `001_000_003`) and
+`system_version` (`1` → `3`). The only other file it touches under `runtime/` or `pallets/` is
+`pallets/midnight/src/tests.rs` (plus one dev-dependency), which does not reach the runtime blob:
+
+```shell
+git diff --stat node-1.0.1 origin/release/node-1.0.3 -- runtime/ pallets/
+```
+
+So **1.0.3's pallet metadata surface is byte-for-byte 1.0.1's**, and every pallet, storage, call,
+event, error and runtime-API change below — everything except the `System::Version` constant — holds
+unchanged for 1.0.3 → 2.1.0-beta.1. The pallet-surface diff is therefore taken between the published
+`1.0.1` blob and `2.1.0-beta.1` (both extracted from their node images at `/artifacts-amd64/`,
+`subwasm` v0.21.3), while the version fields in the table below are read from
+`release/node-1.0.3`'s source.
+
+## Metadata
+
+| Field | 1.0.3 (`release/node-1.0.3`) | 2.1.0-beta.1 |
+| --- | --- | --- |
+| `spec_name` | `midnight` | `midnight` |
+| `spec_version` | 1_000_003 | **2_001_000** |
+| `impl_version` | 0 | 0 |
+| `transaction_version` | 3 | **4** |
+| `authoring_version` | 1 | 1 |
+| `system_version` | 3 | 3 |
+| Metadata version | V14 | V14 |
+| Blake2-256 | not published (release pending) | `0x61ee82de20ecbebfa682cc7b8f7e7cec0e00cdeb6d2879a8ce6f7302b1947f71` |
+| Compressed size | not published (release pending) | 565,196 bytes (81.92%) |
+| `system.setCode` hash | not published (release pending) | `0xd2224138194fa98b36d153ea7807c4c3d3d8c66f3a0c377c8ca9493b36938729` |
+| `authorizeUpgrade` hash | not published (release pending) | `0x92604f4efabd79e682db114d9f99c3ab5a1eb5e2b2bcbc39cfaf6367ba383ba7` |
+
+For reference, the 1.0.1 blob the pallet diff was taken against has Blake2-256
+`0x11504f7312a72b7d4b4ec26dc5c31788d4d704e3f4a9f026fd77b5823ef9e027`, is 543,996 bytes compressed
+(81.41%), and reports core version `midnight-1000000 (midnight-0.tx3.au1)`. 2.1.0-beta.1 reports
+`midnight-2001000 (midnight-0.tx4.au1)`.
+
+## Summary
+
+`spec_version` bumps 1_000_003 → 2_001_000 and **`transaction_version` bumps 3 → 4**. A
+`transaction_version` bump means signed extrinsics encoded against the 1.0.x runtime will not decode
+under 2.1.0: every client, SDK, and indexer must re-fetch metadata at or after the `set_code` block,
+and any pre-signed or queued extrinsic must be rebuilt.
+
+**`system_version` does not change — 1.0.3 already ships 3.** From `system_version: 2` onward
+`frame_system` stages new code in `:pending_code` and applies it at the start of the *next* block,
+rather than overwriting `:code` inside the `set_code` block itself. That means the block applying
+this runtime is not a skew block: `:code` and the ledger `StateKey` it is read against stay in step
+across the boundary, so the pathology in
+[#1959](https://github.com/midnightntwrk/midnight-node/issues/1959) cannot arise when forking from
+1.0.3.
+
+One pallet is added (`C2MBridge`, index 33), none removed. Four existing pallets change their
+error/event/storage surface, and `CNightObservation` renumbers its error variants.
+
+`subwasm`'s reduced differ reports `Compatible: true` / `Require transaction_version bump: false`.
+That verdict is about call indices and call signatures, which indeed did not change
+incompatibly; it does not account for the `transaction_version` bump that was made deliberately,
+nor for storage or error-index changes. Treat the bump above as authoritative.
+
+## Pallet changes
+
+**Added:**
+
+| Pallet | Index | Notes |
+| --- | --- | --- |
+| `C2MBridge` | 33 | Cardano-to-Midnight bridge pallet. Ships inert: without `MainChainScripts` configured its inherent data provider reports the `Inert` variant, so a governance action is required to enable it. |
+
+**Removed** — none.
+
+**Modified:**
+
+### `System` (index 0)
+
+- Event `CodeUpdated` gained an argument: `hash: T::Hash`.
+- Constant `Version` changed (the SCALE-encoded `RuntimeVersion` — `spec_version`,
+  `transaction_version`, `system_version` and the runtime API list, per the header table).
+
+### `Midnight` (index 5)
+
+- Errors added: `ContractNotPresent` (13), `BeneficiaryNotFound` (14).
+
+### `MidnightSystem` (index 6)
+
+- Errors added: `Deserialization` (2), `Serialization` (3), `Transaction` (4), `LedgerCacheError`
+  (5), `NoLedgerState` (6), `LedgerStateScaleDecodingError` (7), `ContractCallCostError` (8),
+  `BlockLimitExceededError` (9), `FeeCalculationError` (10), `HostApiError` (11),
+  `GetTransactionContextError` (12), `ContractNotPresent` (13), `BeneficiaryNotFound` (14).
+- Error removed: `LedgerApiError` — the single catch-all is replaced by the granular variants
+  above ([#1449](https://github.com/midnightntwrk/midnight-node/pull/1449)).
+
+### `CNightObservation` (index 13)
+
+- Calls added: `set_cnight_identifier(policy_id, asset_name)` (3),
+  `set_auth_token_asset_name(asset_name)` (4) — both root-only
+  ([#1602](https://github.com/midnightntwrk/midnight-node/pull/1602)).
+- Events added: `DustReapplyStarted` (5), `DustReapplyBatchFailed { nonces }` (6),
+  `DustReapplyCompleted { applied, skipped }` (7), `DustReapplySkipped { applied, skipped }` (8),
+  `ObservationsSkippedForMigration` (9) — the ledger 8→9 dust replay
+  ([#2012](https://github.com/midnightntwrk/midnight-node/pull/2012)).
+- Storage added: `DustReapplyCtime` (Optional), `DustReapplyProgress` (Default),
+  `PreForkStateKey` (Optional), `Mapping` (Optional).
+- Storage removed: `Mappings` — renamed to `Mapping`.
+- **Errors renumbered.** `MaxRegistrationsExceeded` is gone and every remaining variant shifted
+  down one index, then twelve new variants were appended:
+
+  | Index | 1.0.1 | 2.1.0-beta.1 |
+  | --- | --- | --- |
+  | 1 | `MaxRegistrationsExceeded` | `NonAsciiAssetName` |
+  | 2 | `LedgerApiError` | `InherentAlreadyExecuted` |
+  | 3 | `InherentAlreadyExecuted` | `CardanoPositionRegression` |
+  | 4 | `CardanoPositionRegression` | `TooManyUtxos` |
+  | 5 | `TooManyUtxos` | `Deserialization` |
+  | 6–17 | — | `Serialization`, `Transaction`, `LedgerCacheError`, `NoLedgerState`, `LedgerStateScaleDecodingError`, `ContractCallCostError`, `BlockLimitExceededError`, `FeeCalculationError`, `HostApiError`, `GetTransactionContextError`, `ContractNotPresent`, `BeneficiaryNotFound` |
+
+  Tooling that maps `DispatchError::Module { index, error }` to a name from a hardcoded table,
+  rather than from metadata fetched at the block being decoded, will mis-report these.
+
+### `Bridge` (index 32)
+
+- Event removed: `Transfer`.
+
+### `FederatedAuthority` (index 44)
+
+- Errors removed: `MotionTooEarlyToClose`, `MotionAlreadyExists`, `MotionExpired`
+  ([#938](https://github.com/midnightntwrk/midnight-node/pull/938) reworked motion lifecycle
+  handling).
+
+## Runtime APIs
+
+V14 metadata does not carry runtime API definitions, so `subwasm` cannot diff them. Taken from
+`runtime/src/lib.rs` at each tag instead:
+
+**Added:**
+
+- `pallet_c2m_bridge::C2MBridgeApi<Block>`
+- `midnight_primitives_session_info::SessionInfoApi<Block>` — exposes the substrate session index
+  ([#1534](https://github.com/midnightntwrk/midnight-node/pull/1534))
+
+**Removed** — none.
+
+**Modified** — none. `MidnightRuntimeApi` is still `#[api_version(5)]` with an unchanged method
+set. (The `get_transaction_cost` "version 2" referenced by the dust-replay change file is the
+*host function* version, not the runtime API version.)
+
+## Raw subwasm diff
+
+Taken between the published 1.0.1 and 2.1.0-beta.1 blobs, per the note at the top of this
+document. The `Version` constant's byte-level diff is elided — it is the SCALE encoding of the
+`RuntimeVersion` struct, and on this side of the comparison it carries 1.0.1's `spec_version` and
+`system_version` rather than 1.0.3's; use the header table for the real version delta. Everything
+else is verbatim, and holds identically for 1.0.3 → 2.1.0-beta.1.
+
+```text
+!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
+[≠] pallet 0: System -> 2 change(s)
+  - events changes:
+    [≠]  2: CodeUpdated ( )  )
+        [Signature(SignatureChange { args: [Added(0, ArgDesc { name: "hash", ty: "T::Hash" })] })]
+
+  - constants changes:
+    [≠] Version: [ 32, 109, 105, 100, 110, 105, 103, 104, 116, 32, 109, 105, 100, 110, 105, 103, 104, 116, 1, 0, 0, 0, 64, 66, 15, 0, 0, 0, 0, 0, 96, 251, ... ]
+        [Value([...184 U8Change(..), 24 Added(..) — SCALE bytes of the RuntimeVersion constant; see the header table above...])]
+
+[≠] pallet 5: Midnight -> 2 change(s)
+  - errors changes:
+    [+] ErrorDesc { index: 13, name: "ContractNotPresent" }
+    [+] ErrorDesc { index: 14, name: "BeneficiaryNotFound" }
+
+[≠] pallet 6: MidnightSystem -> 14 change(s)
+  - errors changes:
+    [+] ErrorDesc { index: 2, name: "Deserialization" }
+    [+] ErrorDesc { index: 3, name: "Serialization" }
+    [+] ErrorDesc { index: 4, name: "Transaction" }
+    [+] ErrorDesc { index: 5, name: "LedgerCacheError" }
+    [+] ErrorDesc { index: 6, name: "NoLedgerState" }
+    [+] ErrorDesc { index: 7, name: "LedgerStateScaleDecodingError" }
+    [+] ErrorDesc { index: 8, name: "ContractCallCostError" }
+    [+] ErrorDesc { index: 9, name: "BlockLimitExceededError" }
+    [+] ErrorDesc { index: 10, name: "FeeCalculationError" }
+    [+] ErrorDesc { index: 11, name: "HostApiError" }
+    [+] ErrorDesc { index: 12, name: "GetTransactionContextError" }
+    [+] ErrorDesc { index: 13, name: "ContractNotPresent" }
+    [+] ErrorDesc { index: 14, name: "BeneficiaryNotFound" }
+    [-] "LedgerApiError"
+
+[≠] pallet 13: CNightObservation -> 29 change(s)
+  - calls changes:
+    [+] CallDesc { index: 3, name: "set_cnight_identifier", signature: SignatureDesc { args: [ArgDesc { name: "policy_id", ty: "[u8; CNIGHT_POLICY_ID_LENGTH as usize]" }, ArgDesc { name: "asset_name", ty: "BoundedVec<u8, ConstU32<CARDANO_ASSET_NAME_MAX_LENGTH>>" }] } }
+    [+] CallDesc { index: 4, name: "set_auth_token_asset_name", signature: SignatureDesc { args: [ArgDesc { name: "asset_name", ty: "BoundedVec<u8, ConstU32<CARDANO_ASSET_NAME_MAX_LENGTH>>" }] } }
+
+  - events changes:
+    [+] EventDesc { index: 5, name: "DustReapplyStarted", signature: SignatureDesc { args: [] } }
+    [+] EventDesc { index: 6, name: "DustReapplyBatchFailed", signature: SignatureDesc { args: [ArgDesc { name: "nonces", ty: "Vec<T::Hash>" }] } }
+    [+] EventDesc { index: 7, name: "DustReapplyCompleted", signature: SignatureDesc { args: [ArgDesc { name: "applied", ty: "u32" }, ArgDesc { name: "skipped", ty: "u32" }] } }
+    [+] EventDesc { index: 8, name: "DustReapplySkipped", signature: SignatureDesc { args: [ArgDesc { name: "applied", ty: "u32" }, ArgDesc { name: "skipped", ty: "u32" }] } }
+    [+] EventDesc { index: 9, name: "ObservationsSkippedForMigration", signature: SignatureDesc { args: [] } }
+
+  - errors changes:
+    [≠]  1: MaxRegistrationsExceeded
+        [Name(StringChange("MaxRegistrationsExceeded", "NonAsciiAssetName"))]
+    [≠]  2: LedgerApiError  
+        [Name(StringChange("LedgerApiError", "InherentAlreadyExecuted"))]
+    [≠]  3: InherentAlreadyExecuted
+        [Name(StringChange("InherentAlreadyExecuted", "CardanoPositionRegression"))]
+    [≠]  4: CardanoPositionRegression
+        [Name(StringChange("CardanoPositionRegression", "TooManyUtxos"))]
+    [≠]  5: TooManyUtxos    
+        [Name(StringChange("TooManyUtxos", "Deserialization"))]
+    [+] ErrorDesc { index: 6, name: "Serialization" }
+    [+] ErrorDesc { index: 7, name: "Transaction" }
+    [+] ErrorDesc { index: 8, name: "LedgerCacheError" }
+    [+] ErrorDesc { index: 9, name: "NoLedgerState" }
+    [+] ErrorDesc { index: 10, name: "LedgerStateScaleDecodingError" }
+    [+] ErrorDesc { index: 11, name: "ContractCallCostError" }
+    [+] ErrorDesc { index: 12, name: "BlockLimitExceededError" }
+    [+] ErrorDesc { index: 13, name: "FeeCalculationError" }
+    [+] ErrorDesc { index: 14, name: "HostApiError" }
+    [+] ErrorDesc { index: 15, name: "GetTransactionContextError" }
+    [+] ErrorDesc { index: 16, name: "ContractNotPresent" }
+    [+] ErrorDesc { index: 17, name: "BeneficiaryNotFound" }
+
+  - storages changes:
+    [+] StorageDesc { name: "DustReapplyCtime", modifier: "Optional", default_value: [0] }
+    [+] StorageDesc { name: "DustReapplyProgress", modifier: "Default", default_value: [0, 0, 0, 0, 0, 0, 0, 0] }
+    [+] StorageDesc { name: "Mapping", modifier: "Optional", default_value: [0] }
+    [+] StorageDesc { name: "PreForkStateKey", modifier: "Optional", default_value: [0] }
+    [-] "Mappings"
+
+[≠] pallet 32: Bridge -> 1 change(s)
+  - events changes:
+    [-] "Transfer"
+
+[+] id: 33 - new pallet: C2MBridge
+[≠] pallet 44: FederatedAuthority -> 3 change(s)
+  - errors changes:
+    [-] "MotionTooEarlyToClose"
+    [-] "MotionAlreadyExists"
+    [-] "MotionExpired"
+
+SUMMARY:
+- Compatible.......................: true
+- Require transaction_version bump.: false
+
+!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
+```
+
+## Reproducing
+
+```shell
+# Confirm 1.0.3 changes nothing in the runtime blob beyond the two version constants.
+git diff node-1.0.1 origin/release/node-1.0.3 -- runtime/ pallets/
+
+# Extract the two published blobs and diff them.
+for t in 1.0.1 2.1.0-beta.1; do
+  cid=$(docker create midnightntwrk/midnight-node:$t)
+  docker cp "$cid:/artifacts-amd64/midnight_node_runtime.compact.compressed.wasm" "runtime-$t.wasm"
+  docker rm -f "$cid"
+done
+subwasm info runtime-1.0.1.wasm
+subwasm info runtime-2.1.0-beta.1.wasm
+subwasm diff runtime-1.0.1.wasm runtime-2.1.0-beta.1.wasm
+subwasm diff --json runtime-1.0.1.wasm runtime-2.1.0-beta.1.wasm
+```
+
+Once 1.0.3 is released, re-run the diff directly against its blob to confirm the `Version` constant
+is the only delta from the run above.
+
+See also the [2.1.0-beta.1 release notes](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/release-notes-2.1.0-beta.1.md) and the
+[1.0.3 → 2.1.0 hardfork migration guide](https://github.com/midnightntwrk/midnight-node/blob/main/docs/release-notes/2.1.0-beta.1/migration-hardfork-1.0.x.md).


### PR DESCRIPTION
# Overview

Adds the formatted release notes for [`node-2.1.0-beta.1`](https://github.com/midnightntwrk/midnight-node/releases/tag/node-2.1.0-beta.1) plus the two supporting docs they reference, following the layout already established by `docs/release-notes/2.0.0-alpha.1/`.

The notes are also the body of the GitHub release, so the docs need to live on `main` for the cross-doc links in that body to resolve — hence absolute `blob/main/...` URLs rather than relative paths.

| File | What it is |
| --- | --- |
| `release-notes-2.1.0-beta.1.md` | v5-structured release notes |
| `runtime-diff.md` | `subwasm` metadata diff, 1.0.3 → 2.1.0-beta.1 |
| `migration-hardfork-1.0.x.md` | operator runbook for the ledger 8 → 9 hard fork from a 1.0.3 chain |

Two things worth a reviewer's eye:

- **Baseline.** 2.0.0 never shipped a final release, so the change entries are the delta against the 2.0.0 pre-release line *and* against 1.0.3 — the supported fork-from baseline. Anything already carried by the 1.0.x maintenance line (the runtime-gated tblock correction #2002, the `system_version` bump to 3 #1900) is deliberately not restated, and #1985 is filed under `Other Changes` because on the 1.0.3 baseline the applying block is not a skew block.
- **How the runtime diff was produced.** 1.0.3 is still pending, so there is no 1.0.3 WASM to feed `subwasm`, and this pre-release publishes no WASM asset either (#2061). `git diff node-1.0.1 origin/release/node-1.0.3 -- runtime/ pallets/` changes only `spec_version` and `system_version` inside `runtime/`, so 1.0.3's pallet metadata surface is 1.0.1's; the pallet diff is taken between the published 1.0.1 and 2.1.0-beta.1 blobs and the version fields are read from the 1.0.3 branch source. The doc states this method inline, with the command to re-verify.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: docs-only, no product surface affected
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

Docs only — no code paths touched.

- `npx markdownlint-cli docs/release-notes/2.1.0-beta.1/*.md` — clean (same disable list as the 2.0.0-alpha.1 notes).
- Every intra-doc anchor and cross-doc link checked programmatically; all resolve.
- Runtime diff regenerated with `subwasm` v0.21.3 against the runtime blobs extracted from the published `midnightntwrk/midnight-node:1.0.1` and `:2.1.0-beta.1` images.

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [x] N/A

## Links

- Release: <https://github.com/midnightntwrk/midnight-node/releases/tag/node-2.1.0-beta.1>
- Blocks a 2.1.0 final release: #2061 (no deterministic runtime WASM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)