### PR TITLE
Fix issue #2070. Don't fail context update when there is a record of rejected transaction

### DIFF
--- a/changes/toolkit/changed/fix-replay-abort-on-well-formed-failure.md
+++ b/changes/toolkit/changed/fix-replay-abort-on-well-formed-failure.md
@@ -1,0 +1,28 @@
+#toolkit #bugfix
+# Don't abort context replay on a `well_formed` failure the chain itself tolerated
+
+`LedgerContext::apply_txs_collect_events` (in both the ledger-8 and ledger-9
+implementations, behind `update_from_block`) aborted the whole block replay
+whenever a transaction's `well_formed` check returned `Err`, e.g.
+`OutOfDustValidityWindow` for a dust action whose `ctime` lands a couple of
+seconds past the including block's `tblock`. This made every toolkit workflow
+that replays a context (transaction generation, wallet inspection, faucets,
+test-data generators) unusable against a chain — such as Preview — carrying a
+transaction the chain itself had accepted: on-chain,
+`pallet_midnight::send_mn_transaction` hits this same check via
+`LedgerApi::apply_transaction`, but only fails that one extrinsic's dispatch
+(storage rolled back, `ExtrinsicFailed` emitted) without affecting block
+validity, so a `well_formed` failure alone is not evidence of an invalid block.
+
+`apply_txs_collect_events` now matches on `LedgerContextError::InvalidTransaction`
+specifically and, on that variant, logs a warning and moves on to the next
+transaction instead of propagating the error and aborting the replay. Every
+other error variant still aborts. `update_from_tx` (used by the `batches`
+generator to validate each transaction it builds before chaining more on top
+of it) is untouched and keeps hard-failing: a generator needs to know
+immediately if its own just-built transaction is doomed, since tolerating it
+there would let a doomed transaction ship in the output batch and further
+batches get built against funds it never actually created.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2098
+Issue: https://github.com/midnightntwrk/midnight-node/issues/2070

--- a/ledger/helpers/unsafe/src/ledger_8/context.rs
+++ b/ledger/helpers/unsafe/src/ledger_8/context.rs
@@ -173,10 +173,26 @@ impl<D: DB + Clone> LedgerContext<D> {
 		let mut all_events: Vec<Event<D>> = Vec::new();
 		let strictness = Self::strictness_for(block_context, root_verified);
 		for tx in txs {
-			let (events, cost) =
-				self.update_from_tx_with_strictness(tx, block_context, strictness)?;
-			all_events.extend(events);
-			total_cost = total_cost + cost;
+			match self.update_from_tx_with_strictness(tx, block_context, strictness) {
+				Ok((events, cost)) => {
+					all_events.extend(events);
+					total_cost = total_cost + cost;
+				},
+				// A `well_formed` rejection (e.g. `OutOfDustValidityWindow` from a dust action
+				// whose `ctime` lands a couple of seconds past the including block's `tblock`)
+				// is not evidence of an invalid block: on-chain, `pallet_midnight::send_mn_transaction`
+				// hits this same check via `LedgerApi::apply_transaction` and simply fails that
+				// one extrinsic's dispatch (storage rolled back, `ExtrinsicFailed` emitted)
+				// without affecting block validity. Already-committed, external chain history is
+				// replayed here, so mirror that instead of aborting the whole replay.
+				Err(LedgerContextError::InvalidTransaction(reason)) => {
+					let hash = hex::encode(tx.transaction_hash().0.0);
+					log::warn!(
+						"Tolerating well_formed rejection {reason} of tx 0x{hash} while replaying block"
+					);
+				},
+				Err(e) => return Err(e),
+			}
 		}
 
 		let mut latest_ledger_state = self
@@ -383,6 +399,11 @@ impl<D: DB + Clone> LedgerContext<D> {
 		)
 	}
 
+	/// A `well_formed` rejection surfaces as `Err(LedgerContextError::InvalidTransaction(_))`,
+	/// distinct from every other (fatal) error variant, so callers can decide for themselves
+	/// whether to tolerate it: `apply_txs_collect_events` (block replay) does, `update_from_tx`
+	/// (this function's only other caller, used to validate a transaction the caller is about
+	/// to build more transactions on top of or submit itself) does not.
 	fn update_from_tx_with_strictness<S: SignatureKind<D>, P: ProofKind<D> + std::fmt::Debug>(
 		&self,
 		tx: &SerdeTransaction<S, P, D>,

--- a/ledger/helpers/unsafe/src/ledger_8/context.rs
+++ b/ledger/helpers/unsafe/src/ledger_8/context.rs
@@ -21,6 +21,7 @@ use crate::ledger_8::{
 	clamp_and_normalize, compute_overall_fullness, default_storage, deserialize,
 	mn_ledger_serialize as serialize, mn_ledger_storage as storage, types::StorableSyntheticCost,
 };
+use crate::replay_stats::{FAILED_TXS, PARTIALLY_FAILED_TXS};
 use derive_where::derive_where;
 use hex::encode as hex_encode;
 use lazy_static::lazy_static;
@@ -435,7 +436,10 @@ impl<D: DB + Clone> LedgerContext<D> {
 				} else {
 					tx.erase_proofs().well_formed(ref_state, strictness, tblock)
 				}
-				.map_err(|e| LedgerContextError::InvalidTransaction(format!("{e:?}")))?;
+				.map_err(|e| {
+					FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+					LedgerContextError::InvalidTransaction(format!("{e:?}"))
+				})?;
 				let cost = tx
 					.cost(&tx_context.ref_state.parameters, false)
 					.map_err(|e| LedgerContextError::CostCalculation(format!("{e:?}")))?;
@@ -445,8 +449,7 @@ impl<D: DB + Clone> LedgerContext<D> {
 				match result {
 					TransactionResult::Success(events) => (new_ledger_state, offers, events, cost),
 					TransactionResult::PartialSuccess(failure, events) => {
-						crate::replay_stats::PARTIALLY_FAILED_TXS
-							.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+						PARTIALLY_FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 						let hash = hex::encode(tx.transaction_hash().0.0);
 						log::debug!(
 							"Partially failing result {failure:?} of applying tx 0x{hash} to update Local Ledger State"
@@ -454,8 +457,7 @@ impl<D: DB + Clone> LedgerContext<D> {
 						(new_ledger_state, offers, events, cost)
 					},
 					TransactionResult::Failure(failure) => {
-						crate::replay_stats::FAILED_TXS
-							.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+						FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 						let hash = hex::encode(tx.transaction_hash().0.0);
 						log::warn!(
 							"Failing result {failure:?} of applying tx 0x{hash} to update Local Ledger State"

--- a/ledger/helpers/unsafe/src/ledger_9/context.rs
+++ b/ledger/helpers/unsafe/src/ledger_9/context.rs
@@ -173,10 +173,26 @@ impl<D: DB + Clone> LedgerContext<D> {
 		let mut all_events: Vec<Event<D>> = Vec::new();
 		let strictness = Self::strictness_for(block_context, root_verified);
 		for tx in txs {
-			let (events, cost) =
-				self.update_from_tx_with_strictness(tx, block_context, strictness)?;
-			all_events.extend(events);
-			total_cost = total_cost + cost;
+			match self.update_from_tx_with_strictness(tx, block_context, strictness) {
+				Ok((events, cost)) => {
+					all_events.extend(events);
+					total_cost = total_cost + cost;
+				},
+				// A `well_formed` rejection (e.g. `OutOfDustValidityWindow` from a dust action
+				// whose `ctime` lands a couple of seconds past the including block's `tblock`)
+				// is not evidence of an invalid block: on-chain, `pallet_midnight::send_mn_transaction`
+				// hits this same check via `LedgerApi::apply_transaction` and simply fails that
+				// one extrinsic's dispatch (storage rolled back, `ExtrinsicFailed` emitted)
+				// without affecting block validity. Already-committed, external chain history is
+				// replayed here, so mirror that instead of aborting the whole replay.
+				Err(LedgerContextError::InvalidTransaction(reason)) => {
+					let hash = hex::encode(tx.transaction_hash().0.0);
+					log::warn!(
+						"Tolerating well_formed rejection {reason} of tx 0x{hash} while replaying block"
+					);
+				},
+				Err(e) => return Err(e),
+			}
 		}
 
 		let mut latest_ledger_state = self
@@ -383,6 +399,11 @@ impl<D: DB + Clone> LedgerContext<D> {
 		)
 	}
 
+	/// A `well_formed` rejection surfaces as `Err(LedgerContextError::InvalidTransaction(_))`,
+	/// distinct from every other (fatal) error variant, so callers can decide for themselves
+	/// whether to tolerate it: `apply_txs_collect_events` (block replay) does, `update_from_tx`
+	/// (this function's only other caller, used to validate a transaction the caller is about
+	/// to build more transactions on top of or submit itself) does not.
 	fn update_from_tx_with_strictness<S: SignatureKind<D>, P: ProofKind<D> + std::fmt::Debug>(
 		&self,
 		tx: &SerdeTransaction<S, P, D>,

--- a/ledger/helpers/unsafe/src/ledger_9/context.rs
+++ b/ledger/helpers/unsafe/src/ledger_9/context.rs
@@ -21,6 +21,7 @@ use crate::ledger_9::{
 	clamp_and_normalize, compute_overall_fullness, default_storage, deserialize,
 	mn_ledger_serialize as serialize, mn_ledger_storage as storage, types::StorableSyntheticCost,
 };
+use crate::replay_stats::{FAILED_TXS, PARTIALLY_FAILED_TXS};
 use derive_where::derive_where;
 use hex::encode as hex_encode;
 use lazy_static::lazy_static;
@@ -435,7 +436,10 @@ impl<D: DB + Clone> LedgerContext<D> {
 				} else {
 					tx.erase_proofs().well_formed(ref_state, strictness, tblock)
 				}
-				.map_err(|e| LedgerContextError::InvalidTransaction(format!("{e:?}")))?;
+				.map_err(|e| {
+					FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+					LedgerContextError::InvalidTransaction(format!("{e:?}"))
+				})?;
 				let cost = tx
 					.cost(&tx_context.ref_state.parameters, false)
 					.map_err(|e| LedgerContextError::CostCalculation(format!("{e:?}")))?;
@@ -445,8 +449,7 @@ impl<D: DB + Clone> LedgerContext<D> {
 				match result {
 					TransactionResult::Success(events) => (new_ledger_state, offers, events, cost),
 					TransactionResult::PartialSuccess(failure, events) => {
-						crate::replay_stats::PARTIALLY_FAILED_TXS
-							.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+						PARTIALLY_FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 						let hash = hex::encode(tx.transaction_hash().0.0);
 						log::debug!(
 							"Partially failing result {failure:?} of applying tx 0x{hash} to update Local Ledger State"
@@ -454,8 +457,7 @@ impl<D: DB + Clone> LedgerContext<D> {
 						(new_ledger_state, offers, events, cost)
 					},
 					TransactionResult::Failure(failure) => {
-						crate::replay_stats::FAILED_TXS
-							.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+						FAILED_TXS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 						let hash = hex::encode(tx.transaction_hash().0.0);
 						log::warn!(
 							"Failing result {failure:?} of applying tx 0x{hash} to update Local Ledger State"


### PR DESCRIPTION
# Overview

Fixed #2070 by not crashing replay when there is a `send_mn_transaction` record of a transaction that wasn't included in Midnight Ledger because it was not well formed.

## 🗹 TODO before merging

<!-- Add anything here that needs to be completed before the PR can be merged. -->
- [x] Ready

## 📌 Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [x] All commits are signed off (`git commit -s`) for the DCO
- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [x] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: <!-- e.g. change only affects CI -->
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [ ] Update documentation (if relevant)
- [ ] Updated AGENTS.md if build commands, architecture, or workflows changed
- [ ] No new todos introduced

## 🧪 Testing Evidence

<!-- Describe how this was tested. Include commands, logs, test outputs or paste in screen clips where useful. -->

Please describe any additional testing aside from CI:

- [ ] Additional tests are provided (if possible)

## 🔱 Fork Strategy

<!-- How can we update to these changes without disrupting the network? Is it an update to the Node runtime, client, etc. -->

- [ ] Node Runtime Update
- [ ] Node Client Update
- [ ] Other: <!-- Please give details. -->
- [ ] N/A

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
