### PR TITLE
fix: toolkit update-ledger-parameters erroneous param re-use

### DIFF
--- a/changes/toolkit/changed/fix-update-ledger-parameters-block-limits.md
+++ b/changes/toolkit/changed/fix-update-ledger-parameters-block-limits.md
@@ -19,4 +19,4 @@ Would result in all the block limit params being set to 2000000000000:
             },
 ```
 
-PR:
+PR: https://github.com/midnightntwrk/midnight-node/pull/2073

--- a/changes/toolkit/changed/fix-update-ledger-parameters-block-limits.md
+++ b/changes/toolkit/changed/fix-update-ledger-parameters-block-limits.md
@@ -1,0 +1,22 @@
+#toolkit
+# Fix `update-ledger-parameters` command re-using the same param across multiple limits
+
+The toolkit was re-using the `read_time` block limit across all the block limit params - this meant updating the toolkit like this:
+
+```shell
+midnight-node-toolkit update-ledger-parameters --block-limit-read-time 2000000000000
+```
+
+Would result in all the block limit params being set to 2000000000000:
+
+```
+            block_limits: SyntheticCost {
+                read_time: 2.000s,
+                compute_time: 2.000s,
+                block_usage: 2000000000000,
+                bytes_written: 2000000000000,
+                bytes_churned: 2000000000000,
+            },
+```
+
+PR:

--- a/util/toolkit/src/commands/update_ledger_parameters.rs
+++ b/util/toolkit/src/commands/update_ledger_parameters.rs
@@ -189,17 +189,17 @@ pub async fn execute(args: UpdateLedgerParametersArgs) -> Result<(), LedgerParam
 					.map(|t| CostDuration::from_picoseconds(t))
 					.unwrap_or(base.limits.block_limits.read_time),
 				compute_time: params
-					.block_limit_read_time
+					.block_limit_compute_time
 					.map(|t| CostDuration::from_picoseconds(t))
 					.unwrap_or(base.limits.block_limits.compute_time),
 				block_usage: params
-					.block_limit_read_time
+					.block_limit_block_usage
 					.unwrap_or(base.limits.block_limits.block_usage),
 				bytes_written: params
-					.block_limit_read_time
+					.block_limit_bytes_written
 					.unwrap_or(base.limits.block_limits.bytes_written),
 				bytes_churned: params
-					.block_limit_read_time
+					.block_limit_bytes_churned
 					.unwrap_or(base.limits.block_limits.bytes_churned),
 			},
 			..base.limits


### PR DESCRIPTION
# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

The toolkit was re-using the `read_time` block limit across all the block limit params - this meant updating the toolkit like this:

```shell
midnight-node-toolkit update-ledger-parameters --block-limit-read-time 2000000000000
```

Would result in all the block limit params being set to 2000000000000:

```
            block_limits: SyntheticCost {
                read_time: 2.000s,
                compute_time: 2.000s,
                block_usage: 2000000000000,
                bytes_written: 2000000000000,
                bytes_churned: 2000000000000,
            },
```

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [ ] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
