### PR TITLE
fix(toolkit): fail --no-watch-progress sends when the pool rejects the tx

### DIFF
--- a/changes/toolkit/changed/sender-no-watch-pool-verdict.md
+++ b/changes/toolkit/changed/sender-no-watch-pool-verdict.md
@@ -1,0 +1,21 @@
+#toolkit
+# `--no-watch-progress` sends now fail when the pool rejects the transaction
+
+With `--no-watch-progress`, the sender logged `SENT` as soon as
+`submit_and_watch` returned and dropped the subscription unread. A node whose
+transaction pool is full does not reject the submission as an RPC error: it
+accepts the subscription and delivers the rejection as the first stream event
+(`Invalid`, or `Dropped`), so every such transaction was reported as sent and
+the loss was invisible to the caller. Under burst load on perfnet this hid up
+to 61% loss per run.
+
+- In `--no-watch-progress` mode the sender now reads the subscription up to the
+  pool's first verdict (bounded at 5s). `Invalid`/`Dropped`/`Error` fail the
+  send and are logged with the existing `INVALID_TRANSACTION` /
+  `DROPPED_TRANSACTION` / `TRANSACTION_ERROR` tags; any other status
+  (`Validated`, `Broadcasted`, `InBestBlock`, ...) returns immediately as
+  before.
+- If no status arrives within the bound, or the subscription ends first, the
+  send still succeeds but logs `NO_POOL_VERDICT` with the reason, so unknown
+  outcomes stay countable.
+- The `--no-watch-progress` help text describes the new behaviour.

--- a/changes/toolkit/changed/sender-no-watch-pool-verdict.md
+++ b/changes/toolkit/changed/sender-no-watch-pool-verdict.md
@@ -19,3 +19,5 @@ to 61% loss per run.
   send still succeeds but logs `NO_POOL_VERDICT` with the reason, so unknown
   outcomes stay countable.
 - The `--no-watch-progress` help text describes the new behaviour.
+
+PR: https://github.com/midnightntwrk/midnight-node/pull/2138

--- a/util/toolkit/src/sender.rs
+++ b/util/toolkit/src/sender.rs
@@ -198,6 +198,8 @@ impl Sender {
 
 		if self.watch_progress {
 			self.send_and_log(&tx_hash_string, tx_progress).await?;
+		} else {
+			Self::wait_for_pool_verdict(&tx_hash_string, tx_progress).await?;
 		}
 		Ok(())
 	}
@@ -304,6 +306,103 @@ impl Sender {
 		))
 	}
 
+	/// Reads the subscription only as far as the pool's first verdict. A full
+	/// pool rejects a submission asynchronously, as an `Invalid`/`Dropped` event
+	/// rather than an RPC error, so returning straight after `submit_and_watch`
+	/// would report a dropped tx as sent.
+	async fn wait_for_pool_verdict(
+		tx_hashes: &TxHashes,
+		mut progress: Progress,
+	) -> Result<(), SenderError> {
+		const POOL_VERDICT_TIMEOUT: Duration = Duration::from_secs(5);
+
+		let url = progress.url.clone();
+		let first = tokio::time::timeout(POOL_VERDICT_TIMEOUT, progress.tx_progress.next()).await;
+		let err = match first {
+			Ok(Some(Ok(TransactionStatus::Invalid { message }))) => {
+				SenderError::InvalidTransaction { message }
+			},
+			Ok(Some(Ok(TransactionStatus::Dropped { message }))) => {
+				SenderError::DroppedTransaction { message }
+			},
+			Ok(Some(Ok(TransactionStatus::Error { message }))) => {
+				SenderError::TransactionError { message }
+			},
+			Ok(Some(Err(e))) => SenderError::TransactionError { message: e.to_string() },
+			Ok(Some(Ok(status))) => {
+				log::debug!(url = url; "pool accepted tx: {}", Self::status_name(&status));
+				return Ok(());
+			},
+			// Accepted by the RPC but its fate is unknown: do not fail the send,
+			// but leave a countable trace.
+			Ok(None) => {
+				return Self::log_no_pool_verdict(
+					&url,
+					tx_hashes,
+					"subscription ended before the pool reported a status",
+				);
+			},
+			Err(_) => {
+				return Self::log_no_pool_verdict(
+					&url,
+					tx_hashes,
+					&format!("no pool status after {}s", POOL_VERDICT_TIMEOUT.as_secs()),
+				);
+			},
+		};
+		Self::log_send_failure(&url, tx_hashes, &err);
+		Err(err)
+	}
+
+	fn log_no_pool_verdict(
+		url: &str,
+		tx_hashes: &TxHashes,
+		reason: &str,
+	) -> Result<(), SenderError> {
+		log::warn!(
+			url = url,
+			extrinsic_hash = &tx_hashes.extrinsic_hash,
+			midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+			reason = reason;
+			"NO_POOL_VERDICT"
+		);
+		Ok(())
+	}
+
+	fn status_name(
+		status: &TransactionStatus<
+			MidnightNodeClientConfig,
+			OnlineClientAtBlockImpl<MidnightNodeClientConfig>,
+		>,
+	) -> &'static str {
+		match status {
+			TransactionStatus::Validated => "Validated",
+			TransactionStatus::Broadcasted => "Broadcasted",
+			TransactionStatus::NoLongerInBestBlock => "NoLongerInBestBlock",
+			TransactionStatus::InBestBlock(_) => "InBestBlock",
+			TransactionStatus::InFinalizedBlock(_) => "InFinalizedBlock",
+			TransactionStatus::Error { .. } => "Error",
+			TransactionStatus::Invalid { .. } => "Invalid",
+			TransactionStatus::Dropped { .. } => "Dropped",
+		}
+	}
+
+	fn log_send_failure(url: &str, tx_hashes: &TxHashes, err: &SenderError) {
+		let tag = match err {
+			SenderError::InvalidTransaction { .. } => "INVALID_TRANSACTION",
+			SenderError::DroppedTransaction { .. } => "DROPPED_TRANSACTION",
+			SenderError::TransactionError { .. } => "TRANSACTION_ERROR",
+			_ => "FAILED_TO_REACH_BEST_BLOCK",
+		};
+		log::info!(
+			url = url,
+			extrinsic_hash = &tx_hashes.extrinsic_hash,
+			midnight_tx_hash = &tx_hashes.midnight_tx_hash,
+			reason = err.to_string().as_str();
+			"{tag}"
+		);
+	}
+
 	/// Waits until the tx lands in a block. The `bool` in the success value is
 	/// true when the subscription skipped straight to `InFinalizedBlock`
 	/// (event coalescing under load) — the caller can skip the finality wait.
@@ -340,12 +439,7 @@ impl Sender {
 						return Err(SenderError::TransactionError { message });
 					},
 					Ok(status) => {
-						last_status = match status {
-							TransactionStatus::Validated => "Validated",
-							TransactionStatus::Broadcasted => "Broadcasted",
-							TransactionStatus::NoLongerInBestBlock => "NoLongerInBestBlock",
-							_ => "Unknown",
-						};
+						last_status = Self::status_name(&status);
 					},
 					Err(e) => {
 						return Err(SenderError::TransactionError { message: e.to_string() });
@@ -463,19 +557,7 @@ impl Sender {
 		let (best_block, already_finalized) = match best_block_result {
 			Ok(info) => info,
 			Err(err) => {
-				let tag = match &err {
-					SenderError::InvalidTransaction { .. } => "INVALID_TRANSACTION",
-					SenderError::DroppedTransaction { .. } => "DROPPED_TRANSACTION",
-					SenderError::TransactionError { .. } => "TRANSACTION_ERROR",
-					_ => "FAILED_TO_REACH_BEST_BLOCK",
-				};
-				log::info!(
-					url = &url,
-					extrinsic_hash = &tx_hashes.extrinsic_hash,
-					midnight_tx_hash = &tx_hashes.midnight_tx_hash,
-					reason = err.to_string().as_str();
-					"{tag}"
-				);
+				Self::log_send_failure(&url, tx_hashes, &err);
 				return Err(err);
 			},
 		};

--- a/util/toolkit/src/tx_generator/destination.rs
+++ b/util/toolkit/src/tx_generator/destination.rs
@@ -30,7 +30,8 @@ pub struct Destination {
 	/// Output filename to write generated transaction.
 	#[arg(long, conflicts_with = "dest_urls", global = true)]
 	pub dest_file: Option<String>,
-	/// Do not wait for finalization when sending transactions. May cause errors when sending batches.
+	/// Do not wait for finalization when sending transactions; still waits for the pool's first
+	/// verdict, so a rejected or dropped tx fails the send. May cause errors when sending batches.
 	#[arg(long, conflicts_with = "dest_file", env = "MN_DONT_WATCH_PROGRESS", global = true)]
 	pub no_watch_progress: bool,
 }


### PR DESCRIPTION
## Summary

`generate-txs send --no-watch-progress` (and every other `--no-watch-progress` send) now fails when the node's transaction pool rejects the transaction, instead of reporting it as sent.

## Root cause

`Sender::send_tx_no_wait` calls `submit_and_watch`, logs `SENT` as soon as the subscription is returned, and in no-watch mode drops the `TransactionProgress` unread.

The node's `transactionWatch` RPC (`sc-rpc-spec-v2`, subxt's default backend) accepts the subscription **before** awaiting the pool, and when the fork-aware pool's mempool is full (`pool_limit` + future limit, purged only on finality) `submit_and_watch` fails with `ImmediatelyDropped`/`InvalidTransaction`. That error is not an RPC error: it is sent as the first stream event (`Invalid`) and counted in `rpc_transaction_invalid_time`. The sender never read it.

On the perfnet burst ladder of 2026-09-09 (11 runs × 1000 txs) the sender reported 1000/1000 sent on every run while 20–61 % of the txs never entered any pool; per validator, `rpc_transaction_invalid_time_count` matched the lost count exactly.

## Change

- `Sender::send_tx` in no-watch mode now calls `wait_for_pool_verdict`, which reads the subscription up to the pool's **first** status, bounded at 5 s:
  - `Invalid` / `Dropped` / `Error` (or a subscription error) fail the send, logged with the existing `INVALID_TRANSACTION` / `DROPPED_TRANSACTION` / `TRANSACTION_ERROR` tags (same fields as the watch path).
  - any other status (`Validated`, `Broadcasted`, `InBestBlock`, …) returns at once, so throughput of no-watch sends is unchanged in practice: the pool validates before emitting `Ready`, so the first event arrives within milliseconds of the RPC returning.
  - no status within the bound, or a subscription that ends first, keeps the send successful but logs `NO_POOL_VERDICT` with the reason, so unknown outcomes stay countable.
- Failure-tag logging and status naming are factored into `log_send_failure` / `status_name` and shared with the watch path (no behaviour change there).
- `--no-watch-progress` help text updated; changelog fragment added under `changes/toolkit/changed/`.

## Verification

- `cargo fmt`, `cargo check -p midnight-node-toolkit`, `cargo clippy -p midnight-node-toolkit` clean.
- Not exercised against a live node in this PR. Plan: build the toolkit from this branch via midnight-performance `build-node.yml` and re-run one perfnet burst; the sender's `Invalid` count should match the validators' `rpc_transaction_invalid_time_count` delta.

## Downstream

midnight-performance `send_batch_txs.py` treats a non-zero toolkit exit as a failed send, so its end-of-run `Invalid:` count and the job summary will now show the drops with no change on that side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
