### PR TITLE
fix(node): honor allow_non_ssl for db-sync connections via PgSslMode::Prefer

### DIFF
--- a/changes/node/changed/allow-non-ssl-honored-again.md
+++ b/changes/node/changed/allow-non-ssl-honored-again.md
@@ -1,0 +1,17 @@
+#node
+# Honor `allow_non_ssl` again for db-sync database connections
+
+Since the TLS enforcement change, `allow_non_ssl` was accepted but ignored,
+every db-sync Postgres connection used `PgSslMode::Require`, and a node
+pointed at a database without TLS support failed to start with "server does
+not support TLS". Operators reaching db-sync over an already-secured transport
+(localhost, a VPN or mesh network) with no TLS on Postgres had no
+configuration that allowed the node to connect.
+
+`allow_non_ssl = true` (or `ALLOW_NON_SSL=1`) now maps to `PgSslMode::Prefer`:
+TLS when the server offers it, plaintext otherwise, with a startup warning.
+The secure defaults are unchanged: without the flag connections still require
+TLS, `ssl_root_cert` still forces `VerifyFull` and takes precedence over
+`allow_non_ssl`, and `PgSslMode::Disable` remains unreachable.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2122

--- a/node/src/cfg/midnight_cfg/mod.rs
+++ b/node/src/cfg/midnight_cfg/mod.rs
@@ -103,13 +103,17 @@ pub struct MidnightCfg {
 	/// Whether substrate and midnight storage should be separate or unified
 	pub storage_separation: StorageSeparation,
 
-	/// Deprecated: plaintext database connections are no longer permitted.
-	/// This flag is ignored — all connections use TLS. It will be removed in a future release.
+	/// Allow plaintext database connections when the server does not support TLS.
+	/// When set, connections use PgSslMode::Prefer: TLS when the server offers it,
+	/// plaintext otherwise. Ignored when ssl_root_cert is set. Intended for
+	/// databases reached over an already-secured transport (localhost, a VPN or
+	/// mesh network). Defaults to false (TLS required).
 	pub allow_non_ssl: bool,
 
 	/// Path to SSL root certificate for database connections.
 	/// When set, connections use PgSslMode::VerifyFull (certificate + hostname validation).
-	/// When absent, connections use PgSslMode::Require (encrypted but no certificate validation).
+	/// When absent, connections use PgSslMode::Require (encrypted but no certificate
+	/// validation), or PgSslMode::Prefer when allow_non_ssl is set.
 	#[validate(custom = |s| maybe(s, path_exists))]
 	pub ssl_root_cert: Option<String>,
 

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -225,21 +225,11 @@ const BRIDGE_POOL_CFG: DbPoolCfg =
 const ICS_POOL_CFG: DbPoolCfg =
 	DbPoolCfg { acquire_timeout: std::time::Duration::from_secs(30), max_connections: 5 };
 
-fn warn_deprecated_allow_non_ssl(cfg: &MidnightCfg) {
-	if cfg.allow_non_ssl {
-		log::warn!(
-			"allow_non_ssl is set but ignored — all database connections use TLS. \
-			 This flag will be removed in a future release."
-		);
-	}
-}
-
 pub async fn create_cached_data_sources(
 	cfg: MidnightCfg,
 	mc_metrics_opt: Option<McFollowerMetrics>,
 	midnight_metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<DataSources, Box<dyn Error + Send + Sync + 'static>> {
-	warn_deprecated_allow_non_ssl(&cfg);
 	let postgres_uri = &cfg
 		.db_sync_postgres_connection_string
 		.ok_or(missing("db_sync_postgres_connection_string"))?;
@@ -266,13 +256,17 @@ pub async fn create_cached_data_sources(
 		slot_duration_millis: Duration::from_millis(cfg.mc_slot_duration_millis),
 	};
 
-	let candidates_pool =
-		get_connection(postgres_uri, CANDIDATES_POOL_CFG, cfg.ssl_root_cert.as_deref())
-			.await
-			.map_err(|e| {
-				log::warn!("Failed to connect to database for candidates data source: {e}");
-				e
-			})?;
+	let candidates_pool = get_connection(
+		postgres_uri,
+		CANDIDATES_POOL_CFG,
+		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
+	)
+	.await
+	.map_err(|e| {
+		log::warn!("Failed to connect to database for candidates data source: {e}");
+		e
+	})?;
 
 	// All these pools are connections to the same database, so we can use any pool to create the index
 	create_index_if_not_exists(&candidates_pool).await;
@@ -290,13 +284,17 @@ pub async fn create_cached_data_sources(
 			e
 		})?;
 
-	let sidechain_pool =
-		get_connection(postgres_uri, SIDECHAIN_POOL_CFG, cfg.ssl_root_cert.as_deref())
-			.await
-			.map_err(|e| {
-				log::warn!("Failed to connect to database for sidechain data source: {e}");
-				e
-			})?;
+	let sidechain_pool = get_connection(
+		postgres_uri,
+		SIDECHAIN_POOL_CFG,
+		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
+	)
+	.await
+	.map_err(|e| {
+		log::warn!("Failed to connect to database for sidechain data source: {e}");
+		e
+	})?;
 	let sidechain_block_data_source = Arc::new(BlockDataSourceImpl::from_config(
 		sidechain_pool,
 		db_sync_block_data_source_config.clone(),
@@ -308,12 +306,17 @@ pub async fn create_cached_data_sources(
 		mc_metrics_opt.clone(),
 	);
 
-	let mc_hash_pool = get_connection(postgres_uri, MC_HASH_POOL_CFG, cfg.ssl_root_cert.as_deref())
-		.await
-		.map_err(|e| {
-			log::warn!("Failed to connect to database for mc_hash data source: {e}");
-			e
-		})?;
+	let mc_hash_pool = get_connection(
+		postgres_uri,
+		MC_HASH_POOL_CFG,
+		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
+	)
+	.await
+	.map_err(|e| {
+		log::warn!("Failed to connect to database for mc_hash data source: {e}");
+		e
+	})?;
 	let mc_hash_block_data_source = BlockDataSourceImpl::from_config(
 		mc_hash_pool,
 		db_sync_block_data_source_config.clone(),
@@ -322,13 +325,17 @@ pub async fn create_cached_data_sources(
 	let mc_hash =
 		McHashDataSourceImpl::new(Arc::new(mc_hash_block_data_source), mc_metrics_opt.clone());
 
-	let cnight_observation_pool =
-		get_connection(postgres_uri, CNIGHT_OBSERVATION_POOL_CFG, cfg.ssl_root_cert.as_deref())
-			.await
-			.map_err(|e| {
-				log::warn!("Failed to connect to database for cnight_observation data source: {e}");
-				e
-			})?;
+	let cnight_observation_pool = get_connection(
+		postgres_uri,
+		CNIGHT_OBSERVATION_POOL_CFG,
+		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
+	)
+	.await
+	.map_err(|e| {
+		log::warn!("Failed to connect to database for cnight_observation data source: {e}");
+		e
+	})?;
 	let cnight_observation = MidnightCNightObservationDataSourceImpl::new(
 		cnight_observation_pool,
 		midnight_metrics_opt.clone(),
@@ -339,6 +346,7 @@ pub async fn create_cached_data_sources(
 		postgres_uri,
 		FEDERATED_AUTHORITY_OBSERVATION_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
 	)
 	.await
 	.map_err(|e| {
@@ -353,12 +361,17 @@ pub async fn create_cached_data_sources(
 		1000,
 	);
 
-	let bridge_pool = get_connection(postgres_uri, BRIDGE_POOL_CFG, cfg.ssl_root_cert.as_deref())
-		.await
-		.map_err(|e| {
-			log::warn!("Failed to connect to database for bridge data source: {e}");
-			e
-		})?;
+	let bridge_pool = get_connection(
+		postgres_uri,
+		BRIDGE_POOL_CFG,
+		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
+	)
+	.await
+	.map_err(|e| {
+		log::warn!("Failed to connect to database for bridge data source: {e}");
+		e
+	})?;
 
 	let bridge = CachedTokenBridgeDataSourceImpl::new(
 		bridge_pool,
@@ -382,12 +395,12 @@ pub async fn create_cnight_observation_data_source(
 	cfg: MidnightCfg,
 	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<Arc<dyn MidnightCNightObservationDataSource>, Box<dyn Error + Send + Sync + 'static>> {
-	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
 		&cfg.db_sync_postgres_connection_string
 			.ok_or(missing("db_sync_postgres_connection_string"))?,
 		CNIGHT_OBSERVATION_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
 	)
 	.await?;
 
@@ -403,12 +416,12 @@ pub async fn create_federated_authority_observation_data_source(
 	metrics_opt: Option<MidnightDataSourceMetrics>,
 ) -> Result<Arc<dyn FederatedAuthorityObservationDataSource>, Box<dyn Error + Send + Sync + 'static>>
 {
-	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
 		&cfg.db_sync_postgres_connection_string
 			.ok_or(missing("db_sync_postgres_connection_string"))?,
 		FEDERATED_AUTHORITY_OBSERVATION_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
 	)
 	.await?;
 
@@ -434,12 +447,12 @@ pub async fn create_authority_selection_data_source_with_pool(
 	(Arc<dyn AuthoritySelectionDataSource + Send + Sync>, sqlx::PgPool),
 	Box<dyn Error + Send + Sync + 'static>,
 > {
-	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
 		&cfg.db_sync_postgres_connection_string
 			.ok_or(missing("db_sync_postgres_connection_string"))?,
 		CANDIDATES_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
 	)
 	.await?;
 
@@ -454,12 +467,12 @@ pub async fn create_authority_selection_data_source_with_pool(
 pub async fn create_ics_genesis_pool(
 	cfg: MidnightCfg,
 ) -> Result<sqlx::PgPool, Box<dyn Error + Send + Sync + 'static>> {
-	warn_deprecated_allow_non_ssl(&cfg);
 	let pool = get_connection(
 		&cfg.db_sync_postgres_connection_string
 			.ok_or(missing("db_sync_postgres_connection_string"))?,
 		ICS_POOL_CFG,
 		cfg.ssl_root_cert.as_deref(),
+		cfg.allow_non_ssl,
 	)
 	.await?;
 	Ok(pool)
@@ -468,12 +481,18 @@ pub async fn create_ics_genesis_pool(
 fn build_ssl_connect_options(
 	connection_string: &str,
 	ssl_root_cert: Option<&str>,
+	allow_non_ssl: bool,
 ) -> Result<
 	(sqlx::postgres::PgSslMode, sqlx::postgres::PgConnectOptions),
 	Box<dyn Error + Send + Sync + 'static>,
 > {
 	let ssl_mode = if ssl_root_cert.is_some() {
 		sqlx::postgres::PgSslMode::VerifyFull
+	} else if allow_non_ssl {
+		log::warn!(
+			"allow_non_ssl is set: using PgSslMode::Prefer (TLS when the server supports it, plaintext otherwise). Unset allow_non_ssl and set ssl_root_cert for full MITM protection."
+		);
+		sqlx::postgres::PgSslMode::Prefer
 	} else {
 		log::warn!(
 			"No ssl_root_cert configured: using PgSslMode::Require (encrypted but no certificate validation). Set ssl_root_cert for full MITM protection."
@@ -492,8 +511,10 @@ async fn get_connection(
 	connection_string: &str,
 	pool_cfg: DbPoolCfg,
 	ssl_root_cert: Option<&str>,
+	allow_non_ssl: bool,
 ) -> Result<sqlx::PgPool, Box<dyn Error + Send + Sync + 'static>> {
-	let (ssl_mode, connect_options) = build_ssl_connect_options(connection_string, ssl_root_cert)?;
+	let (ssl_mode, connect_options) =
+		build_ssl_connect_options(connection_string, ssl_root_cert, allow_non_ssl)?;
 	log::info!("Database connection SSL mode: {ssl_mode:?}");
 
 	let pool = sqlx::postgres::PgPoolOptions::new()
@@ -545,27 +566,43 @@ mod tests {
 	#[test]
 	fn ssl_mode_is_verify_full_when_root_cert_provided() {
 		let (mode, _opts) =
-			build_ssl_connect_options(TEST_CONN_STR, Some("/path/to/ca.pem")).unwrap();
+			build_ssl_connect_options(TEST_CONN_STR, Some("/path/to/ca.pem"), false).unwrap();
 		assert!(matches!(mode, sqlx::postgres::PgSslMode::VerifyFull));
 	}
 
 	#[test]
 	fn ssl_mode_is_require_when_no_root_cert() {
-		let (mode, _opts) = build_ssl_connect_options(TEST_CONN_STR, None).unwrap();
+		let (mode, _opts) = build_ssl_connect_options(TEST_CONN_STR, None, false).unwrap();
 		assert!(matches!(mode, sqlx::postgres::PgSslMode::Require));
+	}
+
+	#[test]
+	fn ssl_mode_is_prefer_when_allow_non_ssl() {
+		let (mode, _opts) = build_ssl_connect_options(TEST_CONN_STR, None, true).unwrap();
+		assert!(matches!(mode, sqlx::postgres::PgSslMode::Prefer));
+	}
+
+	#[test]
+	fn root_cert_takes_precedence_over_allow_non_ssl() {
+		let (mode, _opts) =
+			build_ssl_connect_options(TEST_CONN_STR, Some("/path/to/ca.pem"), true).unwrap();
+		assert!(matches!(mode, sqlx::postgres::PgSslMode::VerifyFull));
 	}
 
 	#[test]
 	fn ssl_mode_is_never_disable() {
 		for cert in [None, Some("/path/to/ca.pem")] {
-			let (mode, _opts) = build_ssl_connect_options(TEST_CONN_STR, cert).unwrap();
-			assert!(!matches!(mode, sqlx::postgres::PgSslMode::Disable));
+			for allow_non_ssl in [false, true] {
+				let (mode, _opts) =
+					build_ssl_connect_options(TEST_CONN_STR, cert, allow_non_ssl).unwrap();
+				assert!(!matches!(mode, sqlx::postgres::PgSslMode::Disable));
+			}
 		}
 	}
 
 	#[test]
 	fn invalid_connection_string_returns_error() {
-		let result = build_ssl_connect_options("not-a-valid-uri", None);
+		let result = build_ssl_connect_options("not-a-valid-uri", None, false);
 		assert!(result.is_err());
 	}
 }


### PR DESCRIPTION
First off, thanks for the TLS-by-default hardening of the db-sync connections. Requiring encrypted connections out of the box is the right call and this PR keeps that default intact.

It did remove the only escape hatch, though. `allow_non_ssl` became accepted-but-ignored, every connection uses `PgSslMode::Require`, and a node pointed at a Postgres without TLS support fails to start with "server does not support TLS". We run our db-sync replicas inside a private network (wireguard mesh) with no TLS configured on Postgres, and there is currently no configuration that lets the node connect at all. We are running this patch in production on our dev cluster today.

What this PR does:

- `allow_non_ssl = true` (or `ALLOW_NON_SSL=1`) maps to `PgSslMode::Prefer`: TLS when the server offers it, plaintext otherwise, with a startup warning naming the tradeoff.
- Defaults are unchanged: without the flag, connections still use `Require`.
- `ssl_root_cert` still forces `VerifyFull` and takes precedence over `allow_non_ssl`.
- `PgSslMode::Disable` remains unreachable, and the `ssl_mode_is_never_disable` test now also covers the flag.
- Removes the "set but ignored" deprecation warning and updates the config docs; adds tests for the `Prefer` mapping and the cert-wins precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
