### PR TITLE
bump ledger 8+9 on 2.1 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto"
 version = "1.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "atomic-write-file",
@@ -7569,7 +7569,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "1.1.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7649,9 +7649,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-coin-structure"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295ff7814b0288a9f0cbfea0cf13e5bfaa9a631f0525fd43175d572ca9af03ce"
+checksum = "80c19a7fa7414487ba3d10e431a50c7f6b13e5822603fabc24a8593bfa6b58c9"
 dependencies = [
  "fake",
  "lazy_static",
@@ -7667,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "midnight-coin-structure"
 version = "3.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "fake",
  "lazy_static",
@@ -7739,9 +7739,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger"
-version = "8.1.1"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479798394847a6686bb9fabda270d16f8525457e9adcc9d2c3486b2422cc4e1c"
+checksum = "73c578eae63d6382db49e4273bf9b37b0f7efd9cd465535378a465c4475422af"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -7753,13 +7753,13 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 2.0.2",
  "midnight-ledger-static 9.0.0",
- "midnight-onchain-runtime 3.1.0",
+ "midnight-onchain-runtime 3.1.1",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
- "midnight-zswap 8.1.1",
+ "midnight-zswap 8.1.2",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "midnight-ledger-static"
 version = "10.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "midnight-ledger-v9"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -7998,15 +7998,15 @@ dependencies = [
  "lazy_static",
  "log",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 2.0.2",
  "midnight-coin-structure 3.0.0",
  "midnight-ledger",
  "midnight-ledger-v9",
  "midnight-node-ledger-helpers",
  "midnight-node-res",
- "midnight-onchain-runtime 3.1.0",
+ "midnight-onchain-runtime 3.1.1",
  "midnight-onchain-runtime 4.0.0",
- "midnight-onchain-state 3.0.0",
+ "midnight-onchain-state 3.0.1",
  "midnight-onchain-state 4.0.0",
  "midnight-primitives-ledger",
  "midnight-serialize",
@@ -8014,7 +8014,7 @@ dependencies = [
  "midnight-storage-core",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
- "midnight-zswap 8.1.1",
+ "midnight-zswap 8.1.2",
  "midnight-zswap 9.0.0",
  "moka 0.11.3",
  "parity-db 0.5.4",
@@ -8048,18 +8048,18 @@ dependencies = [
  "lazy_static",
  "log",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 2.0.2",
  "midnight-coin-structure 3.0.0",
  "midnight-ledger",
  "midnight-ledger-v9",
- "midnight-onchain-runtime 3.1.0",
+ "midnight-onchain-runtime 3.1.1",
  "midnight-onchain-runtime 4.0.0",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
  "midnight-transient-crypto 3.0.0",
  "midnight-zkir",
- "midnight-zswap 8.1.1",
+ "midnight-zswap 8.1.2",
  "midnight-zswap 9.0.0",
  "num_enum",
  "postcard",
@@ -8243,9 +8243,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-runtime"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbc5ffd4440bcadc02ad13d7e608c48de5facdc860f949eef4a22be50cb29b7"
+checksum = "bee1ae52e2afcbce98df3970763da80a2abb78f8656600740e38b62e83927441"
 dependencies = [
  "derive-where",
  "enum_index",
@@ -8255,9 +8255,9 @@ dependencies = [
  "konst",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
- "midnight-onchain-state 3.0.0",
- "midnight-onchain-vm 3.1.0",
+ "midnight-coin-structure 2.0.2",
+ "midnight-onchain-state 3.0.1",
+ "midnight-onchain-vm 3.1.1",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
@@ -8270,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-runtime"
 version = "4.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "derive-where",
  "enum_index",
@@ -8294,15 +8294,15 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-state"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf32b5175d303251d7051fb30532d4fdef3c19c7e36c5831c002a27e8440163"
+checksum = "871c190650050cf79fa147a291d22b5cc3aeb7412211c0b915c4f0788db2f0a9"
 dependencies = [
  "derive-where",
  "fake",
  "hex",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 2.0.2",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
@@ -8314,7 +8314,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-state"
 version = "4.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "derive-where",
  "fake",
@@ -8332,17 +8332,17 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-vm"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950c687ea706f5dd92270e06474829c732b0d7e8119430a14ea60e635050071a"
+checksum = "53aa11fb73bef231e59fbefd30a1be8b72afc03e360348e412fd26db5649bcaf"
 dependencies = [
  "derive-where",
  "fake",
  "hex",
  "konst",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
- "midnight-onchain-state 3.0.0",
+ "midnight-coin-structure 2.0.2",
+ "midnight-onchain-state 3.0.1",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
@@ -8355,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-vm"
 version = "4.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "derive-where",
  "fake",
@@ -8549,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize"
 version = "1.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "crypto",
  "konst",
@@ -8562,7 +8562,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize-macros"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -8571,8 +8571,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-storage"
-version = "2.0.2"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+version = "2.0.4"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "crypto",
  "derive-where",
@@ -8591,8 +8591,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-storage-core"
-version = "1.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+version = "1.2.2"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "archery",
  "crypto",
@@ -8619,7 +8619,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-macros"
 version = "1.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "midnight-serialize-macros",
  "proc-macro2",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "midnight-transient-crypto"
 version = "3.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "midnight-zkir"
 version = "2.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "const-hex",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "midnight-zkir-v3"
 version = "3.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "const-hex",
@@ -8806,9 +8806,9 @@ dependencies = [
 
 [[package]]
 name = "midnight-zswap"
-version = "8.1.1"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff4a06f9d1dcb857be73dd926fcb233b61af3d2a8ab0103b5e39725cd4feb8"
+checksum = "d8585d0b77a51691e8c7672bd3b4af80a8c3d7e1a32a171bed34b7d1ed7b810c"
 dependencies = [
  "derive-where",
  "fake",
@@ -8817,9 +8817,9 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "midnight-base-crypto",
- "midnight-coin-structure 2.0.1",
+ "midnight-coin-structure 2.0.2",
  "midnight-ledger-static 9.0.0",
- "midnight-onchain-runtime 3.1.0",
+ "midnight-onchain-runtime 3.1.1",
  "midnight-serialize",
  "midnight-storage",
  "midnight-transient-crypto 2.2.0",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "midnight-zswap"
 version = "9.0.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.4#cd652d7f97b34b805bb5f0310ce7434eb883af38"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-9.1.0.0-rc.5#dd6c68b06070f4411c5487b647c3ea23350c41be"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -19699,7 +19699,7 @@ dependencies = [
  "midnight-base-crypto",
  "midnight-ledger",
  "midnight-ledger-v9",
- "midnight-onchain-state 3.0.0",
+ "midnight-onchain-state 3.0.1",
  "midnight-onchain-state 4.0.0",
  "midnight-serialize",
  "midnight-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,16 +82,16 @@ zkir = { version = "^2.2.0", package = "midnight-zkir" }
 
 # Ledger 8 (compatible with layout-v2)
 # coin-structure, transient-crypto (2.x) and zkir are shared above so reuse those entries.
-mn-ledger-8 = { version = "=8.1.1", package = "midnight-ledger" }
+mn-ledger-8 = { version = "=8.1.2", package = "midnight-ledger" }
 # `state-translation` (needed by the v8->v9 storage migration) pulls in
 # `public-internal-structure`, exposing `merkle_patricia_trie`/`storable`/the
 # `state_translation` module used by the `v8-to-v9-state-translation` crate.
-ledger-storage-ledger-8 = { version = "=2.0.2", package = "midnight-storage", features = ["parity-db", "state-translation"] }
-onchain-runtime-ledger-8 = { version = "=3.1.0", package = "midnight-onchain-runtime" }
+ledger-storage-ledger-8 = { version = "=2.0.4", package = "midnight-storage", features = ["parity-db", "state-translation"] }
+onchain-runtime-ledger-8 = { version = "=3.1.1", package = "midnight-onchain-runtime" }
 # Same `midnight-onchain-state` instance that `mn-ledger-8`'s `ContractState`
-# resolves to (via onchain-runtime 3.1.0); used as the v8 side of the state translation table.
-onchain-state-ledger-8 = { version = "=3.0.0", package = "midnight-onchain-state" }
-zswap-ledger-8 = { version = "=8.1.1", package = "midnight-zswap" }
+# resolves to (via onchain-runtime 3.1.1); used as the v8 side of the state translation table.
+onchain-state-ledger-8 = { version = "=3.0.1", package = "midnight-onchain-state" }
+zswap-ledger-8 = { version = "=8.1.2", package = "midnight-zswap" }
 
 # Ledger 9 (compatible with layout-v2; midnight-ledger-v9 crate)
 # storage shares versions with L8 so reuses that entry. coin-structure and
@@ -456,20 +456,20 @@ zeroize = { opt-level = 3 }
 [patch.crates-io]
 yamux = { git = "https://github.com/midnightntwrk/rust-yamux", branch = "yamux-v0.12.2" }
 parity-db = { git = "https://github.com/midnightntwrk/parity-db.git", branch = "master" }
-midnight-ledger-v9            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-zswap                = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-coin-structure       = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-base-crypto          = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-base-crypto-derive   = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-transient-crypto     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
+midnight-ledger-v9            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-zswap                = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-coin-structure       = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-base-crypto          = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-base-crypto-derive   = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-transient-crypto     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
 midnight-transient-crypto-old = { package = "midnight-transient-crypto", git = "https://github.com/midnightntwrk/midnight-ledger", tag = "transient-crypto-2.2.0-rc.1" }
-midnight-onchain-vm           = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-onchain-state        = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-onchain-runtime      = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-zkir                 = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-serialize            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-storage              = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
-midnight-storage-core         = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.4" }
+midnight-onchain-vm           = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-onchain-state        = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-onchain-runtime      = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-zkir                 = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-serialize            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-storage              = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
+midnight-storage-core         = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "ledger-9.1.0.0-rc.5" }
 
 [workspace.metadata.cargo-shear]
 ignored = []

--- a/changes/node/changed/bump-ledger-8.1.2.md
+++ b/changes/node/changed/bump-ledger-8.1.2.md
@@ -1,0 +1,9 @@
+# Bump ledger 8 version to 8.1.2
+Security patch: low-level deserialization is hardened - non-canonical encodings and
+invariant-violating values are now rejected, so an 8.1.2 node
+accepts strictly less than an 8.1.1 one. Also carries panic/overflow fixes in Dust
+parameters and seq, Zswap binding randomness, delta normalization and contract-call
+cost accounting.
+Release notes: https://github.com/midnightntwrk/midnight-ledger/releases/tag/ledger-8.1.2
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2096

--- a/changes/node/changed/bump-ledger-9.1.0.0-rc.5.md
+++ b/changes/node/changed/bump-ledger-9.1.0.0-rc.5.md
@@ -1,0 +1,10 @@
+#node #runtime #toolkit
+
+# Bump ledger 9 version to 9.1.0.0-rc.5
+
+Version bump required to move midnight-storage and midnight-storage-core
+to ledger 8.1.2 compatible versions
+
+See commit: https://github.com/midnightntwrk/midnight-ledger/commit/dd6c68b06070f4411c5487b647c3ea23350c41be
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2096


### PR DESCRIPTION

Bump ledger 8 to 8.1.2 to include latest security patch.
Bump ledger 9 to latest RC.

( Cherry pick of https://github.com/midnightntwrk/midnight-node/pull/2096 from main )