### PR TITLE
fix: for consistency use Display everywhere

### DIFF
--- a/changes/node/changed/rejection-reason-display.md
+++ b/changes/node/changed/rejection-reason-display.md
@@ -12,4 +12,4 @@ Switch all of them to `Display` (the segment map is now rendered as
 node-side `InvalidError` code returned to callers is unchanged, so nothing
 downstream of the log is affected.
 
-PR: <link>
+PR: https://github.com/midnightntwrk/midnight-node/pull/2105

--- a/changes/node/changed/rejection-reason-display.md
+++ b/changes/node/changed/rejection-reason-display.md
@@ -1,0 +1,15 @@
+#logging #hygiene
+# Log transaction rejection reasons via Display rather than Debug
+
+The mempool, pre-dispatch and apply sinks rendered a rejected transaction's
+`TransactionInvalid` with `{:?}`, which prints the error's full payload -
+including any ledger `StateValue` embedded in it - instead of the one-line
+diagnostic its `Display` impl already provides. The `PartialSuccess` sink did
+the same for its whole per-segment result map.
+
+Switch all of them to `Display` (the segment map is now rendered as
+`[<segment>: <reason>, ...]`). Log lines become shorter and readable; the
+node-side `InvalidError` code returned to callers is unchanged, so nothing
+downstream of the log is affected.
+
+PR: <link>

--- a/ledger/src/ledger_8/api/ledger.rs
+++ b/ledger/src/ledger_8/api/ledger.rs
@@ -176,16 +176,24 @@ impl<D: DB> Ledger<D> {
 		match result {
 			TransactionResult::Success(_) => Ok((new_sp, AppliedStage::AllApplied)),
 			TransactionResult::PartialSuccess(segments, _) => {
+				let rendered = segments
+					.iter()
+					.map(|(id, res)| match res {
+						Ok(()) => format!("{id}: ok"),
+						Err(reason) => format!("{id}: {reason}"),
+					})
+					.collect::<Vec<_>>()
+					.join(", ");
 				log::warn!(
 					target: LOG_TARGET,
-					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = {:?}",
+					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = [{}]",
 					tx.identifiers().map(|i| api.tagged_serialize(&i)).collect::<Vec<_>>(),
-					segments
+					rendered
 				);
 				Ok((new_sp, AppliedStage::PartialSuccess(segments.into_iter().collect())))
 			},
 			TransactionResult::Failure(reason) => {
-				log::warn!(target: LOG_TARGET, "Error applying Transaction: {reason:?}");
+				log::warn!(target: LOG_TARGET, "Error applying Transaction: {reason}");
 				Err(LedgerApiError::Transaction(TransactionError::Invalid(reason.into())))
 			},
 		}

--- a/ledger/src/ledger_8/api/ledger.rs
+++ b/ledger/src/ledger_8/api/ledger.rs
@@ -25,6 +25,7 @@ use ledger_storage_local::{
 	storage::default_storage,
 };
 
+use crate::utils::SegmentResults;
 use helpers_local::{StorableSyntheticCost, compute_overall_fullness};
 use midnight_serialize_local::{self as serialize, Tagged};
 use mn_ledger_local::{
@@ -176,19 +177,11 @@ impl<D: DB> Ledger<D> {
 		match result {
 			TransactionResult::Success(_) => Ok((new_sp, AppliedStage::AllApplied)),
 			TransactionResult::PartialSuccess(segments, _) => {
-				let rendered = segments
-					.iter()
-					.map(|(id, res)| match res {
-						Ok(()) => format!("{id}: ok"),
-						Err(reason) => format!("{id}: {reason}"),
-					})
-					.collect::<Vec<_>>()
-					.join(", ");
 				log::warn!(
 					target: LOG_TARGET,
 					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = [{}]",
 					tx.identifiers().map(|i| api.tagged_serialize(&i)).collect::<Vec<_>>(),
-					rendered
+					SegmentResults(&segments)
 				);
 				Ok((new_sp, AppliedStage::PartialSuccess(segments.into_iter().collect())))
 			},

--- a/ledger/src/ledger_8/mod.rs
+++ b/ledger/src/ledger_8/mod.rs
@@ -1188,7 +1188,7 @@ where
 			Err(reason) => {
 				log::warn!(
 					target: LOG_TARGET,
-					"🚫 Rejected transaction {} from mempool: guaranteed execution would fail: {reason:?}",
+					"🚫 Rejected transaction {} from mempool: guaranteed execution would fail: {reason}",
 					tx_hash_hex
 				);
 				// Do NOT cache failures — tx will be fully re-checked on next revalidation
@@ -1233,7 +1233,7 @@ where
 			Err(reason) => {
 				log::warn!(
 					target: LOG_TARGET,
-					"🚫 Rejecting transaction {} at pre-dispatch: guaranteed execution would fail: {reason:?}",
+					"🚫 Rejecting transaction {} at pre-dispatch: guaranteed execution would fail: {reason}",
 					hex::encode(tx.hash())
 				);
 				Err(LedgerApiError::Transaction(types::TransactionError::Invalid(reason.into())))

--- a/ledger/src/ledger_9/api/ledger.rs
+++ b/ledger/src/ledger_9/api/ledger.rs
@@ -176,16 +176,24 @@ impl<D: DB> Ledger<D> {
 		match result {
 			TransactionResult::Success(_) => Ok((new_sp, AppliedStage::AllApplied)),
 			TransactionResult::PartialSuccess(segments, _) => {
+				let rendered = segments
+					.iter()
+					.map(|(id, res)| match res {
+						Ok(()) => format!("{id}: ok"),
+						Err(reason) => format!("{id}: {reason}"),
+					})
+					.collect::<Vec<_>>()
+					.join(", ");
 				log::warn!(
 					target: LOG_TARGET,
-					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = {:?}",
+					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = [{}]",
 					tx.identifiers().map(|i| api.tagged_serialize(&i)).collect::<Vec<_>>(),
-					segments
+					rendered
 				);
 				Ok((new_sp, AppliedStage::PartialSuccess(segments.into_iter().collect())))
 			},
 			TransactionResult::Failure(reason) => {
-				log::warn!(target: LOG_TARGET, "Error applying Transaction: {reason:?}");
+				log::warn!(target: LOG_TARGET, "Error applying Transaction: {reason}");
 				Err(LedgerApiError::Transaction(TransactionError::Invalid(reason.into())))
 			},
 		}

--- a/ledger/src/ledger_9/api/ledger.rs
+++ b/ledger/src/ledger_9/api/ledger.rs
@@ -25,6 +25,7 @@ use ledger_storage_local::{
 	storage::default_storage,
 };
 
+use crate::utils::SegmentResults;
 use helpers_local::{StorableSyntheticCost, compute_overall_fullness};
 use midnight_serialize_local::{self as serialize, Tagged};
 use mn_ledger_local::{
@@ -176,19 +177,11 @@ impl<D: DB> Ledger<D> {
 		match result {
 			TransactionResult::Success(_) => Ok((new_sp, AppliedStage::AllApplied)),
 			TransactionResult::PartialSuccess(segments, _) => {
-				let rendered = segments
-					.iter()
-					.map(|(id, res)| match res {
-						Ok(()) => format!("{id}: ok"),
-						Err(reason) => format!("{id}: {reason}"),
-					})
-					.collect::<Vec<_>>()
-					.join(", ");
 				log::warn!(
 					target: LOG_TARGET,
 					"Non guaranteed part of the transaction failed tx_hash = {:?}, segments = [{}]",
 					tx.identifiers().map(|i| api.tagged_serialize(&i)).collect::<Vec<_>>(),
-					rendered
+					SegmentResults(&segments)
 				);
 				Ok((new_sp, AppliedStage::PartialSuccess(segments.into_iter().collect())))
 			},

--- a/ledger/src/ledger_9/mod.rs
+++ b/ledger/src/ledger_9/mod.rs
@@ -1188,7 +1188,7 @@ where
 			Err(reason) => {
 				log::warn!(
 					target: LOG_TARGET,
-					"🚫 Rejected transaction {} from mempool: guaranteed execution would fail: {reason:?}",
+					"🚫 Rejected transaction {} from mempool: guaranteed execution would fail: {reason}",
 					tx_hash_hex
 				);
 				// Do NOT cache failures — tx will be fully re-checked on next revalidation
@@ -1233,7 +1233,7 @@ where
 			Err(reason) => {
 				log::warn!(
 					target: LOG_TARGET,
-					"🚫 Rejecting transaction {} at pre-dispatch: guaranteed execution would fail: {reason:?}",
+					"🚫 Rejecting transaction {} at pre-dispatch: guaranteed execution would fail: {reason}",
 					hex::encode(tx.hash())
 				);
 				Err(LedgerApiError::Transaction(types::TransactionError::Invalid(reason.into())))

--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -11,6 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{
+	collections::BTreeMap,
+	fmt::{self, Display, Formatter},
+};
+
+/// Lazy `Display` for a `PartialSuccess` per-segment result map.
+///
+/// Renders directly into the formatter rather than building a string, so a log line that the
+/// level filter drops costs nothing and an enabled one allocates no intermediate.
+pub struct SegmentResults<'a, E>(pub &'a BTreeMap<u16, Result<(), E>>);
+
+impl<E: Display> Display for SegmentResults<'_, E> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		for (i, (id, res)) in self.0.iter().enumerate() {
+			if i > 0 {
+				f.write_str(", ")?;
+			}
+			match res {
+				Ok(()) => write!(f, "{id}: ok")?,
+				Err(reason) => write!(f, "{id}: {reason}")?,
+			}
+		}
+		Ok(())
+	}
+}
+
 /// Resolved version (UTF-8 bytes) of a ledger generation's backing crate, for the
 /// `get_ledger_version` runtime API / RPC.
 ///
@@ -30,6 +56,30 @@ mod tests {
 	fn should_find_crate_version() {
 		let version = find_crate_version("mn-ledger-8");
 		assert!(version.is_some());
+	}
+
+	struct Reason(&'static str);
+
+	impl Display for Reason {
+		fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+			f.write_str(self.0)
+		}
+	}
+
+	#[test]
+	fn should_render_segment_results_in_key_order() {
+		let segments =
+			BTreeMap::from([(2u16, Err(Reason("expected a cell, received map"))), (1u16, Ok(()))]);
+		assert_eq!(
+			SegmentResults(&segments).to_string(),
+			"1: ok, 2: expected a cell, received map"
+		);
+	}
+
+	#[test]
+	fn should_render_empty_segment_results() {
+		let segments: BTreeMap<u16, Result<(), Reason>> = BTreeMap::new();
+		assert_eq!(SegmentResults(&segments).to_string(), "");
 	}
 
 	#[test]


### PR DESCRIPTION
#logging #hygiene
# Log transaction rejection reasons via Display rather than Debug

The mempool, pre-dispatch and apply sinks rendered a rejected transaction's
`TransactionInvalid` with `{:?}`, which prints the error's full payload -
including any ledger `StateValue` embedded in it - instead of the one-line
diagnostic its `Display` impl already provides. The `PartialSuccess` sink did
the same for its whole per-segment result map.

Switch all of them to `Display` (the segment map is now rendered as
`[<segment>: <reason>, ...]`). Log lines become shorter and readable; the
node-side `InvalidError` code returned to callers is unchanged, so nothing
downstream of the log is affected.