### PR TITLE
fix: abort committee rotation on session key registration failure

### DIFF
--- a/changes/runtime/changed/abort-committee-on-session-key-registration-failure.md
+++ b/changes/runtime/changed/abort-committee-on-session-key-registration-failure.md
@@ -1,0 +1,21 @@
+#runtime #partner-chains
+# Abort committee rotation when session key registration fails
+
+`pallet_session_validator_management` no longer treats `SessionInterface::set_keys`
+as best-effort. `set_keys` is a black box: any error from `pallet_session` aborts
+the hand-off. `new_session` returns `None` so `pallet_session` keeps the previous
+authority set. A reduced committee is never installed.
+
+The failed committee is consumed and the queued epoch is advanced so session
+rotation does not retry every block. The previously queued committee stays as
+both the current and queued set, matching the authorities `pallet_session`
+retains. `set_keys` writes run in a storage layer and are rolled back on
+failure, so a retained validator cannot keep rotated keys while committee
+storage still records the previous ones. Genesis panics if the initial
+committee cannot be registered in full.
+
+This keeps `CurrentCommittee`/`QueuedCommittee` aligned with the live session
+validator set, so AURA author-index and BEEFY stake matching stay defined.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2078
+Issue: https://github.com/midnightntwrk/midnight-node/issues/1895

--- a/changes/runtime/changed/abort-committee-on-session-key-registration-failure.md
+++ b/changes/runtime/changed/abort-committee-on-session-key-registration-failure.md
@@ -9,10 +9,11 @@ authority set. A reduced committee is never installed.
 The failed committee is consumed and the queued epoch is advanced so session
 rotation does not retry every block. The previously queued committee stays as
 both the current and queued set, matching the authorities `pallet_session`
-retains. `set_keys` writes run in a storage layer and are rolled back on
-failure, so a retained validator cannot keep rotated keys while committee
-storage still records the previous ones. Genesis panics if the initial
-committee cannot be registered in full.
+retains. Account provisioning and `set_keys` writes run in one storage layer
+and are rolled back together on failure, so a retained validator cannot keep
+rotated keys while committee storage still records the previous ones, and a
+rejected committee cannot leave behind otherwise-unused system accounts.
+Genesis panics if the initial committee cannot be registered in full.
 
 This keeps `CurrentCommittee`/`QueuedCommittee` aligned with the live session
 validator set, so AURA author-index and BEEFY stake matching stay defined.

--- a/partner-chains/toolkit/committee-selection/pallet/src/lib.rs
+++ b/partner-chains/toolkit/committee-selection/pallet/src/lib.rs
@@ -456,19 +456,7 @@ pub mod pallet {
 		/// (its selection epoch + 1), and, if [NextCommittee] is defined, its value is moved to
 		/// [QueuedCommittee]. Returns the value taken from [NextCommittee].
 		pub fn rotate_committee_to_next_epoch() -> Option<Vec<T::CommitteeMember>> {
-			// The committee queued at the previous rotation has just become the effective
-			// validator set; promote it even if there is no new committee to queue. `get`
-			// rather than `take`: the queued value must remain in place as the anchor of the
-			// selection pipeline (see [QueuedCommittee]).
-			//
-			// The promoted committee is stamped with its selection epoch + 1: the epoch it was
-			// due to start serving. In normal operation this is the epoch the rotation happens
-			// in, but after skipped epochs (catch-up rotations in consecutive blocks) it keeps
-			// each recovered committee's label unique and in recovery order, instead of
-			// collapsing them all onto the current epoch.
-			let mut promoted = QueuedCommittee::<T>::get();
-			promoted.epoch = promoted.epoch + One::one();
-			CurrentCommittee::<T>::put(promoted);
+			Self::promote_queued_committee_to_current();
 
 			let next_committee = NextCommittee::<T>::take()?;
 
@@ -481,6 +469,45 @@ pub mod pallet {
 				next_committee.epoch
 			);
 			Some(validators)
+		}
+
+		/// Drops [NextCommittee] without handing it to `pallet_session` after session-key
+		/// registration failed for any member.
+		///
+		/// The previously queued committee has just become the effective validator set, so it is
+		/// still promoted to [CurrentCommittee]. [QueuedCommittee] keeps those same members —
+		/// matching `pallet_session` keeping the previous authorities when `new_session` returns
+		/// [`None`] — and is stamped with the skipped committee's epoch so
+		/// [`pallet_session::ShouldEndSession`] does not retry every block.
+		pub(crate) fn skip_unregistered_next_committee() {
+			Self::promote_queued_committee_to_current();
+
+			if let Some(next_committee) = NextCommittee::<T>::take() {
+				QueuedCommittee::<T>::mutate(|queued| {
+					queued.epoch = next_committee.epoch;
+				});
+				warn!(
+					"Skipped committee for epoch {}: session key registration failed; keeping previous validator set",
+					next_committee.epoch
+				);
+			}
+		}
+
+		/// Promotes [QueuedCommittee] to [CurrentCommittee].
+		///
+		/// The queued committee has just become the effective validator set. `get` rather than
+		/// `take`: the queued value must remain in place as the anchor of the selection pipeline
+		/// (see [QueuedCommittee]).
+		///
+		/// The promoted committee is stamped with its selection epoch + 1: the epoch it was due
+		/// to start serving. In normal operation this is the epoch the rotation happens in, but
+		/// after skipped epochs (catch-up rotations in consecutive blocks) it keeps each
+		/// recovered committee's label unique and in recovery order, instead of collapsing them
+		/// all onto the current epoch.
+		fn promote_queued_committee_to_current() {
+			let mut promoted = QueuedCommittee::<T>::get();
+			promoted.epoch = promoted.epoch + One::one();
+			CurrentCommittee::<T>::put(promoted);
 		}
 
 		/// Returns main chain scripts.

--- a/partner-chains/toolkit/committee-selection/pallet/src/pallet_session_support.rs
+++ b/partner-chains/toolkit/committee-selection/pallet/src/pallet_session_support.rs
@@ -16,14 +16,16 @@
 //! registration, so re-proving ownership on-chain here would be redundant.
 //!
 //! Key registration is all-or-nothing. `set_keys` is treated as a black box: any error
-//! aborts the hand-off. The registration loop runs in a storage layer and is rolled back
-//! on failure, so a retained validator cannot keep rotated keys while committee storage
-//! still records the previous ones. `pallet_session` silently drops validators without
-//! `NextKeys`, so handing over a partial committee would desync `QueuedCommittee`/
-//! `CurrentCommittee` from the live authority set and make derived mappings (AURA author
-//! index, BEEFY stake matching) undefined. On failure `new_session` returns [`None`] so
-//! `pallet_session` keeps the previous authority set. The failed committee is not queued;
-//! the previous set stays as both current and queued. There is no reduced committee.
+//! aborts the hand-off. Account provisioning and the registration loop run in one storage
+//! layer and are rolled back together on failure, so a retained validator cannot keep
+//! rotated keys while committee storage still records the previous ones, and a rejected
+//! committee cannot leave behind otherwise-unused system accounts. `pallet_session`
+//! silently drops validators without `NextKeys`, so handing over a partial committee
+//! would desync `QueuedCommittee`/`CurrentCommittee` from the live authority set and
+//! make derived mappings (AURA author index, BEEFY stake matching) undefined. On failure
+//! `new_session` returns [`None`] so `pallet_session` keeps the previous authority set.
+//! The failed committee is not queued; the previous set stays as both current and queued.
+//! There is no reduced committee.
 use crate::CommitteeMember;
 use frame_support::storage::with_storage_layer;
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -41,7 +43,6 @@ where
 	/// Sets the first validator-set by mapping the current committee from [crate::Pallet]
 	fn new_session_genesis(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 		let committee = crate::Pallet::<T>::current_committee_storage().committee;
-		provide_committee_accounts::<T>(&committee);
 		assert!(
 			register_committee_keys::<T>(&committee),
 			"genesis committee session key registration failed; refusing to start with a partial authority set"
@@ -54,7 +55,6 @@ where
 		info!("Session manager: new_session {new_index}, rotating the committee");
 		let next_committee = crate::Pallet::<T>::next_committee_storage()?;
 
-		provide_committee_accounts::<T>(&next_committee.committee);
 		if !register_committee_keys::<T>(&next_committee.committee) {
 			error!(
 				"Session manager: aborting committee hand-off for session {new_index}; keeping previous validator set"
@@ -88,7 +88,8 @@ fn committee_account_ids<T: crate::Config>(committee: &[T::CommitteeMember]) -> 
 ///
 /// Returns `true` iff every unique member's `set_keys` succeeded. `pallet_session` is a
 /// black box: any `Err` aborts, whatever the reason. The caller must not hand the committee
-/// over. The loop runs in a storage layer; on failure every `set_keys` write is rolled back.
+/// over. Account provisioning and `set_keys` run in one storage layer; on failure both
+/// are rolled back, so a consumed committee cannot leak provider-created accounts.
 pub(crate) fn register_committee_keys<
 	T: crate::Config + pallet_session::Config + pallet_session::historical::Config,
 >(
@@ -98,6 +99,7 @@ where
 	<T as pallet_session::Config>::Keys: From<T::AuthorityKeys>,
 {
 	with_storage_layer(|| {
+		provide_committee_accounts::<T>(new_committee);
 		let mut keys_added: BTreeSet<T::AccountId> = BTreeSet::new();
 		for member in new_committee.iter() {
 			let account_id = member.authority_id().into();
@@ -127,6 +129,10 @@ where
 //   and decreasing it afterwards, or
 // - considering account existence when selecting the committee
 // This will be addressed in later development.
+//
+// Session rotations must call this from inside `register_committee_keys`' storage layer so
+// a failed `set_keys` rolls the provider increments back. Genesis build calls it directly:
+// that path cannot fail into a consumed committee.
 pub(crate) fn provide_committee_accounts<T: crate::Config>(new_committee: &[T::CommitteeMember]) {
 	let new_accs: BTreeSet<T::AccountId> =
 		new_committee.iter().map(|m| m.authority_id().into()).collect();
@@ -234,6 +240,8 @@ mod tests {
 				Session::load_keys(&EVE.authority_id),
 				Some(SessionKeys { foo: UintAuthorityId(EVE.authority_keys) })
 			);
+			assert!(System::account_exists(&DAVE.authority_id));
+			assert!(System::account_exists(&EVE.authority_id));
 		});
 	}
 
@@ -371,10 +379,15 @@ mod tests {
 				ids_and_keys_fn(&[ALICE, BOB])
 			);
 			assert!(SessionCommitteeManagement::next_committee().is_none());
-			// The storage layer rolls back CHARLIE's successful `set_keys` together with
-			// DAVE's failed registration.
+			// The storage layer rolls back CHARLIE's successful `set_keys` and the
+			// provider increment that created CHARLIE's account, together with DAVE's
+			// failed registration.
 			assert_eq!(Session::load_keys(&CHARLIE.authority_id), None);
 			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
+			assert!(!System::account_exists(&CHARLIE.authority_id));
+			assert!(!System::account_exists(&DAVE.authority_id));
+			assert_eq!(System::providers(&CHARLIE.authority_id), 0);
+			assert_eq!(System::providers(&DAVE.authority_id), 0);
 
 			increment_epoch();
 			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
@@ -420,6 +433,8 @@ mod tests {
 				ids_and_keys_fn(&[ALICE, BOB])
 			);
 			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
+			assert!(System::account_exists(&ALICE.authority_id));
+			assert!(!System::account_exists(&DAVE.authority_id));
 
 			increment_epoch();
 			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
@@ -457,6 +472,8 @@ mod tests {
 			);
 			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
 			assert_eq!(Session::load_keys(&EVE.authority_id), None);
+			assert!(!System::account_exists(&DAVE.authority_id));
+			assert!(!System::account_exists(&EVE.authority_id));
 
 			increment_epoch();
 			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
@@ -474,6 +491,41 @@ mod tests {
 				SessionCommitteeManagement::queued_committee_storage().committee,
 				ids_and_keys_fn(&[CHARLIE, DAVE])
 			);
+		});
+	}
+
+	/// A rejected committee is consumed. Provider increments for members whose accounts
+	/// did not yet exist must roll back with `set_keys`, otherwise repeated rejections
+	/// permanently create otherwise-unused system accounts.
+	#[test]
+	fn aborted_registration_does_not_provision_unused_accounts() {
+		new_test_ext().execute_with(|| {
+			assert!(!System::account_exists(&CHARLIE.authority_id));
+			assert!(!System::account_exists(&DAVE.authority_id));
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, dave_with_charlie_keys()], 1).unwrap();
+			advance_one_block();
+			assert!(!System::account_exists(&CHARLIE.authority_id));
+			assert!(!System::account_exists(&DAVE.authority_id));
+			assert_eq!(System::providers(&CHARLIE.authority_id), 0);
+			assert_eq!(System::providers(&DAVE.authority_id), 0);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, dave_with_charlie_keys()], 2).unwrap();
+			advance_one_block();
+			assert!(!System::account_exists(&CHARLIE.authority_id));
+			assert!(!System::account_exists(&DAVE.authority_id));
+			assert_eq!(System::providers(&CHARLIE.authority_id), 0);
+			assert_eq!(System::providers(&DAVE.authority_id), 0);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 3).unwrap();
+			advance_one_block();
+			assert!(System::account_exists(&CHARLIE.authority_id));
+			assert!(System::account_exists(&DAVE.authority_id));
+			assert!(System::account_exists(&ALICE.authority_id));
+			assert!(System::account_exists(&BOB.authority_id));
 		});
 	}
 

--- a/partner-chains/toolkit/committee-selection/pallet/src/pallet_session_support.rs
+++ b/partner-chains/toolkit/committee-selection/pallet/src/pallet_session_support.rs
@@ -14,9 +14,20 @@
 //! callers and (unlike the `set_keys` extrinsic) does not require an ownership proof — a
 //! validator's session keys are already authenticated off-chain as part of their Cardano
 //! registration, so re-proving ownership on-chain here would be redundant.
+//!
+//! Key registration is all-or-nothing. `set_keys` is treated as a black box: any error
+//! aborts the hand-off. The registration loop runs in a storage layer and is rolled back
+//! on failure, so a retained validator cannot keep rotated keys while committee storage
+//! still records the previous ones. `pallet_session` silently drops validators without
+//! `NextKeys`, so handing over a partial committee would desync `QueuedCommittee`/
+//! `CurrentCommittee` from the live authority set and make derived mappings (AURA author
+//! index, BEEFY stake matching) undefined. On failure `new_session` returns [`None`] so
+//! `pallet_session` keeps the previous authority set. The failed committee is not queued;
+//! the previous set stays as both current and queued. There is no reduced committee.
 use crate::CommitteeMember;
+use frame_support::storage::with_storage_layer;
 use frame_system::pallet_prelude::BlockNumberFor;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use pallet_session::SessionInterface;
 use sp_staking::SessionIndex;
 use sp_std::collections::btree_set::BTreeSet;
@@ -31,27 +42,29 @@ where
 	fn new_session_genesis(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 		let committee = crate::Pallet::<T>::current_committee_storage().committee;
 		provide_committee_accounts::<T>(&committee);
-		register_committee_keys::<T>(&committee);
-		Some(
-			committee
-				.into_iter()
-				.map(|member| member.authority_id().into())
-				.collect::<Vec<_>>(),
-		)
+		assert!(
+			register_committee_keys::<T>(&committee),
+			"genesis committee session key registration failed; refusing to start with a partial authority set"
+		);
+		Some(committee_account_ids::<T>(&committee))
 	}
 
 	/// Rotates the committee in [crate::Pallet] and plans this new committee as upcoming validator-set.
 	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 		info!("Session manager: new_session {new_index}, rotating the committee");
+		let next_committee = crate::Pallet::<T>::next_committee_storage()?;
+
+		provide_committee_accounts::<T>(&next_committee.committee);
+		if !register_committee_keys::<T>(&next_committee.committee) {
+			error!(
+				"Session manager: aborting committee hand-off for session {new_index}; keeping previous validator set"
+			);
+			crate::Pallet::<T>::skip_unregistered_next_committee();
+			return None;
+		}
+
 		let new_committee = crate::Pallet::<T>::rotate_committee_to_next_epoch()?;
-
-		provide_committee_accounts::<T>(&new_committee);
-		register_committee_keys::<T>(&new_committee);
-
-		let new_committee_accounts =
-			new_committee.into_iter().map(|member| member.authority_id().into()).collect();
-
-		Some(new_committee_accounts)
+		Some(committee_account_ids::<T>(&new_committee))
 	}
 
 	fn end_session(end_index: SessionIndex) {
@@ -65,33 +78,45 @@ where
 	}
 }
 
-// Registers keys of new committee members in the session pallet. This is necessary, as the pallet
-// requires the keys to be registered prior to session start and we do not wish to force block
-// producers to do it manually.
+fn committee_account_ids<T: crate::Config>(committee: &[T::CommitteeMember]) -> Vec<T::AccountId> {
+	committee.iter().map(|member| member.authority_id().into()).collect()
+}
+
+/// Registers keys of new committee members in the session pallet. This is necessary, as the pallet
+/// requires the keys to be registered prior to session start and we do not wish to force block
+/// producers to do it manually.
+///
+/// Returns `true` iff every unique member's `set_keys` succeeded. `pallet_session` is a
+/// black box: any `Err` aborts, whatever the reason. The caller must not hand the committee
+/// over. The loop runs in a storage layer; on failure every `set_keys` write is rolled back.
 pub(crate) fn register_committee_keys<
 	T: crate::Config + pallet_session::Config + pallet_session::historical::Config,
 >(
 	new_committee: &[T::CommitteeMember],
-) where
+) -> bool
+where
 	<T as pallet_session::Config>::Keys: From<T::AuthorityKeys>,
 {
-	let mut keys_added: BTreeSet<T::AccountId> = BTreeSet::new();
-	for member in new_committee.iter() {
-		let account_id = member.authority_id().into();
+	with_storage_layer(|| {
+		let mut keys_added: BTreeSet<T::AccountId> = BTreeSet::new();
+		for member in new_committee.iter() {
+			let account_id = member.authority_id().into();
+			if !keys_added.insert(account_id.clone()) {
+				continue;
+			}
 
-		if keys_added.contains(&account_id) {
-			continue;
+			let keys = <T as pallet_session::Config>::Keys::from(member.authority_keys());
+			match <pallet_session::Pallet<T> as SessionInterface>::set_keys(&account_id, keys) {
+				Ok(_) => debug!("set_keys for {account_id:?}"),
+				Err(e) => {
+					error!("Could not set_keys for {account_id:?}, error: {:?}", e);
+					return Err(e);
+				},
+			}
 		}
-
-		keys_added.insert(account_id.clone());
-		let keys = <T as pallet_session::Config>::Keys::from(member.authority_keys());
-		let call_result =
-			<pallet_session::Pallet<T> as SessionInterface>::set_keys(&account_id, keys);
-		match call_result {
-			Ok(_) => debug!("set_keys for {account_id:?}"),
-			Err(e) => info!("Could not set_keys for {account_id:?}, error: {:?}", e),
-		}
-	}
+		Ok(())
+	})
+	.is_ok()
 }
 
 // Ensures that all accounts tied to new committee members exist by incrementing their
@@ -271,5 +296,217 @@ mod tests {
 			);
 			assert_eq!(SessionCommitteeManagement::current_committee_storage().epoch, 2);
 		});
+	}
+
+	fn dave_with_charlie_keys() -> MockValidator {
+		MockValidator {
+			name: "DaveWithCharlieKeys",
+			authority_keys: CHARLIE.authority_keys,
+			authority_id: DAVE.authority_id,
+		}
+	}
+
+	fn dave_with_alice_keys() -> MockValidator {
+		MockValidator {
+			name: "DaveWithAliceKeys",
+			authority_keys: ALICE.authority_keys,
+			authority_id: DAVE.authority_id,
+		}
+	}
+
+	fn eve_with_bob_keys() -> MockValidator {
+		MockValidator {
+			name: "EveWithBobKeys",
+			authority_keys: BOB.authority_keys,
+			authority_id: EVE.authority_id,
+		}
+	}
+
+	fn bob_with_alice_keys() -> MockValidator {
+		MockValidator {
+			name: "BobWithAliceKeys",
+			authority_keys: ALICE.authority_keys,
+			authority_id: BOB.authority_id,
+		}
+	}
+
+	fn queued_session_validator_ids() -> Vec<u64> {
+		Session::queued_keys().into_iter().map(|(id, _)| id).collect()
+	}
+
+	fn queued_session_key_values() -> Vec<(u64, u64)> {
+		Session::queued_keys().into_iter().map(|(id, keys)| (id, keys.foo.0)).collect()
+	}
+
+	fn alice_with_rotated_keys() -> MockValidator {
+		MockValidator { name: "AliceRotated", authority_keys: 99, authority_id: ALICE.authority_id }
+	}
+
+	fn dave_with_bob_keys() -> MockValidator {
+		MockValidator {
+			name: "DaveWithBobKeys",
+			authority_keys: BOB.authority_keys,
+			authority_id: DAVE.authority_id,
+		}
+	}
+
+	/// `set_keys` rejects DAVE (here because CHARLIE already claimed the same key). Any
+	/// rejection skips the whole incoming committee; both views keep the previous full set.
+	#[test]
+	fn set_keys_failure_skips_entire_incoming_committee() {
+		new_test_ext().execute_with(|| {
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, dave_with_charlie_keys()], 1).unwrap();
+			advance_one_block();
+
+			assert_eq!(Session::current_index(), 1);
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(queued_session_validator_ids(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::queued_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert!(SessionCommitteeManagement::next_committee().is_none());
+			// The storage layer rolls back CHARLIE's successful `set_keys` together with
+			// DAVE's failed registration.
+			assert_eq!(Session::load_keys(&CHARLIE.authority_id), None);
+			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
+			advance_one_block();
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+		});
+	}
+
+	/// A retained validator's `set_keys` succeeds (rotated keys) before a later member
+	/// is rejected. Without a storage-layer rollback, `rotate_session` would re-queue the
+	/// retained set with those new keys while committee storage still recorded the old
+	/// ones. After rollback both views keep the pre-abort keys.
+	#[test]
+	fn aborted_registration_does_not_rotate_retained_validator_keys() {
+		new_test_ext().execute_with(|| {
+			increment_epoch();
+			set_validators_directly(&[alice_with_rotated_keys(), dave_with_bob_keys()], 1).unwrap();
+			advance_one_block();
+
+			assert_eq!(Session::current_index(), 1);
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				queued_session_key_values(),
+				vec![
+					(ALICE.authority_id, ALICE.authority_keys),
+					(BOB.authority_id, BOB.authority_keys),
+				]
+			);
+			assert_eq!(
+				Session::load_keys(&ALICE.authority_id),
+				Some(SessionKeys { foo: UintAuthorityId(ALICE.authority_keys) })
+			);
+			assert_eq!(
+				SessionCommitteeManagement::queued_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
+			advance_one_block();
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(
+				Session::load_keys(&ALICE.authority_id),
+				Some(SessionKeys { foo: UintAuthorityId(ALICE.authority_keys) })
+			);
+		});
+	}
+
+	/// Every incoming member's `set_keys` is rejected (colliding with live keys). Same skip.
+	#[test]
+	fn all_set_keys_failures_keep_previous_committee_in_sync_with_session() {
+		new_test_ext().execute_with(|| {
+			increment_epoch();
+			set_validators_directly(&[dave_with_alice_keys(), eve_with_bob_keys()], 1).unwrap();
+			advance_one_block();
+
+			assert_eq!(Session::current_index(), 1);
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(queued_session_validator_ids(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::queued_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(Session::load_keys(&DAVE.authority_id), None);
+			assert_eq!(Session::load_keys(&EVE.authority_id), None);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
+			advance_one_block();
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				queued_session_validator_ids(),
+				vec![CHARLIE.authority_id, DAVE.authority_id]
+			);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[ALICE, BOB])
+			);
+			assert_eq!(
+				SessionCommitteeManagement::queued_committee_storage().committee,
+				ids_and_keys_fn(&[CHARLIE, DAVE])
+			);
+		});
+	}
+
+	#[test]
+	fn recovers_on_next_valid_committee_after_set_keys_failure() {
+		new_test_ext().execute_with(|| {
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, dave_with_charlie_keys()], 1).unwrap();
+			advance_one_block();
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 2).unwrap();
+			advance_one_block();
+			assert_eq!(Session::validators(), vec![ALICE.authority_id, BOB.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::queued_committee_storage().committee,
+				ids_and_keys_fn(&[CHARLIE, DAVE])
+			);
+
+			increment_epoch();
+			set_validators_directly(&[CHARLIE, DAVE], 3).unwrap();
+			advance_one_block();
+			assert_eq!(Session::validators(), vec![CHARLIE.authority_id, DAVE.authority_id]);
+			assert_eq!(
+				SessionCommitteeManagement::current_committee_storage().committee,
+				ids_and_keys_fn(&[CHARLIE, DAVE])
+			);
+		});
+	}
+
+	#[test]
+	#[should_panic(expected = "genesis committee session key registration failed")]
+	fn genesis_panics_if_session_key_registration_fails() {
+		let _ = new_test_ext_with_genesis_initial_authorities(&[ALICE, bob_with_alice_keys()]);
 	}
 }


### PR DESCRIPTION
## Overview

`register_committee_keys` currently logs `SessionInterface::set_keys` failures and still hands the full committee to `pallet_session`. That pallet then drops members without `NextKeys`, so the live authority set diverges from `CurrentCommittee`/`QueuedCommittee`. AURA author index and BEEFY stake matching become undefined; a partial or empty set is a liveness/finality risk ([#1895](https://github.com/midnightntwrk/midnight-node/issues/1895)).

`set_keys` is treated as a **black box**. The session manager does not inspect or special-case the error (`DuplicatedKey` today, `NoAccount`, or a reason `pallet_session` adds later). Any `Err` aborts the hand-off.

Policy is all-or-nothing:

- Call `set_keys` for each unique member. First failure skips the whole incoming committee.
- `new_session` returns `None`, so `pallet_session` keeps the previous validators.
- The failed committee is not queued. `QueuedCommittee` stays the previous full set; the skipped epoch is stamped so rotation does not retry every block.
- A reduced committee is never installed.
- Genesis panics if the initial committee cannot be registered in full (empty default genesis config is still allowed).

A later epoch with a clean committee still rotates normally.

## 🗹 TODO before merging

- [ ] Ready

## 📌 Submission Checklist

- [ ] All commits are signed off (`git commit -s`) for the DCO
- [ ] Changes are backward-compatible (or flagged if breaking)
- [ ] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [x] No new todos introduced

## 🧪 Testing Evidence

- [x] Additional tests are provided (if possible)

`cargo test -p pallet-session-validator-management --lib`

Colliding session keys are only a fixture to make `set_keys` return `Err`. Tests cover: any registration failure skips the whole incoming set; all members rejected keeps the previous set; recovery on the next valid committee; genesis panics if the initial committee cannot register in full.

## 🔱 Fork Strategy

- [x] Node Runtime Update
- [ ] Node Client Update
- [ ] Other:
- [ ] N/A

Runtime upgrade required so live chains pick up the new `SessionManager` behaviour.

## Links

Closes https://github.com/midnightntwrk/midnight-node/issues/1895