### PR TITLE
fix(toolkit): write wallet-cache entries at the umask default, and stop the GC sweep deleting what it cannot read

### DIFF
--- a/changes/toolkit/changed/wallet-cache-shared-dir-permissions.md
+++ b/changes/toolkit/changed/wallet-cache-shared-dir-permissions.md
@@ -53,4 +53,4 @@ Tests pin the file mode against the process umask rather than a literal
 unreadable and foreign-format entries alone, an unreadable entry
 recovering once it is readable again, and permissions healing on replace.
 
-PR: https://github.com/midnightntwrk/midnight-node/pull/PENDING
+PR: https://github.com/midnightntwrk/midnight-node/pull/2081

--- a/changes/toolkit/changed/wallet-cache-shared-dir-permissions.md
+++ b/changes/toolkit/changed/wallet-cache-shared-dir-permissions.md
@@ -1,0 +1,56 @@
+#toolkit
+# Fix `--ledger-state-db` entries being unreadable — and silently deleted — when the cache directory is shared between users
+
+Both writers in the file cache backend staged through
+`NamedTempFile::new_in`, which hard-codes mode 0600, and `persist()` uses
+`rename(2)` — so that mode landed on the finished cache file. A umask can
+only clear bits, never add them, so no umask setting could widen it.
+
+A `--ledger-state-db` shared between users is the normal case on a perf
+box (CI jobs run as one user, interactive sessions as another, both in a
+common group over a setgid directory). Every user but the writer therefore
+saw each seed as a cache miss, and one missing entry forces
+`build_fork_aware_context_cached` to replay from genesis for the whole
+seed set — ~90 minutes on a 31k-block chain.
+
+Two further defects turned that from "slow" into "destructive":
+
+- `get_all_cached_wallet_heights` exists to collect snapshot GC
+  references, but it scanned the *entire* wallets directory and deleted
+  any file whose 9-byte header it could not parse — and its parser could
+  not tell "unreadable by this user" from "corrupt", because
+  `read_wallet_height` was `.ok()?` throughout. Since that scan runs on
+  every cache save by every command, two users sharing a directory
+  destroyed each other's entries on every save, and so did two toolkit
+  builds with different `WALLET_CACHE_FORMAT_VERSION` values.
+- `get_wallet_states` turned any io error into an unlogged cache miss, so
+  the resulting hour-and-a-half replay came with nothing in the log to
+  explain it.
+
+Changes:
+
+- New `staging_file` helper used by both writers: requests 0666 and lets
+  the process umask narrow it (0002 → 0664, the usual 0022 → 0644, 0077 →
+  0600 for a deliberately private cache). Directories are already left to
+  the umask via `fs::create_dir_all`, so a shared deployment now sets one
+  umask and both halves follow. `#[cfg(unix)]`-gated.
+- `read_wallet_height` returns `io::Result<Option<u64>>`: `Err` for
+  "could not read", `Ok(None)` for "not this format version".
+- The GC scan is read-only. An entry it cannot account for is simply not
+  counted as a snapshot reference — an older build's entries are left for
+  that build, and a failed read never costs anyone their cache. Eviction
+  of genuinely corrupt entries stays in `get_wallet_states`, where it is
+  scoped to the seeds the caller asked for and where the format-versioned
+  cache key means an undecodable body really is corruption.
+- `write_wallet_if_newer` logs, then replaces, an existing entry whose
+  height it cannot read — which is how a directory full of 0600 entries
+  heals.
+- `get_wallet_states` logs an unreadable entry instead of silently
+  reporting a miss.
+
+Tests pin the file mode against the process umask rather than a literal
+(so the intent survives any CI umask), and cover the sweep leaving both
+unreadable and foreign-format entries alone, an unreadable entry
+recovering once it is readable again, and permissions healing on replace.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/PENDING

--- a/util/toolkit/src/fetcher/fetch_storage/file_backend.rs
+++ b/util/toolkit/src/fetcher/fetch_storage/file_backend.rs
@@ -31,7 +31,7 @@ use std::{
 	time::Duration,
 };
 use subxt::utils::H256;
-use tempfile::NamedTempFile;
+use tempfile::{Builder as TempFileBuilder, NamedTempFile};
 
 /// Ledger snapshots younger than this are never GC'd, giving concurrent
 /// processes time to finish saving wallet states that reference them.
@@ -84,25 +84,56 @@ fn parse_seed_hash(filename: &str) -> Option<H256> {
 	if bytes.len() == 32 { Some(H256::from_slice(&bytes)) } else { None }
 }
 
+/// Create the staging file for an atomic replace inside `dir`.
+///
+/// [`NamedTempFile::new_in`] hard-codes mode 0600 and `persist()` renames, so that mode lands on
+/// the finished cache file — and no umask can widen it, since a umask only ever clears bits. A
+/// `--ledger-state-db` shared between users (perf boxes run jobs as one user and interactive
+/// sessions as another, both in a common group) therefore ends up holding entries only the
+/// writing user can open: every other user's run sees each seed as a cache miss and replays from
+/// genesis, and its snapshot GC sweep used to delete the entries it could not read.
+///
+/// So request 0666 and let the process umask narrow it — 0002 yields 0664, the usual 0022 yields
+/// 0644, and 0077 still yields 0600 for anyone who wants a private cache. Directories created by
+/// this backend are left to the umask the same way (`fs::create_dir_all` uses `0777 & !umask`),
+/// so a shared deployment sets one umask and both halves follow.
+fn staging_file(dir: &Path) -> io::Result<NamedTempFile> {
+	// `mut` is only needed by the `cfg(unix)` block below.
+	#[allow(unused_mut)]
+	let mut builder = TempFileBuilder::new();
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		builder.permissions(fs::Permissions::from_mode(0o666));
+	}
+	builder.tempfile_in(dir)
+}
+
 /// Write to a unique temp file, then rename over `<path>`.
 fn write_via_tmp_and_rename(path: &Path, data: &[u8]) -> io::Result<()> {
 	let dir = path
 		.parent()
 		.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
-	let tmp = NamedTempFile::new_in(dir)?;
+	let tmp = staging_file(dir)?;
 	fs::write(tmp.path(), data)?;
 	// persist() uses rename(2) on POSIX — atomic directory-entry swap
 	tmp.persist(path).map_err(|e| e.error)?;
 	Ok(())
 }
 
-fn read_wallet_height(path: &Path) -> Option<u64> {
-	let mut file = fs::File::open(path).ok()?;
-	// Header is `[version: u8][block_height: u64 LE]` (9 bytes); a stale/old-format file yields
-	// `None` from `block_height_from_header` (version mismatch), which callers treat as absent.
+/// Read the recorded block height out of a wallet entry's header.
+///
+/// `Err(_)` means the file could not be read at all (missing, unreadable by this user, io error);
+/// `Ok(None)` means it was read but is not this format version (a stale entry from an older
+/// toolkit, whose cache key differs anyway — see `WALLET_CACHE_FORMAT_VERSION`). Callers must keep
+/// the two apart: an entry we merely cannot open right now is not a corrupt entry, and must never
+/// be deleted on that basis.
+fn read_wallet_height(path: &Path) -> io::Result<Option<u64>> {
+	let mut file = fs::File::open(path)?;
+	// Header is `[version: u8][block_height: u64 LE]` (9 bytes).
 	let mut header = [0u8; 9];
-	io::Read::read_exact(&mut file, &mut header).ok()?;
-	CachedWalletState::block_height_from_header(&header)
+	io::Read::read_exact(&mut file, &mut header)?;
+	Ok(CachedWalletState::block_height_from_header(&header))
 }
 
 /// Write wallet data only if `new_height` exceeds the existing file's height.
@@ -116,12 +147,20 @@ fn write_wallet_if_newer(path: &Path, new_height: u64, data: &[u8]) -> io::Resul
 	let dir = path
 		.parent()
 		.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
-	let tmp = NamedTempFile::new_in(dir)?;
+	let tmp = staging_file(dir)?;
 	fs::write(tmp.path(), data)?;
-	if let Some(existing) = read_wallet_height(path) {
-		if existing >= new_height {
+	match read_wallet_height(path) {
+		Ok(Some(existing)) if existing >= new_height => {
 			return Ok(Some(existing)); // tmp auto-deleted on drop
-		}
+		},
+		Ok(_) => {},
+		Err(e) if e.kind() == io::ErrorKind::NotFound => {},
+		// Present but unreadable (e.g. written 0600 by another user before this backend started
+		// asking for 0666). We cannot compare heights, so we replace it — which also heals the
+		// permissions, since the replacement comes from `staging_file`.
+		Err(e) => log::warn!(
+			"Cannot read existing wallet cache entry {path:?} ({e}); replacing it at height {new_height}"
+		),
 	}
 	// persist() uses rename(2) on POSIX — atomic directory-entry swap
 	tmp.persist(path).map_err(|e| e.error)?;
@@ -208,12 +247,27 @@ impl WalletStateCaching for FileBackend {
 			paths
 				.into_iter()
 				.map(|(seed_hash, path)| {
-					let data = fs::read(&path).ok()?;
+					let data = match fs::read(&path) {
+						Ok(data) => data,
+						Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
+						// A cache entry that exists but cannot be read is not a cache miss we
+						// should pass over in silence: it forces this seed's whole history to be
+						// replayed from genesis. The usual cause is a shared `ledger_state_db`
+						// holding another user's 0600 entries. Say so, and leave the file alone.
+						Err(e) => {
+							log::warn!(
+								"Wallet cache entry {path:?} exists but cannot be read ({e}); \
+								 treating as a miss — this seed will replay from genesis"
+							);
+							return None;
+						},
+					};
 					match CachedWalletState::from_value_bytes(&data, seed_hash) {
 						Ok(cached) => Some(cached),
 						Err(e) => {
-							// Stale/old-format or corrupt entry: treat as a miss and evict the
-							// file so it is not retried on every run (mirrors delete_wallet_states).
+							// Genuinely corrupt: the cache key folds in the format version, so a
+							// file under *this* key was written by a writer of this format. Treat
+							// as a miss and evict so it is not retried on every run.
 							log::warn!("Evicting undecodable wallet state file {path:?}: {e}");
 							let _ = fs::remove_file(&path);
 							None
@@ -354,18 +408,21 @@ impl WalletStateCaching for FileBackend {
 					continue;
 				}
 				let path = dir.join(&name);
-				let height = read_wallet_height(&path);
-				match height {
-					Some(h) => {
+				// Read-only on purpose. This scan feeds snapshot GC; it is reached from every
+				// cache save by every command, and it sees the *whole* directory rather than the
+				// seeds of the calling run. Deleting from here meant one command could destroy
+				// another user's — or an older toolkit build's — entries wholesale, on nothing
+				// more than a failed read. An entry it cannot account for is simply not counted
+				// as a snapshot reference.
+				match read_wallet_height(&path) {
+					Ok(Some(h)) => {
 						heights.insert(h);
 					},
-					None => {
-						log::error!(
-							"Removing corrupted wallet cache file {name}: \
-							 could not extract block_height"
-						);
-						let _ = fs::remove_file(&path);
-					},
+					Ok(None) => log::debug!(
+						"Ignoring wallet cache file {name}: not this cache format version"
+					),
+					Err(e) if e.kind() == io::ErrorKind::NotFound => {},
+					Err(e) => log::warn!("Ignoring unreadable wallet cache file {name}: {e}"),
 				}
 			}
 			heights.into_iter().collect()
@@ -606,20 +663,140 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn corrupted_wallet_file_is_deleted() {
+	async fn corrupted_wallet_file_is_evicted_on_read() {
 		let (_, backend, cid) = test_fixture();
 
 		let h1 = H256::from([0x01; 32]);
 
-		// Write a valid wallet, then overwrite with garbage
+		// Write a valid wallet, then overwrite with garbage. The cache key folds in the format
+		// version, so a file under this key can only have come from a writer of this format —
+		// undecodable content there is real corruption, and reading the seed evicts it.
 		backend.set_wallet_states(cid, &[test_wallet(h1, 300)]).await;
 		let path = backend.wallet_path(cid, h1);
 		assert!(path.exists());
 		fs::write(&path, b"short").unwrap();
 
-		// Height should not be found and the corrupted file should be deleted
+		assert!(backend.get_wallet_states(cid, &[h1]).await[0].is_none());
+		assert!(!path.exists(), "corrupt entry should have been evicted");
+	}
+
+	/// The mode a file gets from `open(O_CREAT, 0o666)` under this process's umask — what
+	/// `staging_file` should be producing, whatever the umask happens to be in CI.
+	#[cfg(unix)]
+	fn umask_default_file_mode(dir: &Path) -> u32 {
+		use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+		let probe = dir.join("umask-probe");
+		fs::OpenOptions::new()
+			.write(true)
+			.create_new(true)
+			.mode(0o666)
+			.open(&probe)
+			.unwrap();
+		let mode = fs::metadata(&probe).unwrap().permissions().mode() & 0o777;
+		fs::remove_file(&probe).unwrap();
+		mode
+	}
+
+	/// Cache files must not be owner-only: a `--ledger-state-db` is routinely shared between users
+	/// (a CI job and an interactive session on the same box), and 0600 entries make every other
+	/// user's run miss the whole cache and replay from genesis. `NamedTempFile` defaults to 0600
+	/// and `persist()` keeps it, so the mode has to be asked for explicitly — a umask cannot widen
+	/// it. Pinned against the umask rather than a literal so the intent survives any CI umask.
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn cache_files_are_written_at_the_umask_default_not_owner_only() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let (tempdir, backend, cid) = test_fixture();
+		let expected = umask_default_file_mode(tempdir.path());
+
+		let h1 = H256::from([0x01; 32]);
+		backend.set_wallet_states(cid, &[test_wallet(h1, 100)]).await;
+		backend.set_ledger_snapshot(cid, test_snapshot(100)).await;
+
+		for path in [backend.wallet_path(cid, h1), backend.ledger_path(cid, 100)] {
+			let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+			assert_eq!(
+				mode, expected,
+				"{path:?} was written 0{mode:o}, expected the umask default 0{expected:o}"
+			);
+		}
+	}
+
+	/// A file this user cannot open is not a corrupt file. The sweep runs on every save by every
+	/// command and sees the whole directory, so deleting on a failed read let one command destroy
+	/// another user's warm cache.
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn sweep_ignores_unreadable_entry_instead_of_deleting_it() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let (_, backend, cid) = test_fixture();
+		let (h1, h2) = (H256::from([0x01; 32]), H256::from([0x02; 32]));
+		backend
+			.set_wallet_states(cid, &[test_wallet(h1, 100), test_wallet(h2, 200)])
+			.await;
+
+		let unreadable = backend.wallet_path(cid, h1);
+		fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
 		let heights = backend.get_all_cached_wallet_heights(cid).await;
-		assert!(heights.is_empty());
-		assert!(!path.exists(), "corrupted file should have been deleted");
+		assert_eq!(heights, vec![200], "unreadable entry must not be counted as a reference");
+		assert!(unreadable.exists(), "unreadable entry must not be deleted");
+
+		// And it reads back as a miss without being destroyed, so it still heals once the
+		// permissions are fixed.
+		assert!(backend.get_wallet_states(cid, &[h1]).await[0].is_none());
+		assert!(unreadable.exists());
+		fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644)).unwrap();
+		assert_eq!(
+			backend.get_wallet_states(cid, &[h1]).await[0].as_ref().map(|w| w.block_height),
+			Some(100),
+			"entry should be usable again once readable"
+		);
+	}
+
+	/// An entry from an older cache format belongs to an older toolkit build, which keys its
+	/// entries differently and may still be in use against the same directory. Skip it; deleting
+	/// it made two builds sharing a directory wipe each other on every save.
+	#[tokio::test]
+	async fn sweep_ignores_foreign_format_entry_instead_of_deleting_it() {
+		let (_, backend, cid) = test_fixture();
+		let h1 = H256::from([0x01; 32]);
+		backend.set_wallet_states(cid, &[test_wallet(h1, 100)]).await;
+
+		// v1 layout: bare 8-byte LE block height, no version prefix.
+		let foreign = backend.wallet_path(cid, H256::from([0xaa; 32]));
+		let mut v1 = 100u64.to_le_bytes().to_vec();
+		v1.extend_from_slice(&[0u8; 32]);
+		fs::write(&foreign, &v1).unwrap();
+
+		assert_eq!(backend.get_all_cached_wallet_heights(cid).await, vec![100]);
+		assert!(foreign.exists(), "foreign-format entry must not be deleted");
+	}
+
+	/// Replacing an entry whose height cannot be read (another user's 0600 file, pre-fix) is how a
+	/// shared cache heals: the replacement is written at the umask default.
+	#[cfg(unix)]
+	#[tokio::test]
+	async fn unreadable_entry_is_replaced_and_permissions_heal() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let (tempdir, backend, cid) = test_fixture();
+		let expected = umask_default_file_mode(tempdir.path());
+
+		let h1 = H256::from([0x01; 32]);
+		backend.set_wallet_states(cid, &[test_wallet(h1, 100)]).await;
+		let path = backend.wallet_path(cid, h1);
+		fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+
+		backend.set_wallet_states(cid, &[test_wallet(h1, 200)]).await;
+
+		let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+		assert_eq!(mode, expected, "replacement was written 0{mode:o}");
+		assert_eq!(
+			backend.get_wallet_states(cid, &[h1]).await[0].as_ref().map(|w| w.block_height),
+			Some(200),
+		);
 	}
 }


### PR DESCRIPTION
# Overview

A `--ledger-state-db` shared between users silently behaved as if it were empty for everyone but the user who wrote it, and each save actively deleted the other user's entries.

Both writers in the file cache backend staged through `NamedTempFile::new_in`, which hard-codes mode **0600**, and `persist()` uses `rename(2)` — so 0600 landed on the finished cache file. A umask can only *clear* bits, never add them, so no umask setting could widen it.

Sharing that directory is the normal case on a perf box: CI jobs run as one user, interactive sessions as another, both in a common group over a setgid directory. Every user but the writer saw each seed as a cache miss — and **one** missing entry forces `build_fork_aware_context_cached` to replay from genesis for the whole seed set (`builder/mod.rs:1337`), which is ~90 minutes on a 31k-block chain. Two overnight load-generation rounds on `hel1-perf-01` produced zero transactions this way.

Two further defects turned that from slow into destructive:

- `get_all_cached_wallet_heights` exists to collect snapshot-GC references, but it scanned the **entire** wallets directory and deleted any file whose 9-byte header it could not parse — and `read_wallet_height` was `.ok()?` throughout, so it could not tell "unreadable by this user" from "corrupt". That scan runs on every cache save by every command, so two users sharing a directory destroyed each other's entries on every save. So would two toolkit builds with different `WALLET_CACHE_FORMAT_VERSION` values.
- `get_wallet_states` turned any io error into an unlogged miss, so the resulting hour-and-a-half replay had nothing in the log to explain itself.

## Changes

- New `staging_file` helper used by both writers: asks for `0666` and lets the process umask narrow it — `0002` → 0664, the usual `0022` → 0644, `0077` → 0600 for a deliberately private cache. Directories were already left to the umask by `fs::create_dir_all`, so one umask now governs both halves rather than the files being immovable. `#[cfg(unix)]`-gated.
- `read_wallet_height` returns `io::Result<Option<u64>>`: `Err` for "could not read", `Ok(None)` for "not this format version".
- **The GC scan is read-only.** An entry it cannot account for is simply not counted as a snapshot reference and is left alone — an older build's entries stay for that build, and a failed read never costs anyone their cache. Eviction of genuinely corrupt entries stays in `get_wallet_states`, scoped to the seeds the caller asked for, where the format-versioned cache key means an undecodable body really is corruption.
- `write_wallet_if_newer` logs, then replaces, an entry whose height it cannot read — which is how a directory full of 0600 entries heals.
- `get_wallet_states` logs an unreadable entry instead of silently reporting a miss.

Deliberately no policy imposed: the toolkit asks for the permissive mode and the deployment's umask decides. A private cache under `umask 0077` still comes out 0600.

## 🗹 TODO before merging

- [x] Ready

## 📌 Submission Checklist

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason:
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] Updated AGENTS.md if build commands, architecture, or workflows changed <!-- n/a — no build/workflow change -->
- [x] No new todos introduced

Existing on-disk caches need no migration: entries already written 0600 keep working for their owner, and are replaced at the new mode the next time their height advances. The companion infra PR reconciles the modes of what is already on disk.

## 🧪 Testing Evidence

`cargo test -p midnight-node-toolkit --lib --test cached_context` — **139 passed, 0 failed** plus the `cached_context` integration test, which drives `build_fork_aware_context_cached` against the file backend and asserts it matches an uncached build:

```
test fetcher::fetch_storage::file_backend::tests::cache_files_are_written_at_the_umask_default_not_owner_only ... ok
test fetcher::fetch_storage::file_backend::tests::sweep_ignores_unreadable_entry_instead_of_deleting_it ... ok
test fetcher::fetch_storage::file_backend::tests::sweep_ignores_foreign_format_entry_instead_of_deleting_it ... ok
test fetcher::fetch_storage::file_backend::tests::unreadable_entry_is_replaced_and_permissions_heal ... ok
test fetcher::fetch_storage::file_backend::tests::corrupted_wallet_file_is_evicted_on_read ... ok
test result: ok. 139 passed; 0 failed; 1 ignored

running 1 test
test file_cached_context ... ok
```

`cargo clippy -p midnight-node-toolkit --all-targets` clean; `cargo fmt` applied.

The four new tests, and one renamed:

- `cache_files_are_written_at_the_umask_default_not_owner_only` — pins the mode of both a wallet entry and a ledger snapshot against what `open(O_CREAT, 0o666)` yields under the live umask, rather than against a literal, so it asserts the actual intent ("ask for 0666, let the umask decide") whatever umask CI runs with.
- `sweep_ignores_unreadable_entry_instead_of_deleting_it` — a valid entry chmod'd `000`: not counted as a reference, **not deleted**, reads back as a miss, and is usable again once readable. This is the regression that matters most.
- `sweep_ignores_foreign_format_entry_instead_of_deleting_it` — a v1-layout entry (bare 8-byte LE height) survives the scan.
- `unreadable_entry_is_replaced_and_permissions_heal` — replacing an entry whose height cannot be read writes the replacement at the umask default.
- `corrupted_wallet_file_is_deleted` → `corrupted_wallet_file_is_evicted_on_read`: same guarantee, moved to the path that legitimately owns eviction. Deliberate behaviour change — the sweep no longer deletes.

Also verified before the fix, with a throwaway probe against a temp dir, that a small-seed-set save does **not** evict a large warm cache (1000/1000 entries and the referenced snapshot survive) — the eviction was entirely the unreadable-file path, not `set_wallet_states` or snapshot GC. Not applied to `hel1-perf-01` yet; that wants the companion infra change first, since a fresh toolkit writing 0664 into directories still at 0755 only half-works.

- [x] Additional tests are provided (if possible)

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other: toolkit only — no node, runtime or consensus code touched, nothing on a network path.
- [ ] N/A

## Links

Companion infra change (runner `UMask=0002` + mode reconcile on the shared perf directories): shieldedtech/shielded-iac#2194 — the two are complementary, and this one is the half a umask cannot do.